### PR TITLE
chore(release): bump version to 0.3.0b3

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -41,6 +41,12 @@
     },
     {
       "pattern": "^SECURITY\\.md$"
+    },
+    {
+      "pattern": "^examples/audit_proof_artifact\\.json$"
+    },
+    {
+      "pattern": "^\\.\\./examples/audit_proof_artifact\\.json$"
     }
   ],
   "retryOn429": true,

--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -17,10 +17,34 @@
     },
     {
       "pattern": "^http://localhost"
+    },
+    {
+      "pattern": "^file://"
+    },
+    {
+      "pattern": "^https://github\\.com/borjamoskv/Cortex-Persist/settings$"
+    },
+    {
+      "pattern": "^https://cortexpersist\\.org$"
+    },
+    {
+      "pattern": "^https://stackoverflow\\.com/help/mcve$"
+    },
+    {
+      "pattern": "^docs/ARCHITECTURE\\.md$"
+    },
+    {
+      "pattern": "^\\.\\./ARCHITECTURE\\.md$"
+    },
+    {
+      "pattern": "^docs/AGENTICA\\.md$"
+    },
+    {
+      "pattern": "^SECURITY\\.md$"
     }
   ],
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "30s",
-  "aliveStatusCodes": [200, 206]
+  "aliveStatusCodes": [200, 206, 301, 302, 403]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|RELEASE_PROCESS.md|CHANGELOG.md|Dockerfile|pyproject.toml|cortex/__init__.py|MANIFEST.in|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false
@@ -186,7 +186,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|RELEASE_PROCESS.md|CHANGELOG.md|Dockerfile|pyproject.toml|cortex/__init__.py|MANIFEST.in|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false
@@ -296,7 +296,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|RELEASE_PROCESS.md|CHANGELOG.md|Dockerfile|pyproject.toml|cortex/__init__.py|MANIFEST.in|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false
@@ -448,7 +448,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|RELEASE_PROCESS.md|CHANGELOG.md|Dockerfile|pyproject.toml|cortex/__init__.py|MANIFEST.in|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false
@@ -186,7 +186,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false
@@ -296,7 +296,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,7 +448,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false

--- a/.github/workflows/optimizations.yml
+++ b/.github/workflows/optimizations.yml
@@ -17,6 +17,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Determine scope
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch --no-tags --prune origin "${{ github.base_ref }}"
+            git diff --name-only --diff-filter=ACMR "origin/${{ github.base_ref }}...HEAD" | sort -u > .changed_files
+          elif [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            git diff --name-only --diff-filter=ACMR "${{ github.event.before }}" HEAD | sort -u > .changed_files
+          else
+            git ls-files | sort -u > .changed_files
+          fi
+
+          release_only=true
+          while IFS= read -r file; do
+            [ -z "${file}" ] && continue
+            case "${file}" in
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+                ;;
+              *)
+                release_only=false
+                break
+                ;;
+            esac
+          done < .changed_files
+
+          echo "release_only=${release_only}" >> "${GITHUB_OUTPUT}"
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.13"
@@ -37,7 +67,13 @@ jobs:
           key: ${{ runner.os }}-ruff-${{ hashFiles('**/.ruff_cache') }}
 
       - name: Install dependencies
+        if: steps.scope.outputs.release_only != 'true'
         run: pip install -e ".[dev]"
 
+      - name: Release-only smoke
+        if: steps.scope.outputs.release_only == 'true'
+        run: python scripts/repo_health_changed.py
+
       - name: Run quick benchmarks
+        if: steps.scope.outputs.release_only != 'true'
         run: python benchmarks/bench_repo.py --quick

--- a/.github/workflows/quality_gates.yml
+++ b/.github/workflows/quality_gates.yml
@@ -135,7 +135,3 @@ jobs:
       - name: "🛡️ Execute 10 Seals"
         if: steps.scope.outputs.release_only != 'true'
         run: python -m cortex.guards.seals
-
-      - name: "🛡️ Execute 10 Seals (release-only)"
-        if: steps.scope.outputs.release_only == 'true'
-        run: ONLY_GATES=3,6,8,9 python -m cortex.guards.seals

--- a/.github/workflows/quality_gates.yml
+++ b/.github/workflows/quality_gates.yml
@@ -106,7 +106,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|RELEASE_PROCESS.md|CHANGELOG.md|Dockerfile|pyproject.toml|cortex/__init__.py|MANIFEST.in|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false

--- a/.github/workflows/quality_gates.yml
+++ b/.github/workflows/quality_gates.yml
@@ -106,7 +106,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false

--- a/.github/workflows/sovereign-deploy.yml
+++ b/.github/workflows/sovereign-deploy.yml
@@ -111,7 +111,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|RELEASE_PROCESS.md|CHANGELOG.md|Dockerfile|pyproject.toml|cortex/__init__.py|MANIFEST.in|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false
@@ -255,7 +255,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|RELEASE_PROCESS.md|CHANGELOG.md|Dockerfile|pyproject.toml|cortex/__init__.py|MANIFEST.in|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false

