### PR TITLE
chore(release): cut 0.3.0b4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased] — v0.3.0b3
+## [Unreleased] — v0.3.0b4
 
 ### In Progress
 - No unreleased entries yet.
+
+## [0.3.0b4] — 2026-04-14
+
+### Fixed
+- **CLI onboarding cold start**: `cortex init` now forces deterministic fallback embeddings only during initial axiom seeding, avoiding first-run hangs caused by local model bootstrap while preserving the normal embedding path after initialization.
 
 ## [0.3.0b3] — 2026-04-13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cortex-persist"
-version = "0.3.0b3"
+version = "0.3.0b4"
 description = "Cryptographic memory integrity, audit trails, and verifiable lineage for AI agents."
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- bump package version from `0.3.0b3` to `0.3.0b4`
- record the `cortex init` onboarding fix in the changelog

## Verification
- pytest -q tests/test_cli_init.py
- python3 - <<'PY' ... tomllib load of pyproject version ...'PY'