### PR TITLE
feat(ci): PR governor for oversized pull requests

### DIFF
--- a/.github/workflows/pr-governor.yml
+++ b/.github/workflows/pr-governor.yml
@@ -1,0 +1,24 @@
+name: PR Governor
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+
+            if (files.length > 100) {
+              core.setFailed('PR too large (>100 files)');
+            }


### PR DESCRIPTION
Adds a lightweight PR Governor workflow that fails pull requests exceeding 100 changed files.

## Why
- stop mega-PR entropy before CI burns cycles
- force split discipline on oversized changes
- keep merge surfaces legible

## Scope
- hard fail on pull requests with more than 100 files changed
- no runtime or product behavior changes
- additive CI policy only

## Follow-up
This can be extended later with path bucketing, split suggestions, override labels, and non-blocking summaries.