### PR TITLE
ci: add ruff-fix workflow

### DIFF
--- a/.github/workflows/ruff-fix.yml
+++ b/.github/workflows/ruff-fix.yml
@@ -1,0 +1,40 @@
+name: Fix Ruff lint errors
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  ruff-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Run ruff fix
+        run: |
+          ruff check cortex/ tests/ scripts/ --fix --unsafe-fixes || true
+          ruff format cortex/ tests/ scripts/ || true
+
+      - name: Commit fixes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "fix(lint): apply ruff auto-fixes"
+            git push origin main
+          fi


### PR DESCRIPTION
This workflow automates the process of fixing lint errors using Ruff, including installation, running fixes, and committing changes.

## What does this PR do?

<!-- Brief description of the change -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] No hardcoded secrets or API keys
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing)