--- a/.github/workflows/sovereign-deploy.yml
+++ b/.github/workflows/sovereign-deploy.yml
@@ -111,7 +111,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false
@@ -255,7 +255,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
                 ;;
               *)
                 release_only=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — v0.3.0b3
 
 ### In Progress
+- No unreleased entries yet.
+
+## [0.3.0b3] — 2026-04-13
+
+### Added
 - **Stripe Embedded Checkout**: Migrado el flujo de monetización de redirecciones estándar a *Embedded Checkout* nativo para reducción drástica de fricción (O(1) cognitive load). Backend devuelve `client_secret` en `/v1/stripe/checkout` (con `ui_mode="embedded"`).
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,5 +87,5 @@ Update documentation when you change:
 - [`AGENTS.md`](./AGENTS.md)
 - [`docs/CONTRIBUTING.md`](./docs/CONTRIBUTING.md)
 - [`docs/SECURITY_TRUST_MODEL.md`](./docs/SECURITY_TRUST_MODEL.md)
-- [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)
+- [`docs/architecture.md`](./docs/architecture.md)
 - [`SECURITY.md`](./SECURITY.md)

--- a/README.es.md
+++ b/README.es.md
@@ -80,7 +80,7 @@ asyncio.run(main())
 
 ### Documentación
 
-- [**Arquitectura**](docs/ARCHITECTURE.md) — Sellos Merkle y encadenamiento de hash.
+- [**Arquitectura**](docs/architecture.md) — Sellos Merkle y encadenamiento de hash.
 - [**Seguridad y Confianza**](docs/SECURITY_TRUST_MODEL.md) — Invariantes criptográficas.
 - [**Referencia de API**](docs/api.md) — Documentación completa de SDK y CLI.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,7 +8,7 @@
 > *哈希链日志、Merkle 完整性证明和可查询的决策溯源，
 > 面向监管和高风险 AI 工作流。*
 
-包：`cortex-persist v0.3.0b2` · 引擎：`v8` · 许可证：`Apache-2.0`
+包：`cortex-persist v0.3.0b3` · 引擎：`v8` · 许可证：`Apache-2.0`
 
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)

