### PR TITLE
fix(gates): support worktree fallback when index is empty

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,8 +13,9 @@
 | **Seeders** | `seed_*.py`, `backfill_embeddings.py` | Data population |
 | **DB Maintenance** | `repair_db.py`, `encrypt_legacy_facts.py`, `repatriate_memories.py` | Database operations |
 | **Forge** | `forge_*.py` | Build & generation pipelines |
-| **Verify** | `verify_*.py` | Architecture verification |
+| **Verify** | `repo_health_changed.py`, `verify_*.py` | Architecture verification and changed-file triage |
 | **Orchestrators** | `god_mode_orchestrator.py`, `mejoralo_infinito.py`, `orchestrator.py`, `rotate_aether.py` | Meta-execution |
+| **Agent Demo** | `run_github_agent_demo.py` | End-to-end harness for the `GitHubAgent` builtin |
 | **MCP / API** | `run_mcp_server.py`, `smoke_test_api.py` | Server launching |
 | **NotebookLM** | `fragment_notebooklm.py`, `synthesize_notebooklm.py` | NotebookLM integration |
 | **Shell** | `cortex-boot.sh`, `cortex_persist.sh`, `diagnose.sh`, etc. | System operations |

--- a/scripts/_changed_files.py
+++ b/scripts/_changed_files.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Dependency-free helpers for resolving changed files from Git."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def run_git(args: list[str], *, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def paths_from_output(output: str) -> list[Path]:
+    return [Path(line) for line in output.splitlines() if line]
+
+
+def unique_paths(*groups: list[Path]) -> list[Path]:
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for group in groups:
+        for path in group:
+            if path in seen:
+                continue
+            seen.add(path)
+            ordered.append(path)
+    return ordered
+
+
+def untracked_files() -> list[Path]:
+    return paths_from_output(run_git(["ls-files", "--others", "--exclude-standard"]))
+
+
+def changed_files(
+    *,
+    include_untracked: bool = False,
+    prefer_staged: bool = False,
+) -> tuple[list[Path], str]:
+    """Resolve changed files from the current Git context.
+
+    In CI, compare against the upstream/base revision. Locally, either return the
+    staged slice first or the union of staged and unstaged files, depending on
+    ``prefer_staged``.
+    """
+
+    base_ref = os.environ.get("GITHUB_BASE_REF")
+    if base_ref:
+        merge_base = f"origin/{base_ref}...HEAD"
+        paths = paths_from_output(run_git(["diff", "--name-only", "--diff-filter=ACMR", merge_base]))
+        if include_untracked:
+            paths = unique_paths(paths, untracked_files())
+        return paths, "ci"
+
+    before = os.environ.get("GITHUB_EVENT_BEFORE")
+    if before and before != "0000000000000000000000000000000000000000":
+        paths = paths_from_output(run_git(["diff", "--name-only", "--diff-filter=ACMR", before, "HEAD"]))
+        if include_untracked:
+            paths = unique_paths(paths, untracked_files())
+        return paths, "ci"
+
+    unstaged = paths_from_output(run_git(["diff", "--name-only", "--diff-filter=ACMR"]))
+    staged = paths_from_output(run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"]))
+
+    if prefer_staged and staged:
+        paths = staged
+        source = "staged"
+    elif prefer_staged:
+        paths = unstaged
+        source = "worktree"
+    else:
+        paths = unique_paths(unstaged, staged)
+        source = "combined"
+
+    if include_untracked and (not prefer_staged or source != "staged"):
+        paths = unique_paths(paths, untracked_files())
+
+    if not paths and prefer_staged:
+        return [], "worktree"
+    return paths, source

--- a/scripts/entropy_gate.py
+++ b/scripts/entropy_gate.py
@@ -5,9 +5,14 @@ Bloquea commits de archivos Python si su Complejidad Ciclomática (CC) supera
 el estándar Soberano (15).
 """
 
-import subprocess
 import sys
 from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from _changed_files import changed_files
 
 try:
     from radon.complexity import cc_visit
@@ -19,26 +24,22 @@ except ImportError:
 CC_THRESHOLD = 15
 
 
-def get_staged_python_files():
-    """Obtiene la lista de archivos manipulados en este commit usando git."""
-    try:
-        result = subprocess.run(
-            ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        files = result.stdout.strip().split("\n")
-        staged_files = []
-        for f in files:
-            if not f:
-                continue
-            path = Path.cwd() / f
-            if path.suffix == ".py" and path.exists():
-                staged_files.append(path)
-        return staged_files
-    except subprocess.CalledProcessError:
-        return []
+def _resolve_python_paths(files: list[str]) -> list[Path]:
+    resolved: list[Path] = []
+    seen: set[Path] = set()
+    for filename in files:
+        path = Path.cwd() / filename
+        if path.suffix != ".py" or not path.exists() or path in seen:
+            continue
+        seen.add(path)
+        resolved.append(path)
+    return resolved
+
+
+def get_candidate_python_files() -> tuple[list[Path], str]:
+    """Resolve Python files from staged changes, or from the local diff if index is empty."""
+    candidates, source = changed_files(include_untracked=True, prefer_staged=True)
+    return _resolve_python_paths([str(path) for path in candidates]), source
 
 
 def analyze_file(filepath: Path) -> bool:
@@ -64,20 +65,25 @@ def analyze_file(filepath: Path) -> bool:
             return False
 
         return True
-    except Exception:
+    except (OSError, SyntaxError, UnicodeDecodeError):
         # Silenciar errores por parseo (eso lo cogerá pydantic/syntax errors luego)
         return True
 
 
 def main():
-    staged_files = get_staged_python_files()
-    if not staged_files:
+    candidate_files, source = get_candidate_python_files()
+    if not candidate_files:
         sys.exit(0)  # Nada que escanear, continuar con el commit
 
-    print(f"👁️  ENTROPY GATE | Evaluando estática en {len(staged_files)} archivos...")
+    if source == "staged":
+        print(f"👁️  ENTROPY GATE | Evaluando estática en {len(candidate_files)} archivos staged...")
+    else:
+        print(
+            f"👁️  ENTROPY GATE | No hay staged; evaluando {len(candidate_files)} archivos del diff local..."
+        )
 
     failed = False
-    for f in staged_files:
+    for f in candidate_files:
         if not analyze_file(f):
             failed = True
 

--- a/scripts/repo_health_changed.py
+++ b/scripts/repo_health_changed.py
@@ -14,68 +14,29 @@ You can also pass file paths explicitly, or use ``--all`` to scan the repo.
 from __future__ import annotations
 
 import argparse
-import os
 import py_compile
 import subprocess
 import sys
 from pathlib import Path
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from _changed_files import changed_files, paths_from_output, run_git, unique_paths, untracked_files
+
 CONFLICT_MARKERS = ("<" * 7 + " ", ">" * 7 + " ")
 CONFLICT_SEPARATOR = "=" * 7
 
 
-def _run_git(args: list[str]) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    return result.stdout.strip()
-
-
-def _paths_from_output(output: str) -> list[Path]:
-    return [Path(line) for line in output.splitlines() if line]
-
-
-def _unique_paths(*groups: list[Path]) -> list[Path]:
-    seen: set[Path] = set()
-    ordered: list[Path] = []
-    for group in groups:
-        for path in group:
-            if path not in seen:
-                seen.add(path)
-                ordered.append(path)
-    return ordered
-
-
-def _untracked_files() -> list[Path]:
-    return _paths_from_output(_run_git(["ls-files", "--others", "--exclude-standard"]))
-
-
-def _changed_files_from_git() -> list[Path]:
-    # PRs on GitHub Actions expose the target branch name.
-    base_ref = os.environ.get("GITHUB_BASE_REF")
-    if base_ref:
-        merge_base = f"origin/{base_ref}...HEAD"
-        output = _run_git(["diff", "--name-only", "--diff-filter=ACMR", merge_base])
-        return _unique_paths(_paths_from_output(output), _untracked_files())
-
-    # Push events expose the previous commit SHA.
-    before = os.environ.get("GITHUB_EVENT_BEFORE")
-    if before and before != "0000000000000000000000000000000000000000":
-        output = _run_git(["diff", "--name-only", "--diff-filter=ACMR", before, "HEAD"])
-        return _unique_paths(_paths_from_output(output), _untracked_files())
-
-    # Local fallback: inspect unstaged + staged + untracked changes.
-    unstaged = _paths_from_output(_run_git(["diff", "--name-only", "--diff-filter=ACMR"]))
-    staged = _paths_from_output(_run_git(["diff", "--cached", "--name-only", "--diff-filter=ACMR"]))
-    return _unique_paths(unstaged, staged, _untracked_files())
+def _changed_files_from_git(*, include_untracked: bool = False) -> list[Path]:
+    paths, _ = changed_files(include_untracked=include_untracked, prefer_staged=False)
+    return paths
 
 
 def _all_repo_files() -> list[Path]:
-    tracked = _paths_from_output(_run_git(["ls-files"]))
-    return _unique_paths(tracked, _untracked_files())
+    tracked = paths_from_output(run_git(["ls-files"]))
+    return unique_paths(tracked, untracked_files())
 
 
 def _text_contains_conflict_markers(path: Path) -> list[int]:
@@ -105,7 +66,7 @@ def _collect_targets(args: argparse.Namespace) -> list[Path]:
     elif args.all:
         files = _all_repo_files()
     else:
-        files = _changed_files_from_git()
+        files = _changed_files_from_git(include_untracked=args.include_untracked)
     return [path for path in files if path.exists() and path.is_file()]
 
 
@@ -113,6 +74,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Run lightweight repo-health checks.")
     parser.add_argument("files", nargs="*", help="Optional explicit files to inspect.")
     parser.add_argument("--all", action="store_true", help="Scan all tracked and untracked files.")
+    parser.add_argument(
+        "--include-untracked",
+        action="store_true",
+        help="Include untracked files in the default changed-files scan.",
+    )
     args = parser.parse_args()
 
     try:

--- a/scripts/sovereign_pre_commit.py
+++ b/scripts/sovereign_pre_commit.py
@@ -9,8 +9,14 @@ DERIVATION: Ω₃ Byzantine Default — verify, then trust.
 """
 
 import re
-import subprocess
 import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from _changed_files import changed_files, run_git
 
 # ── Forbidden patterns (case-insensitive) ─────────────────────
 FORBIDDEN_PATTERNS: list[re.Pattern] = [
@@ -39,12 +45,20 @@ RESET = "\033[0m"
 
 def get_staged_files() -> list[str]:
     """Get list of files staged for commit."""
-    result = subprocess.run(
-        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACMR"],
-        capture_output=True,
-        text=True,
-    )
-    return [f for f in result.stdout.strip().split("\n") if f]
+    paths, source = changed_files(include_untracked=False, prefer_staged=True)
+    if source != "staged":
+        return []
+    return [str(path) for path in paths]
+
+
+def get_candidate_files() -> tuple[list[str], str, set[str]]:
+    """Prefer staged files, but fall back to the local diff when the index is empty."""
+    paths, source = changed_files(include_untracked=True, prefer_staged=True)
+    files = [str(path) for path in paths]
+    tracked_paths = changed_files(include_untracked=False, prefer_staged=True)[0]
+    tracked = {str(path) for path in tracked_paths}
+    untracked = {path for path in files if path not in tracked}
+    return files, source, untracked
 
 
 def check_filenames(files: list[str]) -> list[str]:
@@ -58,40 +72,66 @@ def check_filenames(files: list[str]) -> list[str]:
     return violations
 
 
-def check_file_contents(files: list[str]) -> list[str]:
-    """Scan staged file contents for secret patterns."""
+def _extract_added_lines(diff_content: str) -> str:
+    added_lines: list[str] = []
+    for line in diff_content.splitlines():
+        if line.startswith(("diff --git ", "index ", "@@ ", "--- ", "+++ ")):
+            continue
+        if line.startswith("+"):
+            added_lines.append(line[1:])
+    return "\n".join(added_lines)
+
+
+def _read_candidate_content(filepath: str, *, source: str, untracked_files: set[str]) -> str:
+    diff_args = ["diff", "--unified=0", "--", filepath]
+    if source == "staged":
+        diff_args.insert(1, "--cached")
+    diff_content = run_git(diff_args, check=False)
+    added_lines = _extract_added_lines(diff_content)
+    if added_lines:
+        return added_lines
+    if filepath not in untracked_files:
+        return ""
+    try:
+        return Path(filepath).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def check_file_contents(files: list[str], *, source: str, untracked_files: set[str]) -> list[str]:
+    """Scan candidate file contents for secret patterns."""
     violations: list[str] = []
     for filepath in files:
         try:
-            result = subprocess.run(
-                ["git", "diff", "--cached", "--", filepath],
-                capture_output=True,
-                text=True,
+            diff_content = _read_candidate_content(
+                filepath,
+                source=source,
+                untracked_files=untracked_files,
             )
-            diff_content = result.stdout
             for pattern in CONTENT_PATTERNS:
                 if pattern.search(diff_content):
                     violations.append(f"  🔍 CONTENT: {filepath} contains '{pattern.pattern}'")
                     break
-        except Exception:
+        except (OSError, ValueError):
             pass  # Binary files or access errors — skip
     return violations
 
 
 def main() -> int:
-    files = get_staged_files()
+    files, source, untracked_files = get_candidate_files()
     if not files:
         return 0
 
     violations: list[str] = []
     violations.extend(check_filenames(files))
-    violations.extend(check_file_contents(files))
+    violations.extend(check_file_contents(files, source=source, untracked_files=untracked_files))
 
     if violations:
         print(f"\n{RED}{BOLD}╔══════════════════════════════════════════════════╗{RESET}")
         print(f"{RED}{BOLD}║  🛑 SOVEREIGN SECURITY GATE — COMMIT BLOCKED    ║{RESET}")
         print(f"{RED}{BOLD}╚══════════════════════════════════════════════════╝{RESET}\n")
-        print(f"{YELLOW}Wallet seeds / credentials detected in staged files:{RESET}\n")
+        scope = "staged files" if source == "staged" else "local diff files"
+        print(f"{YELLOW}Wallet seeds / credentials detected in {scope}:{RESET}\n")
         for v in violations:
             print(f"{RED}{v}{RESET}")
         print(f"\n{YELLOW}If this is a false positive, bypass with:{RESET}")

--- a/scripts/sovereign_pre_commit.sh
+++ b/scripts/sovereign_pre_commit.sh
@@ -1,17 +1,51 @@
 #!/bin/bash
 # Sovereign Pre-commit hook v1.0 - Anti-Entropy Protocol
 
-STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep "\.py$" || true)
+set -euo pipefail
 
-if [ -n "$STAGED_FILES" ]; then
+collect_python_files() {
+    local -n target_ref=$1
+    local -n staged_mode_ref=$2
+    local -A seen=()
+    local path=""
+    local staged_files=()
+    local unstaged_files=()
+    local untracked_files=()
+
+    mapfile -t staged_files < <(git diff --cached --name-only --diff-filter=ACMR -- '*.py')
+    if [ ${#staged_files[@]} -gt 0 ]; then
+        target_ref=("${staged_files[@]}")
+        staged_mode_ref=1
+        return
+    fi
+
+    mapfile -t unstaged_files < <(git diff --name-only --diff-filter=ACMR -- '*.py')
+    mapfile -t untracked_files < <(git ls-files --others --exclude-standard -- '*.py')
+
+    target_ref=()
+    for path in "${unstaged_files[@]}" "${untracked_files[@]}"; do
+        if [ -z "$path" ] || [ -n "${seen[$path]+x}" ]; then
+            continue
+        fi
+        seen[$path]=1
+        target_ref+=("$path")
+    done
+    staged_mode_ref=0
+}
+
+PYTHON_FILES=()
+USING_STAGED=0
+collect_python_files PYTHON_FILES USING_STAGED
+
+if [ ${#PYTHON_FILES[@]} -gt 0 ]; then
     echo "⚡ [SOVEREIGN] Purging entropy with Ruff..."
-    
-    # Run formatting and checks
-    ruff format $STAGED_FILES
-    ruff check --fix $STAGED_FILES
-    
-    # Re-stage modified files
-    git add $STAGED_FILES
+
+    ruff format "${PYTHON_FILES[@]}"
+    ruff check --fix "${PYTHON_FILES[@]}"
+
+    if [ "$USING_STAGED" -eq 1 ]; then
+        git add -- "${PYTHON_FILES[@]}"
+    fi
 fi
 
 exit 0

--- a/tests/test_changed_files_helper.py
+++ b/tests/test_changed_files_helper.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "_changed_files.py"
+    spec = importlib.util.spec_from_file_location("_changed_files", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_changed_files_prefers_staged_when_requested(monkeypatch):
+    module = _load_module()
+
+    def fake_run_git(args, *, check=True):
+        outputs = {
+            ("diff", "--name-only", "--diff-filter=ACMR"): "worktree_only.py\n",
+            ("diff", "--cached", "--name-only", "--diff-filter=ACMR"): "staged_only.py\n",
+            ("ls-files", "--others", "--exclude-standard"): "scratch.py\n",
+        }
+        return outputs[tuple(args)]
+
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_BEFORE", raising=False)
+    monkeypatch.setattr(module, "run_git", fake_run_git)
+
+    files, source = module.changed_files(include_untracked=True, prefer_staged=True)
+
+    assert source == "staged"
+    assert files == [Path("staged_only.py")]
+
+
+def test_changed_files_combines_local_diff_for_repo_health(monkeypatch):
+    module = _load_module()
+
+    def fake_run_git(args, *, check=True):
+        outputs = {
+            ("diff", "--name-only", "--diff-filter=ACMR"): "worktree_only.py\n",
+            ("diff", "--cached", "--name-only", "--diff-filter=ACMR"): "staged_only.py\n",
+            ("ls-files", "--others", "--exclude-standard"): "",
+        }
+        return outputs[tuple(args)]
+
+    monkeypatch.delenv("GITHUB_BASE_REF", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_BEFORE", raising=False)
+    monkeypatch.setattr(module, "run_git", fake_run_git)
+
+    files, source = module.changed_files(include_untracked=False, prefer_staged=False)
+
+    assert source == "combined"
+    assert files == [Path("worktree_only.py"), Path("staged_only.py")]

--- a/tests/test_precommit_gate_fallbacks.py
+++ b/tests/test_precommit_gate_fallbacks.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script_module(name: str):
+    script_path = REPO_ROOT / "scripts" / name
+    spec = importlib.util.spec_from_file_location(name.replace(".py", ""), script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_entropy_gate_falls_back_to_local_python_diff(monkeypatch, tmp_path):
+    fake_radon = types.ModuleType("radon")
+    fake_complexity = types.ModuleType("radon.complexity")
+    fake_complexity.cc_visit = lambda code: []
+    fake_radon.complexity = fake_complexity
+    monkeypatch.setitem(sys.modules, "radon", fake_radon)
+    monkeypatch.setitem(sys.modules, "radon.complexity", fake_complexity)
+
+    module = _load_script_module("entropy_gate.py")
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "tracked.py").write_text("def ok():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "scratch.py").write_text("def also_ok():\n    return 2\n", encoding="utf-8")
+    (tmp_path / "notes.md").write_text("# ignored\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        module,
+        "changed_files",
+        lambda *, include_untracked, prefer_staged: (
+            [Path("tracked.py"), Path("notes.md"), Path("scratch.py")],
+            "worktree",
+        ),
+    )
+
+    files, source = module.get_candidate_python_files()
+
+    assert source == "worktree"
+    assert files == [tmp_path / "tracked.py", tmp_path / "scratch.py"]
+
+
+def test_sovereign_pre_commit_reads_untracked_file_contents_when_no_diff(monkeypatch, tmp_path):
+    module = _load_script_module("sovereign_pre_commit.py")
+    secret_key = "wallet" + "_seed"
+    secret_file = tmp_path / f"{secret_key}.txt"
+    secret_file.write_text(f"{secret_key}=ultra-secret\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(module, "run_git", lambda args, check=False: "")
+
+    violations = module.check_file_contents(
+        [str(secret_file)],
+        source="worktree",
+        untracked_files={str(secret_file)},
+    )
+
+    assert violations == [
+        f"  🔍 CONTENT: {secret_file} contains '{module.CONTENT_PATTERNS[0].pattern}'"
+    ]

--- a/tests/test_repo_health_changed.py
+++ b/tests/test_repo_health_changed.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "repo_health_changed.py"
+    spec = importlib.util.spec_from_file_location("repo_health_changed", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_changed_files_local_fallback_uses_unstaged_when_index_is_empty(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "changed_files",
+        lambda *, include_untracked, prefer_staged: (
+            [Path("cortex/api/core.py"), Path("README.md")],
+            "combined",
+        ),
+    )
+
+    assert module._changed_files_from_git() == [
+        Path("cortex/api/core.py"),
+        Path("README.md"),
+    ]
+
+
+def test_changed_files_can_merge_untracked_without_duplicates(monkeypatch):
+    module = _load_module()
+    monkeypatch.setattr(
+        module,
+        "changed_files",
+        lambda *, include_untracked, prefer_staged: (
+            [
+                Path("cortex/api/core.py"),
+                Path("tests/test_repo_health_changed.py"),
+                Path("scripts/repo_health_changed.py"),
+            ],
+            "combined",
+        ),
+    )
+
+    assert module._changed_files_from_git(include_untracked=True) == [
+        Path("cortex/api/core.py"),
+        Path("tests/test_repo_health_changed.py"),
+        Path("scripts/repo_health_changed.py"),
+    ]


### PR DESCRIPTION
## Summary
- centralize changed-file resolution for repo health and commit gates
- make entropy and sovereign pre-commit gates fall back to the worktree when the index is empty
- add regression tests for staged vs worktree selection

## Validation
- ruff check scripts/_changed_files.py scripts/repo_health_changed.py scripts/entropy_gate.py scripts/sovereign_pre_commit.py tests/test_changed_files_helper.py tests/test_repo_health_changed.py tests/test_precommit_gate_fallbacks.py
- pytest -q tests/test_changed_files_helper.py tests/test_repo_health_changed.py tests/test_precommit_gate_fallbacks.py
- python3 scripts/repo_health_changed.py