### PR TITLE
chore(release): cut 0.3.0b5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased] — v0.3.0b4
+## [Unreleased] — v0.3.0b5
 
 ### In Progress
 - No unreleased entries yet.
+
+## [0.3.0b5] — 2026-04-14
+
+### Fixed
+- **Public version consistency**: aligned package metadata, `cortex.__version__`, CLI `--version`, and prompt tag fallback on `0.3.0b5` after `0.3.0b4` shipped the onboarding fix with an outdated in-module version string.
 
 ## [0.3.0b4] — 2026-04-14
 

--- a/cortex/__init__.py
+++ b/cortex/__init__.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     pass
 
-__version__ = "0.3.0b3"
+__version__ = "0.3.0b5"
 __author__ = "by borjamoskv.com"
 
 # Lazy imports — CortexEngine and experimental modules load on first access

--- a/cortex/cli/prompt_cmds.py
+++ b/cortex/cli/prompt_cmds.py
@@ -108,10 +108,10 @@ def _count_secret_patterns() -> int:
 
 
 def _git_tag() -> str:
-    """Return the latest git tag or 'v0.3.0b3'."""
+    """Return the latest git tag or 'v0.3.0b5'."""
     git_executable = shutil.which("git")
     if not git_executable:
-        return "v0.3.0b3"
+        return "v0.3.0b5"
 
     try:
         result = subprocess.run(  # noqa: S603 - fixed local command resolved via shutil.which
@@ -120,9 +120,9 @@ def _git_tag() -> str:
             text=True,
             timeout=3,
         )
-        return result.stdout.strip() or "v0.3.0b3"
+        return result.stdout.strip() or "v0.3.0b5"
     except (subprocess.SubprocessError, FileNotFoundError, OSError):
-        return "v0.3.0b3"
+        return "v0.3.0b5"
 
 
 def _generate_live_prompt(project_root: Path) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cortex-persist"
-version = "0.3.0b4"
+version = "0.3.0b5"
 description = "Cryptographic memory integrity, audit trails, and verifiable lineage for AI agents."
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import cortex
+
+
+def test_module_version_matches_pyproject() -> None:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject.open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+
+    assert cortex.__version__ == project["version"]


### PR DESCRIPTION
## Summary
- bump package version to `0.3.0b5`
- align `cortex.__version__` and CLI fallback tags with the published version
- add a regression test to keep module and pyproject versions in sync

## Verification
- pytest -q tests/test_cli_init.py tests/test_version_consistency.py
- python3 -m cortex.cli --version