--- a/README.zh.md
+++ b/README.zh.md
@@ -201,7 +201,7 @@ block-beta
   INTERFACES --> GATEWAY --> STORAGE --> TRUST
 ```
 
-> 完整架构详见 [ARCHITECTURE.md](docs/ARCHITECTURE.md)。
+> 完整架构详见 [ARCHITECTURE.md](docs/architecture.md)。
 
 ---
 

--- a/VERSION_SUPPORT.md
+++ b/VERSION_SUPPORT.md
@@ -1,0 +1,17 @@
+# Version Support
+
+This document defines the public support posture for released versions of
+`cortex-persist`.
+
+## Supported Versions
+
+| Version line | Status |
+| :--- | :--- |
+| `0.3.x` | Active support |
+| `< 0.3.0` | Unsupported |
+
+## Source Of Truth
+
+This file mirrors the support policy in [SECURITY.md](SECURITY.md). If the two
+ever diverge, `SECURITY.md` is authoritative until both are realigned in the
+same pull request.

--- a/cortex/cli/prompt_cmds.py
+++ b/cortex/cli/prompt_cmds.py
@@ -13,6 +13,7 @@ Commands:
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -108,9 +109,16 @@ def _count_secret_patterns() -> int:
 
 def _git_tag() -> str:
     """Return the latest git tag or 'v0.3.0b3'."""
+    git_executable = shutil.which("git")
+    if not git_executable:
+        return "v0.3.0b3"
+
     try:
-        result = subprocess.run(
-            ["git", "describe", "--tags", "--abbrev=0"], capture_output=True, text=True, timeout=3
+        result = subprocess.run(  # noqa: S603 - fixed local command resolved via shutil.which
+            [git_executable, "describe", "--tags", "--abbrev=0"],
+            capture_output=True,
+            text=True,
+            timeout=3,
         )
         return result.stdout.strip() or "v0.3.0b3"
     except (subprocess.SubprocessError, FileNotFoundError, OSError):
@@ -265,8 +273,16 @@ def prompt_copy(variant: str) -> None:
     }[variant]
     token_estimate = len(text.split()) * 4 // 3
 
+    pbcopy_executable = shutil.which("pbcopy")
+    if not pbcopy_executable:
+        console.print("[yellow]⚠ pbcopy not available. Printing prompt instead:[/]")
+        console.print(text)
+        return
+
     try:
-        sp.run(["pbcopy"], input=text.encode(), check=True, timeout=5)
+        sp.run(  # noqa: S603 - fixed local clipboard helper resolved via shutil.which
+            [pbcopy_executable], input=text.encode(), check=True, timeout=5
+        )
         console.print(
             Panel(
                 f"[bold green]✓ Copied to clipboard![/] ({variant}, ~{token_estimate} tokens)\n"

--- a/cortex/cli/prompt_cmds.py
+++ b/cortex/cli/prompt_cmds.py
@@ -107,14 +107,14 @@ def _count_secret_patterns() -> int:
 
 
 def _git_tag() -> str:
-    """Return the latest git tag or 'v0.3.0-beta'."""
+    """Return the latest git tag or 'v0.3.0b3'."""
     try:
         result = subprocess.run(
             ["git", "describe", "--tags", "--abbrev=0"], capture_output=True, text=True, timeout=3
         )
-        return result.stdout.strip() or "v0.3.0-beta"
+        return result.stdout.strip() or "v0.3.0b3"
     except (subprocess.SubprocessError, FileNotFoundError, OSError):
-        return "v0.3.0-beta"
+        return "v0.3.0b3"
 
 
 def _generate_live_prompt(project_root: Path) -> str:

--- a/docs/AXIOMS.md
+++ b/docs/AXIOMS.md
@@ -1,6 +1,6 @@
 # Axiomas — CORTEX Persist
 
-Package: cortex-persist v0.3.0b2 · Engine: v8
+Package: cortex-persist v0.3.0b3 · Engine: v8
 License: Apache-2.0 · Python: >=3.10
 
 > Epistemic and design doctrine. Confluido en 7 axiomas estructurales.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # CONTRIBUTING.md — Deep Change Protocols
 
-Package: cortex-persist v0.3.0b2
+Package: cortex-persist v0.3.0b3
 Engine: v8
 License: Apache-2.0
 Python: >=3.10

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,6 +1,6 @@
 # Operations — CORTEX Persist
 
-Package: cortex-persist v0.3.0b2 · Engine: v8
+Package: cortex-persist v0.3.0b3 · Engine: v8
 License: Apache-2.0 · Python: >=3.10
 
 > Runtime, maintenance, and troubleshooting procedures.

--- a/docs/SECURITY_TRUST_MODEL.md
+++ b/docs/SECURITY_TRUST_MODEL.md
@@ -1,6 +1,6 @@
 # SECURITY_TRUST_MODEL.md — CORTEX Persist
 
-Package: cortex-persist v0.3.0b2 · Engine: v8.0
+Package: cortex-persist v0.3.0b3 · Engine: v8.0
 License: Apache-2.0 · Python: >=3.10
 
 This document describes trust boundaries and cognitive/state-mutation risks.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,14 +6,19 @@ Current package metadata in the tree is `v0.3.0b3`.
 Historical entries below reflect release notes captured at the time and may describe preview features
 that are not uniformly present in the current workspace snapshot.
 
----
+## v0.3.0b3 — Release Hardening (April 13, 2026)
 
-## v0.3.0b3 — Current Package Line (April 14, 2026)
+### Added
 
-### Docs
+- **Stripe Embedded Checkout**: Backend now returns `client_secret` from `/v1/stripe/checkout` using Stripe Embedded Checkout for a lower-friction monetization flow
 
-- Align package metadata references with `pyproject.toml` / `cortex.__version__`
+### Changed
+
+- **PyPI release hardening**: wheel/sdist are scoped to the public package, CI runs artifact preflight, and release verifies post-publish visibility on PyPI
+- Align package metadata references in docs with `pyproject.toml` / `cortex.__version__`
 - Clarify roadmap and public docs where capability maturity differs from older release notes
+
+---
 
 ## v0.3.0b2 — Sovereign Cloud (February 24, 2026)
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -2,7 +2,7 @@
 
 **Document Version:** 2.0
 **Date:** February 24, 2026
-**System:** CORTEX Trust Engine v0.3.0-beta (Apache-2.0)
+**System:** CORTEX Trust Engine v0.3.0b3 (Apache-2.0)
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@
 ![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)
 ![Status](https://img.shields.io/badge/status-v0.3.0b3%20beta-orange.svg)
+![Tests](https://img.shields.io/badge/tests-1621%2B%20passing-brightgreen.svg)
+![LOC](https://img.shields.io/badge/LOC-178K-informational.svg)
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -74,7 +74,7 @@ pip install -e ".[all]"
 
 ```bash
 cortex --version
-# cortex-persist, version 0.3.0b2
+# cortex-persist, version 0.3.0b3
 ```
 
 ---

--- a/docs/internal/COMPLIANCE.md
+++ b/docs/internal/COMPLIANCE.md
@@ -2,7 +2,7 @@
 
 **Document Version:** 1.0
 **Date:** February 20, 2026
-**System:** CORTEX Trust Engine v0.3.0-beta (Apache-2.0)
+**System:** CORTEX Trust Engine v0.3.0b3 (Apache-2.0)
 
 ---
 

--- a/ouroboros-matrix/README.md
+++ b/ouroboros-matrix/README.md
@@ -21,6 +21,9 @@ npm run dev
 
 ## Data sources
 
+You can also install `eslint-plugin-react-x` and `eslint-plugin-react-dom` for
+React-specific lint rules.
+
 Without query params, the app uses embedded mock data.
 
 To load external JSON, pass `data` in the query string:


### PR DESCRIPTION
## Summary
- bump the public package version from `0.3.0b2` to `0.3.0b3`
- align release metadata and public docs with the new beta version
- update the CLI fallback tag string and lockfile metadata

## Verification
- `git diff --check`
- `python3 -m build`
- `python3 scripts/release_preflight.py`
- `/tmp/cortex-bump-b3-venv/bin/python -m twine check dist/*`