### PR TITLE
fix(cli): keep init bootstrap offline

### DIFF
--- a/cortex/cli/init_cmds.py
+++ b/cortex/cli/init_cmds.py
@@ -2,11 +2,34 @@
 
 from __future__ import annotations
 
+import os
+from contextlib import contextmanager
+from collections.abc import Iterator
+
 import click
 from rich.panel import Panel
 
 from cortex import __version__
 from cortex.cli.common import DEFAULT_DB, _run_async, cli, console, get_engine
+
+
+@contextmanager
+def _bootstrap_without_embeddings() -> Iterator[None]:
+    """Force deterministic fallback embeddings during first-run seed writes.
+
+    `cortex init` should create a usable database quickly on a clean machine.
+    The initial axiom seed does not need to pay the cold-start cost of loading
+    or downloading the local embedding model.
+    """
+    previous = os.environ.get("CORTEX_NO_EMBED")
+    os.environ["CORTEX_NO_EMBED"] = "1"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("CORTEX_NO_EMBED", None)
+        else:
+            os.environ["CORTEX_NO_EMBED"] = previous
 
 
 @cli.command()
@@ -32,31 +55,32 @@ def init(db, ouroboros: bool) -> None:
             "Axioma X: Gran Paradoja. El humano es el sueño del agente; el agente es la vigilia del humano.",
         ]
 
-        for idx, axiom in enumerate(axioms, start=1):
-            _run_async(
-                engine.store(
-                    project="global",
-                    content=axiom,
-                    fact_type="identity",
-                    tags=["moskv-1", "axiom", "sovereign", "core", f"axiom-{idx}"],
-                    confidence="C5",
-                    source="ag:genesis",
+        with _bootstrap_without_embeddings():
+            for idx, axiom in enumerate(axioms, start=1):
+                _run_async(
+                    engine.store(
+                        project="global",
+                        content=axiom,
+                        fact_type="identity",
+                        tags=["moskv-1", "axiom", "sovereign", "core", f"axiom-{idx}"],
+                        confidence="C5",
+                        source="ag:genesis",
+                    )
                 )
-            )
 
-        if ouroboros:
-            from cortex.extensions.gate.ouroboros import get_ouroboros_gate
+            if ouroboros:
+                from cortex.extensions.gate.ouroboros import get_ouroboros_gate
 
-            og = get_ouroboros_gate(engine)
-            entropy = og.measure_entropy()
-            _run_async(
-                engine.store(
-                    project="cortex",
-                    content=f"Ouroboros-Ω Initialized. Entropy: {entropy['entropy_index']}",
-                    fact_type="decision",
-                    source="ag:ouroboros",
+                og = get_ouroboros_gate(engine)
+                entropy = og.measure_entropy()
+                _run_async(
+                    engine.store(
+                        project="cortex",
+                        content=f"Ouroboros-Ω Initialized. Entropy: {entropy['entropy_index']}",
+                        fact_type="decision",
+                        source="ag:ouroboros",
+                    )
                 )
-            )
 
         msg = (
             f"[bold #CCFF00]✓ CORTEX v{__version__} initialized[/]\n"

--- a/cortex/cli/init_cmds.py
+++ b/cortex/cli/init_cmds.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 from contextlib import contextmanager
-import os
 
 import click
 from rich.panel import Panel

--- a/cortex/cli/init_cmds.py
+++ b/cortex/cli/init_cmds.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import os
-from contextlib import contextmanager
 from collections.abc import Iterator
+from contextlib import contextmanager
+import os
 
 import click
 from rich.panel import Panel

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+import os
+
+from click.testing import CliRunner
+
+from cortex.cli import cli
+
+
+class _DummyEngine:
+    def __init__(self) -> None:
+        self._db_path = "/tmp/test-cortex.db"
+        self.no_embed_during_store: list[str | None] = []
+        self.closed = False
+
+    async def init_db(self) -> None:
+        return None
+
+    async def store(self, **_: object) -> int:
+        self.no_embed_during_store.append(os.environ.get("CORTEX_NO_EMBED"))
+        return 1
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_init_uses_no_embed_during_seed_and_restores_env(monkeypatch) -> None:
+    engine = _DummyEngine()
+    runner = CliRunner()
+
+    monkeypatch.setattr("cortex.cli.init_cmds.get_engine", lambda _db: engine)
+    monkeypatch.setattr("cortex.cli.init_cmds._run_async", _run)
+    monkeypatch.delenv("CORTEX_NO_EMBED", raising=False)
+
+    result = runner.invoke(cli, ["init", "--db", "/tmp/test-cortex.db"])
+
+    assert result.exit_code == 0
+    assert engine.no_embed_during_store == ["1"] * 10
+    assert os.environ.get("CORTEX_NO_EMBED") is None
+    assert engine.closed is True
+
+
+def test_init_restores_existing_no_embed_value(monkeypatch) -> None:
+    engine = _DummyEngine()
+    runner = CliRunner()
+
+    monkeypatch.setattr("cortex.cli.init_cmds.get_engine", lambda _db: engine)
+    monkeypatch.setattr("cortex.cli.init_cmds._run_async", _run)
+    monkeypatch.setenv("CORTEX_NO_EMBED", "0")
+
+    result = runner.invoke(cli, ["init", "--db", "/tmp/test-cortex.db"])
+
+    assert result.exit_code == 0
+    assert engine.no_embed_during_store == ["1"] * 10
+    assert os.environ.get("CORTEX_NO_EMBED") == "0"


### PR DESCRIPTION
## Summary
- force deterministic fallback embeddings only during `cortex init` seed writes
- restore the previous `CORTEX_NO_EMBED` value after bootstrap
- add CLI tests covering env restoration during init

## Verification
- pytest -q tests/test_cli_init.py
- python3 -m cortex.cli init --db <temp db> (completed in ~11s instead of hanging on model bootstrap)
- public smoke before patch: `pip install cortex-persist==0.3.0b3` + `cortex --version` worked, but `cortex init` timed out without `CORTEX_NO_EMBED=1`