### PR TITLE
feat(site): ship async-first landing and intake flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py|astro.config.mjs|vercel.json|.vercelignore|package.json|package-lock.json|src/*|public/*)
                 ;;
               *)
                 release_only=false
@@ -186,7 +186,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py|astro.config.mjs|vercel.json|.vercelignore|package.json|package-lock.json|src/*|public/*)
                 ;;
               *)
                 release_only=false
@@ -296,7 +296,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py|astro.config.mjs|vercel.json|.vercelignore|package.json|package-lock.json|src/*|public/*)
                 ;;
               *)
                 release_only=false
@@ -448,7 +448,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py|astro.config.mjs|vercel.json|.vercelignore|package.json|package-lock.json|src/*|public/*)
                 ;;
               *)
                 release_only=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,7 +458,11 @@ jobs:
           done < .changed_files
 
           echo "release_only=${release_only}" >> "${GITHUB_OUTPUT}"
+      - name: Release-only container skip
+        if: steps.scope.outputs.release_only == 'true'
+        run: echo "Skipping container build for release-only scope."
       - name: Build Docker image
+        if: steps.scope.outputs.release_only != 'true'
         run: docker build -t cortex:test .
       - name: Scan image with Trivy
         if: steps.scope.outputs.release_only != 'true'

--- a/.github/workflows/quality_gates.yml
+++ b/.github/workflows/quality_gates.yml
@@ -106,7 +106,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py|astro.config.mjs|vercel.json|.vercelignore|package.json|package-lock.json|src/*|public/*)
                 ;;
               *)
                 release_only=false

--- a/.github/workflows/sovereign-deploy.yml
+++ b/.github/workflows/sovereign-deploy.yml
@@ -111,7 +111,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py|astro.config.mjs|vercel.json|.vercelignore|package.json|package-lock.json|src/*|public/*)
                 ;;
               *)
                 release_only=false
@@ -255,7 +255,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "${file}" ] && continue
             case "${file}" in
-              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py)
+              .github/workflows/*|.github/mlc_config.json|README.md|README.es.md|README.zh.md|CONTRIBUTING.md|RELEASE_PROCESS.md|CHANGELOG.md|VERSION_SUPPORT.md|docs/*|ouroboros-matrix/README.md|Dockerfile|pyproject.toml|uv.lock|MANIFEST.in|cortex/__init__.py|cortex/cli/prompt_cmds.py|scripts/release_preflight.py|scripts/repo_health_changed.py|astro.config.mjs|vercel.json|.vercelignore|package.json|package-lock.json|src/*|public/*)
                 ;;
               *)
                 release_only=false

--- a/.github/workflows/sovereign-deploy.yml
+++ b/.github/workflows/sovereign-deploy.yml
@@ -266,7 +266,12 @@ jobs:
 
           echo "release_only=${release_only}" >> "${GITHUB_OUTPUT}"
 
+      - name: Release-only container skip
+        if: steps.scope.outputs.release_only == 'true'
+        run: echo "Skipping container build for release-only scope."
+
       - name: Build Docker image
+        if: steps.scope.outputs.release_only != 'true'
         run: docker build -t cortex-sovereign:${{ github.sha }} .
 
       - name: Trivy scan (CRITICAL + HIGH)

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,9 @@
+*
+!package.json
+!package-lock.json
+!astro.config.mjs
+!vercel.json
+!src
+!src/**
+!public
+!public/**

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,40 +1,10 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
-import starlight from '@astrojs/starlight';
 
 // CORTEX Unified Substrate — v0.3.2b1 Configuration
 export default defineConfig({
   output: 'static',
   integrations: [
     react(),
-    starlight({
-      title: 'CORTEX Docs',
-      logo: {
-        src: './src/assets/logo-white.svg',
-      },
-      social: {
-        github: 'https://github.com/borjamoskv/Cortex-Persist',
-      },
-      sidebar: [
-        {
-          label: 'Start Here',
-          items: [
-            { label: 'Introduction', link: '/guides/introduction' },
-            { label: 'Quickstart', link: '/guides/quickstart' },
-          ],
-        },
-        {
-          label: 'Architecture',
-          autogenerate: { directory: 'architecture' },
-        },
-        {
-          label: 'Reference',
-          autogenerate: { directory: 'reference' },
-        },
-      ],
-      customCss: [
-        './src/styles/custom.css',
-      ],
-    }),
   ],
 });

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
   },
   "dependencies": {
     "@astrojs/react": "^4.2.0",
-    "@astrojs/starlight": "^0.32.0",
-    "@astrojs/tailwind": "^5.1.5",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@types/three": "^0.183.1",
@@ -22,7 +20,6 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.0.1",
-    "tailwindcss": "^4.0.0",
     "three": "^0.183.2"
   }
 }

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M20 5L35 30H5L20 5Z" fill="white" />
+</svg>

--- a/src/components/IntakeFormScript.astro
+++ b/src/components/IntakeFormScript.astro
@@ -1,0 +1,88 @@
+---
+interface IntakeLine {
+	label: string;
+	field: string;
+}
+
+interface Props {
+	requestTitle: string;
+	lines: IntakeLine[];
+	invalidMessage?: string;
+	openingMessage?: string;
+	copiedMessage?: string;
+	copyFailedMessage?: string;
+}
+
+const {
+	requestTitle,
+	lines,
+	invalidMessage = 'Fill the required fields before opening the email draft.',
+	openingMessage = 'Opening email draft...',
+	copiedMessage = 'Copied. Paste it into any email client if mailto is not available.',
+	copyFailedMessage = 'Copy failed. Select the preview text manually and paste it into your email.',
+} = Astro.props;
+---
+
+<script
+	define:vars={{ requestTitle, lines, invalidMessage, openingMessage, copiedMessage, copyFailedMessage }}
+>
+	const form = document.querySelector('[data-intake-form]');
+
+	if (form instanceof HTMLFormElement) {
+		const preview = document.querySelector('[data-intake-preview]');
+		const subjectNode = document.querySelector('[data-intake-subject]');
+		const statusNode = document.querySelector('[data-intake-status]');
+		const copyButton = document.querySelector('[data-copy-intake]');
+		const fields = Array.from(form.querySelectorAll('input, textarea, select'));
+		const supportEmail = form.dataset.email || '';
+		const subject = form.dataset.subject || 'CORTEX intake';
+
+		const buildBody = () => {
+			const data = Object.fromEntries(new FormData(form).entries());
+			return [
+				requestTitle,
+				'',
+				...lines.map(({ label, field }) => `${label}: ${data[field] || '-'}`),
+			].join('\n');
+		};
+
+		const refreshPreview = () => {
+			const body = buildBody();
+			if (preview) preview.textContent = body;
+			if (subjectNode) subjectNode.textContent = subject;
+			return body;
+		};
+
+		fields.forEach((field) => {
+			field.addEventListener('input', refreshPreview);
+			field.addEventListener('change', refreshPreview);
+		});
+
+		form.addEventListener('submit', (event) => {
+			event.preventDefault();
+			if (!form.reportValidity()) {
+				const firstInvalid = form.querySelector(':invalid');
+				if (firstInvalid instanceof HTMLElement) firstInvalid.focus();
+				if (statusNode) statusNode.textContent = invalidMessage;
+				return;
+			}
+
+			const body = refreshPreview();
+			const href = `mailto:${supportEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+			if (statusNode) statusNode.textContent = openingMessage;
+			window.location.href = href;
+		});
+
+		copyButton?.addEventListener('click', async () => {
+			const body = refreshPreview();
+			try {
+				await navigator.clipboard.writeText(body);
+				if (statusNode) statusNode.textContent = copiedMessage;
+			} catch {
+				if (statusNode) statusNode.textContent = copyFailedMessage;
+			}
+		});
+
+		refreshPreview();
+	}
+</script>

--- a/src/layouts/SiteLayout.astro
+++ b/src/layouts/SiteLayout.astro
@@ -1,0 +1,51 @@
+---
+import '../styles/site.css';
+
+interface Props {
+	title: string;
+	description: string;
+	canonical?: string;
+	lang?: string;
+	bodyClass?: string;
+}
+
+const {
+	title,
+	description,
+	canonical = 'https://cortexpersist.com/',
+	lang = 'en',
+	bodyClass = '',
+} = Astro.props;
+---
+
+<!doctype html>
+<html lang={lang}>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>{title}</title>
+		<meta name="description" content={description} />
+		<meta property="og:title" content={title} />
+		<meta property="og:description" content={description} />
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content={canonical} />
+		<meta name="theme-color" content="#0a0a0a" />
+		<link rel="canonical" href={canonical} />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Manrope:wght@400;500;600;700;800&family=Orbitron:wght@500;700;800&display=swap"
+			rel="stylesheet"
+		/>
+		<slot name="head" />
+	</head>
+	<body class:list={['site-body', bodyClass]}>
+		<div class="site-ambience" aria-hidden="true">
+			<div class="site-glow site-glow-a"></div>
+			<div class="site-glow site-glow-b"></div>
+			<div class="site-grid"></div>
+		</div>
+		<slot />
+	</body>
+</html>

--- a/src/lib/intake.ts
+++ b/src/lib/intake.ts
@@ -1,0 +1,1 @@
+export const SUPPORT_EMAIL = 'borja@cortexpersist.com';

--- a/src/pages/async-demo.astro
+++ b/src/pages/async-demo.astro
@@ -1,7 +1,8 @@
 ---
+import IntakeFormScript from '../components/IntakeFormScript.astro';
 import SiteLayout from '../layouts/SiteLayout.astro';
+import { SUPPORT_EMAIL } from '../lib/intake';
 
-const supportEmail = 'borja@cortexpersist.com';
 const subject = 'Request Async Demo for CORTEX Persist';
 const defaultFields = {
 	name: '',
@@ -11,6 +12,14 @@ const defaultFields = {
 	sensitive: 'Not sure yet',
 	timeline: 'Within 30 days',
 };
+const intakeLines = [
+	{ label: 'Name', field: 'name' },
+	{ label: 'Company', field: 'company' },
+	{ label: 'Workflow', field: 'workflow' },
+	{ label: 'Current stack', field: 'stack' },
+	{ label: 'Sensitive data', field: 'sensitive' },
+	{ label: 'Timeline', field: 'timeline' },
+];
 ---
 
 <SiteLayout
@@ -46,7 +55,7 @@ const defaultFields = {
 					<span class="surface-state">Simple</span>
 				</div>
 
-				<form class="intake-form" data-intake-form data-subject={subject} data-email={supportEmail} novalidate>
+				<form class="intake-form" data-intake-form data-subject={subject} data-email={SUPPORT_EMAIL} novalidate>
 					<div class="field-grid">
 						<label class="field">
 							<span>Name</span>
@@ -126,14 +135,14 @@ const defaultFields = {
 					</p>
 					<p class="microcopy">
 						No local mail client? Copy the payload and send it manually to
-						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+						<a class="inline-link" href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>.
 					</p>
 					<p class="intake-status" data-intake-status role="status" aria-live="polite" aria-atomic="true"></p>
 				</form>
 				<noscript>
 					<p class="microcopy">
 						JavaScript is off. Email your workflow and current stack directly to
-						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+						<a class="inline-link" href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>.
 					</p>
 				</noscript>
 			</section>
@@ -171,69 +180,5 @@ const defaultFields = {
 		</section>
 	</main>
 
-	<script is:inline>
-		const form = document.querySelector('[data-intake-form]');
-		if (form) {
-			const preview = document.querySelector('[data-intake-preview]');
-			const subjectNode = document.querySelector('[data-intake-subject]');
-			const statusNode = document.querySelector('[data-intake-status]');
-			const copyButton = document.querySelector('[data-copy-intake]');
-			const fields = Array.from(form.querySelectorAll('input, textarea, select'));
-			const supportEmail = form.dataset.email || '';
-			const subject = form.dataset.subject || 'CORTEX intake';
-
-			const buildBody = () => {
-				const data = Object.fromEntries(new FormData(form).entries());
-				return [
-					'CORTEX async demo request',
-					'',
-					`Name: ${data.name || '-'}`,
-					`Company: ${data.company || '-'}`,
-					`Workflow: ${data.workflow || '-'}`,
-					`Current stack: ${data.stack || '-'}`,
-					`Sensitive data: ${data.sensitive || '-'}`,
-					`Timeline: ${data.timeline || '-'}`,
-				].join('\n');
-			};
-
-			const refreshPreview = () => {
-				const body = buildBody();
-				if (preview) preview.textContent = body;
-				if (subjectNode) subjectNode.textContent = subject;
-				return body;
-			};
-
-			fields.forEach((field) => {
-				field.addEventListener('input', refreshPreview);
-				field.addEventListener('change', refreshPreview);
-			});
-
-			form.addEventListener('submit', (event) => {
-				event.preventDefault();
-				if (!form.reportValidity()) {
-					const firstInvalid = form.querySelector(':invalid');
-					if (firstInvalid instanceof HTMLElement) firstInvalid.focus();
-					if (statusNode) statusNode.textContent = 'Fill the required fields before opening the email draft.';
-					return;
-				}
-
-				const body = refreshPreview();
-				const href = `mailto:${supportEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-				if (statusNode) statusNode.textContent = 'Opening email draft...';
-				window.location.href = href;
-			});
-
-			copyButton?.addEventListener('click', async () => {
-				const body = refreshPreview();
-				try {
-					await navigator.clipboard.writeText(body);
-					if (statusNode) statusNode.textContent = 'Copied. Paste it into any email client if mailto is not available.';
-				} catch {
-					if (statusNode) statusNode.textContent = 'Copy failed. Select the preview text manually and paste it into your email.';
-				}
-			});
-
-			refreshPreview();
-		}
-	</script>
+	<IntakeFormScript requestTitle="CORTEX async demo request" lines={intakeLines} />
 </SiteLayout>

--- a/src/pages/async-demo.astro
+++ b/src/pages/async-demo.astro
@@ -27,13 +27,14 @@ const defaultFields = {
 				<h1>Send the workflow. Get the demo without a call.</h1>
 				<p>
 					Fill the brief, open a ready-made email draft, or copy the payload and send it
-					manually. We reply with an async demo and recommendation within 24 hours.
+					manually. We typically reply with an async demo and recommendation within one
+					business day.
 				</p>
 			</div>
 
 			<div class="chip-row" aria-label="Async demo principles">
 				<span class="chip">No call required</span>
-				<span class="chip">Reply within 24 hours</span>
+				<span class="chip">Typically within 1 business day</span>
 				<span class="chip">Built for technical buyers</span>
 			</div>
 		</section>
@@ -45,15 +46,27 @@ const defaultFields = {
 					<span class="surface-state">Simple</span>
 				</div>
 
-				<form class="intake-form" data-intake-form data-subject={subject} data-email={supportEmail}>
+				<form class="intake-form" data-intake-form data-subject={subject} data-email={supportEmail} novalidate>
 					<div class="field-grid">
 						<label class="field">
 							<span>Name</span>
-							<input name="name" type="text" value={defaultFields.name} placeholder="Your name" />
+							<input
+								name="name"
+								type="text"
+								value={defaultFields.name}
+								placeholder="Your name"
+								autocomplete="name"
+							/>
 						</label>
 						<label class="field">
 							<span>Company</span>
-							<input name="company" type="text" value={defaultFields.company} placeholder="Company or team" />
+							<input
+								name="company"
+								type="text"
+								value={defaultFields.company}
+								placeholder="Company or team"
+								autocomplete="organization"
+							/>
 						</label>
 					</div>
 
@@ -63,6 +76,8 @@ const defaultFields = {
 							name="workflow"
 							rows="4"
 							placeholder="What workflow would be painful to investigate if the agent failed tomorrow?"
+							required
+							aria-required="true"
 						>{defaultFields.workflow}</textarea>
 					</label>
 
@@ -72,6 +87,8 @@ const defaultFields = {
 							name="stack"
 							rows="4"
 							placeholder="Agent orchestration, memory, logs, APIs, repo, or anything relevant."
+							required
+							aria-required="true"
 						>{defaultFields.stack}</textarea>
 					</label>
 
@@ -102,11 +119,23 @@ const defaultFields = {
 					</div>
 
 					<p class="microcopy">
+						Required: workflow and current stack.
+					</p>
+					<p class="microcopy">
+						This page drafts an email. Nothing is submitted server-side from the browser.
+					</p>
+					<p class="microcopy">
 						No local mail client? Copy the payload and send it manually to
 						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
 					</p>
-					<p class="intake-status" data-intake-status aria-live="polite"></p>
+					<p class="intake-status" data-intake-status role="status" aria-live="polite" aria-atomic="true"></p>
 				</form>
+				<noscript>
+					<p class="microcopy">
+						JavaScript is off. Email your workflow and current stack directly to
+						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+					</p>
+				</noscript>
 			</section>
 
 			<aside class="surface-sunken intake-panel">
@@ -181,8 +210,16 @@ const defaultFields = {
 
 			form.addEventListener('submit', (event) => {
 				event.preventDefault();
+				if (!form.reportValidity()) {
+					const firstInvalid = form.querySelector(':invalid');
+					if (firstInvalid instanceof HTMLElement) firstInvalid.focus();
+					if (statusNode) statusNode.textContent = 'Fill the required fields before opening the email draft.';
+					return;
+				}
+
 				const body = refreshPreview();
 				const href = `mailto:${supportEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+				if (statusNode) statusNode.textContent = 'Opening email draft...';
 				window.location.href = href;
 			});
 

--- a/src/pages/async-demo.astro
+++ b/src/pages/async-demo.astro
@@ -1,0 +1,202 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+
+const supportEmail = 'borja@cortexpersist.com';
+const subject = 'Request Async Demo for CORTEX Persist';
+const defaultFields = {
+	name: '',
+	company: '',
+	workflow: '',
+	stack: '',
+	sensitive: 'Not sure yet',
+	timeline: 'Within 30 days',
+};
+---
+
+<SiteLayout
+	title="Request Async Demo | CORTEX Persist"
+	description="Request an async demo for CORTEX Persist and send your workflow details without a call."
+	canonical="https://cortexpersist.com/async-demo"
+>
+	<main class="landing-shell intake-shell">
+		<a class="intake-backlink" href="/">← Back to CORTEX Persist</a>
+
+		<section class="section-frame surface intake-hero">
+			<div class="section-heading">
+				<p class="section-kicker">Async Demo</p>
+				<h1>Send the workflow. Get the demo without a call.</h1>
+				<p>
+					Fill the brief, open a ready-made email draft, or copy the payload and send it
+					manually. We reply with an async demo and recommendation within 24 hours.
+				</p>
+			</div>
+
+			<div class="chip-row" aria-label="Async demo principles">
+				<span class="chip">No call required</span>
+				<span class="chip">Reply within 24 hours</span>
+				<span class="chip">Built for technical buyers</span>
+			</div>
+		</section>
+
+		<section class="intake-grid">
+			<section class="surface intake-panel">
+				<div class="surface-head">
+					<span class="surface-label">What to send</span>
+					<span class="surface-state">Simple</span>
+				</div>
+
+				<form class="intake-form" data-intake-form data-subject={subject} data-email={supportEmail}>
+					<div class="field-grid">
+						<label class="field">
+							<span>Name</span>
+							<input name="name" type="text" value={defaultFields.name} placeholder="Your name" />
+						</label>
+						<label class="field">
+							<span>Company</span>
+							<input name="company" type="text" value={defaultFields.company} placeholder="Company or team" />
+						</label>
+					</div>
+
+					<label class="field">
+						<span>Workflow</span>
+						<textarea
+							name="workflow"
+							rows="4"
+							placeholder="What workflow would be painful to investigate if the agent failed tomorrow?"
+						>{defaultFields.workflow}</textarea>
+					</label>
+
+					<label class="field">
+						<span>Current stack</span>
+						<textarea
+							name="stack"
+							rows="4"
+							placeholder="Agent orchestration, memory, logs, APIs, repo, or anything relevant."
+						>{defaultFields.stack}</textarea>
+					</label>
+
+					<div class="field-grid">
+						<label class="field">
+							<span>Sensitive data</span>
+							<select name="sensitive">
+								<option selected>{defaultFields.sensitive}</option>
+								<option>Yes</option>
+								<option>No</option>
+							</select>
+						</label>
+
+						<label class="field">
+							<span>Timeline</span>
+							<select name="timeline">
+								<option>ASAP</option>
+								<option selected>{defaultFields.timeline}</option>
+								<option>Within this quarter</option>
+								<option>Exploring only</option>
+							</select>
+						</label>
+					</div>
+
+					<div class="intake-actions">
+						<button class="button-primary" type="submit">Open Email Draft</button>
+						<button class="button-secondary" type="button" data-copy-intake>Copy Details</button>
+					</div>
+
+					<p class="microcopy">
+						No local mail client? Copy the payload and send it manually to
+						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+					</p>
+					<p class="intake-status" data-intake-status aria-live="polite"></p>
+				</form>
+			</section>
+
+			<aside class="surface-sunken intake-panel">
+				<div class="surface-head">
+					<span class="surface-label">Preview</span>
+					<span class="surface-state">Ready</span>
+				</div>
+
+				<div class="intake-preview">
+					<p class="preview-label">Email subject</p>
+					<p class="preview-subject" data-intake-subject>{subject}</p>
+					<p class="preview-label">Email body</p>
+					<pre class="preview-body" data-intake-preview></pre>
+				</div>
+
+				<div class="proof-stack">
+					<div class="proof-item">
+						<div>
+							<strong>Async by default</strong>
+							<span>Good fit when the buyer wants signal without scheduling overhead.</span>
+						</div>
+						<span class="proof-tag live">Async</span>
+					</div>
+					<div class="proof-item">
+						<div>
+							<strong>Low-friction intake</strong>
+							<span>Enough detail to qualify the workflow without a discovery call.</span>
+						</div>
+						<span class="proof-tag audit">Scope</span>
+					</div>
+				</div>
+			</aside>
+		</section>
+	</main>
+
+	<script is:inline>
+		const form = document.querySelector('[data-intake-form]');
+		if (form) {
+			const preview = document.querySelector('[data-intake-preview]');
+			const subjectNode = document.querySelector('[data-intake-subject]');
+			const statusNode = document.querySelector('[data-intake-status]');
+			const copyButton = document.querySelector('[data-copy-intake]');
+			const fields = Array.from(form.querySelectorAll('input, textarea, select'));
+			const supportEmail = form.dataset.email || '';
+			const subject = form.dataset.subject || 'CORTEX intake';
+
+			const buildBody = () => {
+				const data = Object.fromEntries(new FormData(form).entries());
+				return [
+					'CORTEX async demo request',
+					'',
+					`Name: ${data.name || '-'}`,
+					`Company: ${data.company || '-'}`,
+					`Workflow: ${data.workflow || '-'}`,
+					`Current stack: ${data.stack || '-'}`,
+					`Sensitive data: ${data.sensitive || '-'}`,
+					`Timeline: ${data.timeline || '-'}`,
+				].join('\n');
+			};
+
+			const refreshPreview = () => {
+				const body = buildBody();
+				if (preview) preview.textContent = body;
+				if (subjectNode) subjectNode.textContent = subject;
+				return body;
+			};
+
+			fields.forEach((field) => {
+				field.addEventListener('input', refreshPreview);
+				field.addEventListener('change', refreshPreview);
+			});
+
+			form.addEventListener('submit', (event) => {
+				event.preventDefault();
+				const body = refreshPreview();
+				const href = `mailto:${supportEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+				window.location.href = href;
+			});
+
+			copyButton?.addEventListener('click', async () => {
+				const body = refreshPreview();
+				try {
+					await navigator.clipboard.writeText(body);
+					if (statusNode) statusNode.textContent = 'Copied. Paste it into any email client if mailto is not available.';
+				} catch {
+					if (statusNode) statusNode.textContent = 'Copy failed. Select the preview text manually and paste it into your email.';
+				}
+			});
+
+			refreshPreview();
+		}
+	</script>
+</SiteLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,42 +26,42 @@ const heroProofs = [
 const signalCards = [
 	{
 		title: 'Verifiable decision lineage',
-		body: 'Show the exact context behind critical agent actions when a workflow is reviewed internally or challenged externally.',
+		body: 'Show what the agent knew when it acted.',
 	},
 	{
 		title: 'Audit-ready exports',
-		body: 'Generate portable evidence your team can inspect without turning incident review into screenshot theater.',
+		body: 'Produce evidence packs without turning review into screenshot theater.',
 	},
 	{
 		title: 'Drop-in architecture',
-		body: 'Add CORTEX on top of the stack you already use instead of forcing a memory platform migration.',
+		body: 'Layer CORTEX on top of the stack you already run.',
 	},
 ];
 
 const capabilityCards = [
 	{
 		label: 'Capture',
-		title: 'Facts, decisions, and state transitions',
-		body: 'CORTEX records the moments that matter in a form that is structured enough to review later.',
-		items: ['Decision events', 'Operational state changes', 'Context that should survive scrutiny'],
+		title: 'Capture the moments that matter',
+		body: 'Record facts, decisions, and state transitions in a form worth reviewing later.',
+		items: ['Decision events', 'Reviewable context'],
 	},
 	{
 		label: 'Seal',
-		title: 'Tamper-evident integrity checks',
-		body: 'The point is not storing more text. The point is protecting the decision record from silent drift and quiet edits.',
-		items: ['Hash-linked lineage', 'Integrity verification', 'Evidence-first review surface'],
+		title: 'Seal the record',
+		body: 'Protect the decision trail from silent edits and quiet drift.',
+		items: ['Hash-linked lineage', 'Integrity checks'],
 	},
 	{
 		label: 'Verify',
-		title: 'Inspect the record later',
-		body: 'When a workflow misfires, teams need to verify what happened, not just browse traces and hope the story holds.',
-		items: ['Reproducible checks', 'Clear record status', 'Faster incident reconstruction'],
+		title: 'Verify later',
+		body: 'When a workflow misfires, teams can validate the record instead of guessing from traces.',
+		items: ['Reproducible checks', 'Clear record status'],
 	},
 	{
 		label: 'Export',
-		title: 'Portable evidence for humans',
-		body: 'CORTEX turns a disputed workflow into something risk, security, or leadership can actually inspect.',
-		items: ['Audit-pack flow', 'Internal review artifacts', 'Customer-trust support material'],
+		title: 'Export proof',
+		body: 'Hand security, risk, or leadership something they can inspect quickly.',
+		items: ['Audit packs', 'Human-readable artifacts'],
 	},
 ];
 
@@ -69,22 +69,22 @@ const pilotSteps = [
 	{
 		index: '01',
 		title: 'Select one workflow',
-		body: 'Start with the workflow that would be most painful to investigate if the agent failed tomorrow.',
+		body: 'Pick the workflow that would hurt most to investigate tomorrow.',
 	},
 	{
 		index: '02',
 		title: 'Integrate on top of your stack',
-		body: 'We instrument the current memory, logging, or orchestration flow instead of forcing a full platform rewrite.',
+		body: 'Instrument the current memory, logging, or orchestration flow.',
 	},
 	{
 		index: '03',
 		title: 'Activate verification',
-		body: 'Your team gets a working verification flow for the decision record and a repeatable evidence path.',
+		body: 'Turn on a repeatable verification path for the decision record.',
 	},
 	{
 		index: '04',
 		title: 'Deliver the handoff',
-		body: 'You leave the pilot with an audit-pack example, runbook, and a clear recommendation for production rollout.',
+		body: 'Leave with an audit-pack example, runbook, and rollout recommendation.',
 	},
 ];
 
@@ -92,7 +92,7 @@ const pricingCards = [
 	{
 		name: 'Community',
 		price: 'Free',
-		body: 'Open source, local-first, and self-hostable for teams that want to start with the core trust layer.',
+		body: 'Open source and self-hostable for teams evaluating the trust layer.',
 		items: ['Single tenant', 'CLI and API', 'Immutable ledger', 'Install and run locally'],
 		cta: 'Install Open Source',
 		href: 'https://github.com/borjamoskv/Cortex-Persist#quickstart',
@@ -100,7 +100,7 @@ const pricingCards = [
 	{
 		name: 'Pilot',
 		price: 'From EUR 9,000',
-		body: 'A scoped 4-week engagement to instrument one critical workflow and deliver verifiable traceability.',
+		body: 'A scoped 4-week engagement for one critical workflow.',
 		items: ['One workflow', 'One environment', 'Verification flow', 'Audit-pack delivery'],
 		cta: 'Get Pilot Scope',
 		href: 'mailto:borja@cortexpersist.com?subject=CORTEX%20Pilot%20Scope&body=Workflow%3A%0AStack%3A%0ASensitive%20data%3A%0ASelf-hosted%20or%20BYOC%3A%0A',
@@ -109,7 +109,7 @@ const pricingCards = [
 	{
 		name: 'Enterprise',
 		price: 'From EUR 30,000/year',
-		body: 'For self-hosted or BYOC deployments that need support, onboarding, and procurement-friendly packaging.',
+		body: 'For self-hosted or BYOC deployments that need support and procurement packaging.',
 		items: ['Self-hosted or BYOC', 'Advanced controls', 'Support and onboarding', 'Custom integration scope'],
 		cta: 'Request Async Demo',
 		href: 'mailto:borja@cortexpersist.com?subject=Request%20Async%20Demo%20for%20CORTEX%20Persist',
@@ -123,7 +123,7 @@ const faqItems = [
 	},
 	{
 		question: 'Is this just observability?',
-		answer: 'No. Observability helps you inspect events. CORTEX adds integrity and traceability to the decision record itself.',
+		answer: 'No. Observability inspects events; CORTEX hardens the decision record itself.',
 	},
 	{
 		question: 'Do we need a call to get started?',
@@ -265,9 +265,8 @@ No call required.</code></pre>
 				<p class="section-kicker">Problem</p>
 				<h2>Logs help you inspect systems. CORTEX helps you verify the decision record.</h2>
 				<p>
-					If an agent touches code, support actions, pricing, finance, approvals, or
-					sensitive internal workflows, “we think this is what happened” is not enough.
-					Teams need a record they can verify later.
+					Critical workflows need a decision record teams can verify later, not a
+					best-effort reconstruction from traces.
 				</p>
 			</div>
 
@@ -292,9 +291,7 @@ No call required.</code></pre>
 				<p class="section-kicker">Pilot</p>
 				<h2>Start with one workflow, not a platform migration.</h2>
 				<p>
-					The fastest path to value is a scoped pilot. We integrate CORTEX into one
-					critical workflow, activate verifiable traceability, and leave your team with a
-					repeatable evidence flow.
+					A scoped pilot gets you to evidence faster than a platform migration.
 				</p>
 			</div>
 
@@ -348,7 +345,7 @@ Reply and get a scoped recommendation.</code></pre>
 			<div class="section-heading">
 				<p class="section-kicker">Pricing</p>
 				<h2>Open source to start. Scoped pilot to buy.</h2>
-				<p>We reply with a scoped recommendation within 24 hours when the workflow is clear.</p>
+				<p>Start free, then buy a pilot only when the workflow is clear.</p>
 			</div>
 
 			<div class="pricing-grid">
@@ -382,8 +379,7 @@ Reply and get a scoped recommendation.</code></pre>
 				<p class="section-kicker">FAQ</p>
 				<h2>Short answers for technical buyers.</h2>
 				<p>
-					CORTEX is easier to position correctly when the scope stays tight: integrity,
-					traceability, and evidence readiness for critical workflows.
+					Keep the scope tight: integrity, traceability, and evidence readiness.
 				</p>
 			</div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,96 +1,427 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Welcome from '../components/Welcome.astro';
+import SiteLayout from '../layouts/SiteLayout.astro';
 
-// CORTEX Unified Substrate — v0.3.2b1 Landing Page Shell
+const navLinks = [
+	{ href: '#problem', label: 'Problem' },
+	{ href: '#pilot', label: 'Pilot' },
+	{ href: '#pricing', label: 'Pricing' },
+	{ href: '#faq', label: 'FAQ' },
+];
+
+const heroProofs = [
+	{
+		value: 'Verifiable lineage',
+		label: 'Prove what the agent knew at decision time instead of reconstructing from vague logs.',
+	},
+	{
+		value: 'Tamper evidence',
+		label: 'Detect silent mutation or post-hoc edits before they become internal fiction.',
+	},
+	{
+		value: 'Async-first scope',
+		label: 'We can qualify the pilot, send the demo, and close the kickoff by email.',
+	},
+];
+
+const signalCards = [
+	{
+		title: 'Verifiable decision lineage',
+		body: 'Show the exact context behind critical agent actions when a workflow is reviewed internally or challenged externally.',
+	},
+	{
+		title: 'Audit-ready exports',
+		body: 'Generate portable evidence your team can inspect without turning incident review into screenshot theater.',
+	},
+	{
+		title: 'Drop-in architecture',
+		body: 'Add CORTEX on top of the stack you already use instead of forcing a memory platform migration.',
+	},
+];
+
+const capabilityCards = [
+	{
+		label: 'Capture',
+		title: 'Facts, decisions, and state transitions',
+		body: 'CORTEX records the moments that matter in a form that is structured enough to review later.',
+		items: ['Decision events', 'Operational state changes', 'Context that should survive scrutiny'],
+	},
+	{
+		label: 'Seal',
+		title: 'Tamper-evident integrity checks',
+		body: 'The point is not storing more text. The point is protecting the decision record from silent drift and quiet edits.',
+		items: ['Hash-linked lineage', 'Integrity verification', 'Evidence-first review surface'],
+	},
+	{
+		label: 'Verify',
+		title: 'Inspect the record later',
+		body: 'When a workflow misfires, teams need to verify what happened, not just browse traces and hope the story holds.',
+		items: ['Reproducible checks', 'Clear record status', 'Faster incident reconstruction'],
+	},
+	{
+		label: 'Export',
+		title: 'Portable evidence for humans',
+		body: 'CORTEX turns a disputed workflow into something risk, security, or leadership can actually inspect.',
+		items: ['Audit-pack flow', 'Internal review artifacts', 'Customer-trust support material'],
+	},
+];
+
+const pilotSteps = [
+	{
+		index: '01',
+		title: 'Select one workflow',
+		body: 'Start with the workflow that would be most painful to investigate if the agent failed tomorrow.',
+	},
+	{
+		index: '02',
+		title: 'Integrate on top of your stack',
+		body: 'We instrument the current memory, logging, or orchestration flow instead of forcing a full platform rewrite.',
+	},
+	{
+		index: '03',
+		title: 'Activate verification',
+		body: 'Your team gets a working verification flow for the decision record and a repeatable evidence path.',
+	},
+	{
+		index: '04',
+		title: 'Deliver the handoff',
+		body: 'You leave the pilot with an audit-pack example, runbook, and a clear recommendation for production rollout.',
+	},
+];
+
+const pricingCards = [
+	{
+		name: 'Community',
+		price: 'Free',
+		body: 'Open source, local-first, and self-hostable for teams that want to start with the core trust layer.',
+		items: ['Single tenant', 'CLI and API', 'Immutable ledger', 'Install and run locally'],
+		cta: 'Install Open Source',
+		href: 'https://github.com/borjamoskv/Cortex-Persist#quickstart',
+	},
+	{
+		name: 'Pilot',
+		price: 'From EUR 9,000',
+		body: 'A scoped 4-week engagement to instrument one critical workflow and deliver verifiable traceability.',
+		items: ['One workflow', 'One environment', 'Verification flow', 'Audit-pack delivery'],
+		cta: 'Get Pilot Scope',
+		href: 'mailto:borja@cortexpersist.com?subject=CORTEX%20Pilot%20Scope&body=Workflow%3A%0AStack%3A%0ASensitive%20data%3A%0ASelf-hosted%20or%20BYOC%3A%0A',
+		featured: true,
+	},
+	{
+		name: 'Enterprise',
+		price: 'From EUR 30,000/year',
+		body: 'For self-hosted or BYOC deployments that need support, onboarding, and procurement-friendly packaging.',
+		items: ['Self-hosted or BYOC', 'Advanced controls', 'Support and onboarding', 'Custom integration scope'],
+		cta: 'Request Async Demo',
+		href: 'mailto:borja@cortexpersist.com?subject=Request%20Async%20Demo%20for%20CORTEX%20Persist',
+	},
+];
+
+const faqItems = [
+	{
+		question: 'Do I need to replace my memory stack?',
+		answer: 'No. CORTEX is designed to sit on top of your current memory, logging, and orchestration stack.',
+	},
+	{
+		question: 'Is this just observability?',
+		answer: 'No. Observability helps you inspect events. CORTEX adds integrity and traceability to the decision record itself.',
+	},
+	{
+		question: 'Do we need a call to get started?',
+		answer: 'No. We can handle scoping, proposal, approval, and kickoff asynchronously by email.',
+	},
+	{
+		question: 'Does this make us automatically compliant?',
+		answer: 'No. CORTEX improves traceability, integrity, and evidence readiness. It does not replace legal or compliance review.',
+	},
+];
+
+const githubUrl = 'https://github.com/borjamoskv/Cortex-Persist';
+const docsUrl = 'https://github.com/borjamoskv/Cortex-Persist/tree/main/docs';
+const asyncDemoUrl =
+	'mailto:borja@cortexpersist.com?subject=Request%20Async%20Demo%20for%20CORTEX%20Persist';
+const pilotScopeUrl =
+	'mailto:borja@cortexpersist.com?subject=CORTEX%20Pilot%20Scope&body=Workflow%3A%0AStack%3A%0ASensitive%20data%3A%0ASelf-hosted%20or%20BYOC%3A%0A';
 ---
 
-<Layout title="CORTEX Persist — Tamper-Evident Agent Memory">
-	<main>
-		<div class="hero">
-			<h1>CORTEX_PERSIST</h1>
-			<p>Sovereign Agentic Context & Decision Lineage</p>
-			
-			<div class="actions">
-				<a href="/vsa" class="btn-sovereign">
-					ENTER_VSA_DASHBOARD
-					<span class="glitch-line"></span>
+<SiteLayout
+	title="CORTEX Persist | Trust Layer for AI Agents"
+	description="Tamper-evident memory and decision lineage for teams shipping AI in sensitive workflows."
+	canonical="https://cortexpersist.com/"
+>
+	<main class="landing-shell">
+		<header class="masthead">
+			<a class="brand" href="/" aria-label="CORTEX Persist home">
+				<span class="brand-mark">CP</span>
+				<span class="brand-copy">
+					<strong>CORTEX Persist</strong>
+					<span>Trust layer for AI agents</span>
+				</span>
+			</a>
+
+			<nav class="site-nav" aria-label="Primary">
+				{
+					navLinks.map((link) => (
+						<a class="nav-link" href={link.href}>
+							{link.label}
+						</a>
+					))
+				}
+			</nav>
+
+			<div class="masthead-actions">
+				<a class="button-tertiary" href={githubUrl} target="_blank" rel="noreferrer">
+					Install
+				</a>
+				<a class="button-primary" href={asyncDemoUrl}>
+					Async Demo
 				</a>
 			</div>
-		</div>
-		<Welcome />
+		</header>
+
+		<section class="hero-section surface">
+			<div class="hero-copy">
+				<p class="eyebrow">Async-first pilot / Industrial Noir 2026</p>
+				<h1>Trust layer for AI agents.</h1>
+				<p class="hero-text">
+					Prove what your agent knew, when it knew it, and what it did next. CORTEX adds
+					tamper-evident memory and decision lineage on top of your existing stack
+					without replacing your memory layer.
+				</p>
+				<p class="microcopy">Prefer async? We can scope the full pilot by email. No call required.</p>
+
+				<div class="action-row">
+					<a class="button-primary" href={asyncDemoUrl}>Request Async Demo</a>
+					<a class="button-secondary" href={githubUrl} target="_blank" rel="noreferrer">
+						Install Open Source
+					</a>
+				</div>
+
+				<div class="chip-row" aria-label="Core product properties">
+					<span class="chip">Tamper-evident memory</span>
+					<span class="chip">Audit-ready exports</span>
+					<span class="chip">Works on top of your stack</span>
+				</div>
+
+				<div class="hero-proofbar" aria-label="What the product enables">
+					{
+						heroProofs.map((proof) => (
+							<article class="hero-proof surface-sunken">
+								<strong>{proof.value}</strong>
+								<span>{proof.label}</span>
+							</article>
+						))
+					}
+				</div>
+			</div>
+
+			<aside class="hero-console surface-sunken" aria-label="Illustrative async pilot flow">
+				<div class="surface-head">
+					<span class="surface-label">Async pilot flow</span>
+					<span class="surface-state">24h scope</span>
+				</div>
+
+				<div class="console-metrics">
+					<div class="metric-tile">
+						<span class="metric-label">Motion</span>
+						<strong>Async</strong>
+					</div>
+					<div class="metric-tile">
+						<span class="metric-label">Pilot</span>
+						<strong>4 Weeks</strong>
+					</div>
+					<div class="metric-tile">
+						<span class="metric-label">Start</span>
+						<strong>1 Flow</strong>
+					</div>
+				</div>
+
+				<pre class="console-block"><code>1. Reply with your workflow
+2. Receive async demo
+3. Get scoped pilot in 24h
+4. Approve and kick off by email
+
+No call required.</code></pre>
+
+				<p class="console-note">
+					Start with one workflow that would be painful to investigate if the agent failed
+					tomorrow. The fastest path is a scoped pilot, not a platform migration.
+				</p>
+			</aside>
+		</section>
+
+		<section class="signal-grid">
+			{
+				signalCards.map((card) => (
+					<article class="signal-card surface">
+						<h2>{card.title}</h2>
+						<p class="surface-copy">{card.body}</p>
+					</article>
+				))
+			}
+		</section>
+
+		<section class="section-frame surface" id="problem">
+			<div class="section-heading">
+				<p class="section-kicker">Problem</p>
+				<h2>Logs help you inspect systems. CORTEX helps you verify the decision record.</h2>
+				<p>
+					If an agent touches code, support actions, pricing, finance, approvals, or
+					sensitive internal workflows, “we think this is what happened” is not enough.
+					Teams need a record they can verify later.
+				</p>
+			</div>
+
+			<div class="architecture-grid">
+				{
+					capabilityCards.map((card) => (
+						<article class="architecture-card surface-sunken">
+							<p class="surface-label">{card.label}</p>
+							<h3>{card.title}</h3>
+							<p>{card.body}</p>
+							<ul>
+								{card.items.map((item) => <li>{item}</li>)}
+							</ul>
+						</article>
+					))
+				}
+			</div>
+		</section>
+
+		<section class="section-frame surface" id="pilot">
+			<div class="section-heading">
+				<p class="section-kicker">Pilot</p>
+				<h2>Start with one workflow, not a platform migration.</h2>
+				<p>
+					The fastest path to value is a scoped pilot. We integrate CORTEX into one
+					critical workflow, activate verifiable traceability, and leave your team with a
+					repeatable evidence flow.
+				</p>
+			</div>
+
+			<div class="flow-layout">
+				<div class="flow-list">
+					{
+						pilotSteps.map((step) => (
+							<article class="flow-step surface-sunken">
+								<span class="step-index">{step.index}</span>
+								<h3>{step.title}</h3>
+								<p>{step.body}</p>
+							</article>
+						))
+					}
+				</div>
+
+				<aside class="flow-console surface-sunken">
+					<div class="surface-head">
+						<span class="surface-label">Pilot scope</span>
+						<span class="surface-state">Async</span>
+					</div>
+
+					<pre class="console-block"><code>Workflow: refund approval
+Stack: OpenAI + LangGraph + Postgres
+Sensitive data: yes
+Need self-hosted: likely
+
+Reply and get a scoped recommendation.</code></pre>
+
+					<div class="proof-stack">
+						<div class="proof-item">
+							<div>
+								<strong>One workflow</strong>
+								<span>Keep the pilot tight and commercially real.</span>
+							</div>
+							<span class="proof-tag live">Scope</span>
+						</div>
+						<div class="proof-item">
+							<div>
+								<strong>One environment</strong>
+								<span>Delivery stays focused and easy to validate.</span>
+							</div>
+							<span class="proof-tag audit">4 Weeks</span>
+						</div>
+					</div>
+				</aside>
+			</div>
+		</section>
+
+		<section class="section-frame surface" id="pricing">
+			<div class="section-heading">
+				<p class="section-kicker">Pricing</p>
+				<h2>Open source to start. Scoped pilot to buy.</h2>
+				<p>We reply with a scoped recommendation within 24 hours when the workflow is clear.</p>
+			</div>
+
+			<div class="pricing-grid">
+				{
+					pricingCards.map((card) => (
+						<article class:list={['pricing-card', 'surface-sunken', card.featured && 'pricing-card-featured']}>
+							<div class="pricing-head">
+								<h3>{card.name}</h3>
+								<p class="plan-price">{card.price}</p>
+							</div>
+							<p>{card.body}</p>
+							<ul class="surface-list">
+								{card.items.map((item) => <li>{item}</li>)}
+							</ul>
+							<a
+								class:list={[card.featured ? 'button-primary' : 'button-secondary', 'pricing-cta']}
+								href={card.href}
+								target={card.href.startsWith('http') ? '_blank' : undefined}
+								rel={card.href.startsWith('http') ? 'noreferrer' : undefined}
+							>
+								{card.cta}
+							</a>
+						</article>
+					))
+				}
+			</div>
+		</section>
+
+		<section class="section-frame surface" id="faq">
+			<div class="section-heading">
+				<p class="section-kicker">FAQ</p>
+				<h2>Short answers for technical buyers.</h2>
+				<p>
+					CORTEX is easier to position correctly when the scope stays tight: integrity,
+					traceability, and evidence readiness for critical workflows.
+				</p>
+			</div>
+
+			<div class="faq-grid">
+				{
+					faqItems.map((item) => (
+						<article class="faq-card surface-sunken">
+							<h3>{item.question}</h3>
+							<p>{item.answer}</p>
+						</article>
+					))
+				}
+			</div>
+		</section>
+
+		<section class="cta-banner surface">
+			<div>
+				<p class="section-kicker">Next Move</p>
+				<h2>If an agent made a bad decision tomorrow, could your team prove what it knew?</h2>
+				<p>
+					Request the async demo or send the workflow directly. We can handle the full
+					pilot scoping flow by email.
+				</p>
+			</div>
+
+			<div class="footer-actions">
+				<a class="button-primary" href={asyncDemoUrl}>Request Async Demo</a>
+				<a class="button-secondary" href={pilotScopeUrl}>Get Pilot Scope</a>
+			</div>
+		</section>
+
+		<footer class="site-footer">
+			<p class="footer-note">CORTEX Persist / The swarm verifies. The hardware remembers.</p>
+			<div class="footer-links">
+				<a href={githubUrl} target="_blank" rel="noreferrer">GitHub</a>
+				<a href={docsUrl} target="_blank" rel="noreferrer">Docs</a>
+				<a href="/vsa">Public Shell</a>
+			</div>
+		</footer>
 	</main>
-</Layout>
-
-<style>
-	main {
-		width: 100%;
-		height: 100vh;
-		display: flex;
-		flex-direction: column;
-		background: #000;
-		color: #fff;
-	}
-
-	.hero {
-		padding: 4rem;
-		flex: 1;
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		border-bottom: 1px solid #111;
-	}
-
-	h1 {
-		font-family: 'Orbitron', sans-serif;
-		font-size: 4rem;
-		letter-spacing: 0.5rem;
-		margin: 0;
-	}
-
-	p {
-		font-family: 'Inter', sans-serif;
-		color: #666;
-		margin-top: 1rem;
-		letter-spacing: 0.1rem;
-	}
-
-	.actions {
-		margin-top: 3rem;
-	}
-
-	.btn-sovereign {
-		position: relative;
-		display: inline-block;
-		padding: 1rem 2rem;
-		background: transparent;
-		border: 1px solid #2B3BE5;
-		color: #2B3BE5;
-		text-decoration: none;
-		font-family: 'Orbitron', sans-serif;
-		font-size: 0.8rem;
-		letter-spacing: 0.2rem;
-		transition: all 0.3s ease;
-		overflow: hidden;
-	}
-
-	.btn-sovereign:hover {
-		background: #2B3BE5;
-		color: #fff;
-		box-shadow: 0 0 20px rgba(43, 59, 229, 0.4);
-	}
-
-	.glitch-line {
-		position: absolute;
-		top: 0;
-		left: -100%;
-		width: 100%;
-		height: 1px;
-		background: rgba(255,255,255,0.5);
-		transition: all 0.5s ease;
-	}
-
-	.btn-sovereign:hover .glitch-line {
-		left: 100%;
-	}
-</style>
+</SiteLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 
 const navLinks = [
 	{ href: '#problem', label: 'Problem' },
+	{ href: '#fit', label: 'Fit' },
 	{ href: '#pilot', label: 'Pilot' },
 	{ href: '#pricing', label: 'Pricing' },
 	{ href: '#faq', label: 'FAQ' },
@@ -10,31 +11,55 @@ const navLinks = [
 
 const heroProofs = [
 	{
-		value: 'Verifiable lineage',
-		label: 'Prove what the agent knew at decision time instead of reconstructing from vague logs.',
+		value: 'Sensitive workflows',
+		label: 'Best fit for code actions, support approvals, pricing, finance, and other flows where mistakes are expensive.',
 	},
 	{
-		value: 'Tamper evidence',
-		label: 'Detect silent mutation or post-hoc edits before they become internal fiction.',
+		value: 'Verifiable record',
+		label: 'Show what the agent actually knew at decision time instead of reconstructing the story later.',
 	},
 	{
-		value: 'Async-first scope',
-		label: 'We can qualify the pilot, send the demo, and close the kickoff by email.',
+		value: '24h async scope',
+		label: 'Send one workflow and get a scoped pilot recommendation without a sales call.',
+	},
+];
+
+const heroCanvasCards = [
+	{
+		label: 'High-stakes flow',
+		title: 'Code and deploy actions',
+		body: 'When an agent can change systems, teams need more than logs and good intentions.',
+	},
+	{
+		label: 'High-stakes flow',
+		title: 'Support and approvals',
+		body: 'High-friction customer actions need a reviewable record, not a best-effort reconstruction.',
+	},
+	{
+		label: 'High-stakes flow',
+		title: 'Pricing, finance, and PII',
+		body: 'The more sensitive the workflow, the less acceptable silent mutation becomes.',
 	},
 ];
 
 const signalCards = [
 	{
-		title: 'Verifiable decision lineage',
-		body: 'Show what the agent knew when it acted.',
+		index: '01',
+		label: 'Context',
+		title: 'Prove the exact context',
+		body: 'Show what the agent knew when it acted, not what the team assumes it knew after the fact.',
 	},
 	{
-		title: 'Audit-ready exports',
-		body: 'Produce evidence packs without turning review into screenshot theater.',
+		index: '02',
+		label: 'Integrity',
+		title: 'Detect silent mutation',
+		body: 'Spot post-hoc edits or quiet drift before they become the official story of the incident.',
 	},
 	{
-		title: 'Drop-in architecture',
-		body: 'Layer CORTEX on top of the stack you already run.',
+		index: '03',
+		label: 'Review',
+		title: 'Export evidence for humans',
+		body: 'Give platform, security, or leadership an artifact they can inspect quickly and repeatably.',
 	},
 ];
 
@@ -42,27 +67,54 @@ const capabilityCards = [
 	{
 		label: 'Capture',
 		title: 'Capture the moments that matter',
-		body: 'Record facts, decisions, and state transitions in a form worth reviewing later.',
-		items: ['Decision events', 'Reviewable context'],
+		body: 'Record facts, decisions, and state transitions in a form that survives contact with real incident review.',
+		items: ['Decision events', 'Reviewable context', 'Workflow ownership'],
 	},
 	{
 		label: 'Seal',
 		title: 'Seal the record',
-		body: 'Protect the decision trail from silent edits and quiet drift.',
-		items: ['Hash-linked lineage', 'Integrity checks'],
+		body: 'Protect the decision trail from silent edits and quiet drift so later review starts from a defensible source.',
+		items: ['Hash-linked lineage', 'Integrity checks', 'Tamper evidence'],
 	},
 	{
 		label: 'Verify',
 		title: 'Verify later',
-		body: 'When a workflow misfires, teams can validate the record instead of guessing from traces.',
-		items: ['Reproducible checks', 'Clear record status'],
+		body: 'When a workflow misfires, teams can validate the record instead of guessing from traces, screenshots, and memory.',
+		items: ['Reproducible checks', 'Clear record status', 'Faster investigations'],
 	},
 	{
 		label: 'Export',
 		title: 'Export proof',
-		body: 'Hand security, risk, or leadership something they can inspect quickly.',
-		items: ['Audit packs', 'Human-readable artifacts'],
+		body: 'Hand security, risk, or leadership something they can inspect quickly without turning the review into theater.',
+		items: ['Audit packs', 'Human-readable artifacts', 'Internal review support'],
 	},
+];
+
+const fitCards = [
+	{
+		label: 'Production',
+		title: 'Teams already shipping agents',
+		body: 'Best fit when the agent already touches a real workflow and the cost of failure is operational, not theoretical.',
+		items: ['Code and deploy actions', 'Support or approval flows'],
+	},
+	{
+		label: 'Risk',
+		title: 'Sensitive or scrutinized surfaces',
+		body: 'Useful when workflows involve pricing, finance, PII, approvals, or anything a human may have to defend later.',
+		items: ['Internal trust reviews', 'Customer or audit scrutiny'],
+	},
+	{
+		label: 'Adoption',
+		title: 'Stacks that cannot migrate cleanly',
+		body: 'CORTEX works best when replacing the full memory stack would be expensive, slow, or politically painful.',
+		items: ['Drop in on top', 'Start with one flow'],
+	},
+];
+
+const whyNowPoints = [
+	'Agents are moving closer to irreversible actions.',
+	'Internal scrutiny gets sharper once automation touches money, code, or customer trust.',
+	'Traceability expectations are rising faster than most teams can rebuild their stack.',
 ];
 
 const pilotSteps = [
@@ -100,10 +152,11 @@ const pricingCards = [
 	{
 		name: 'Pilot',
 		price: 'From EUR 9,000',
+		tag: 'Recommended',
 		body: 'A scoped 4-week engagement for one critical workflow.',
 		items: ['One workflow', 'One environment', 'Verification flow', 'Audit-pack delivery'],
 		cta: 'Get Pilot Scope',
-		href: 'mailto:borja@cortexpersist.com?subject=CORTEX%20Pilot%20Scope&body=Workflow%3A%0AStack%3A%0ASensitive%20data%3A%0ASelf-hosted%20or%20BYOC%3A%0A',
+		href: '/pilot-scope',
 		featured: true,
 	},
 	{
@@ -112,7 +165,7 @@ const pricingCards = [
 		body: 'For self-hosted or BYOC deployments that need support and procurement packaging.',
 		items: ['Self-hosted or BYOC', 'Advanced controls', 'Support and onboarding', 'Custom integration scope'],
 		cta: 'Request Async Demo',
-		href: 'mailto:borja@cortexpersist.com?subject=Request%20Async%20Demo%20for%20CORTEX%20Persist',
+		href: '/async-demo',
 	},
 ];
 
@@ -127,7 +180,7 @@ const faqItems = [
 	},
 	{
 		question: 'Do we need a call to get started?',
-		answer: 'No. We can handle scoping, proposal, approval, and kickoff asynchronously by email.',
+		answer: 'No. We can scope the workflow, send the recommendation, and kick off the pilot asynchronously by email.',
 	},
 	{
 		question: 'Does this make us automatically compliant?',
@@ -137,15 +190,14 @@ const faqItems = [
 
 const githubUrl = 'https://github.com/borjamoskv/Cortex-Persist';
 const docsUrl = 'https://github.com/borjamoskv/Cortex-Persist/tree/main/docs';
-const asyncDemoUrl =
-	'mailto:borja@cortexpersist.com?subject=Request%20Async%20Demo%20for%20CORTEX%20Persist';
-const pilotScopeUrl =
-	'mailto:borja@cortexpersist.com?subject=CORTEX%20Pilot%20Scope&body=Workflow%3A%0AStack%3A%0ASensitive%20data%3A%0ASelf-hosted%20or%20BYOC%3A%0A';
+const asyncDemoUrl = '/async-demo';
+const pilotScopeUrl = '/pilot-scope';
+const scopePrompts = ['Workflow', 'Stack', 'Sensitive data', 'Hosting model'];
 ---
 
 <SiteLayout
-	title="CORTEX Persist | Trust Layer for AI Agents"
-	description="Tamper-evident memory and decision lineage for teams shipping AI in sensitive workflows."
+	title="CORTEX Persist | Verifiable Memory for AI Agents"
+	description="Tamper-evident memory and a verifiable decision record for teams shipping AI in sensitive workflows."
 	canonical="https://cortexpersist.com/"
 >
 	<main class="landing-shell">
@@ -154,7 +206,7 @@ const pilotScopeUrl =
 				<span class="brand-mark">CP</span>
 				<span class="brand-copy">
 					<strong>CORTEX Persist</strong>
-					<span>Trust layer for AI agents</span>
+					<span>Verifiable memory for AI agents</span>
 				</span>
 			</a>
 
@@ -170,7 +222,7 @@ const pilotScopeUrl =
 
 			<div class="masthead-actions">
 				<a class="button-tertiary" href={githubUrl} target="_blank" rel="noreferrer">
-					Install
+					Open Source
 				</a>
 				<a class="button-primary" href={asyncDemoUrl}>
 					Async Demo
@@ -180,14 +232,17 @@ const pilotScopeUrl =
 
 		<section class="hero-section surface">
 			<div class="hero-copy">
-				<p class="eyebrow">Async-first pilot / Industrial Noir 2026</p>
-				<h1>Trust layer for AI agents.</h1>
+				<p class="eyebrow">Sensitive workflows / Verifiable decision record</p>
+				<h1>Prove what your AI agent knew.</h1>
 				<p class="hero-text">
-					Prove what your agent knew, when it knew it, and what it did next. CORTEX adds
-					tamper-evident memory and decision lineage on top of your existing stack
-					without replacing your memory layer.
+					CORTEX adds tamper-evident memory and a verifiable decision record on top of
+					your current memory, logging, and orchestration stack, so teams can prove what
+					the agent knew when it acted.
 				</p>
-				<p class="microcopy">Prefer async? We can scope the full pilot by email. No call required.</p>
+				<p class="microcopy">
+					Prefer async? Send one workflow and your stack details. We reply with a scoped
+					recommendation in 24h. No call required.
+				</p>
 
 				<div class="action-row">
 					<a class="button-primary" href={asyncDemoUrl}>Request Async Demo</a>
@@ -198,8 +253,9 @@ const pilotScopeUrl =
 
 				<div class="chip-row" aria-label="Core product properties">
 					<span class="chip">Tamper-evident memory</span>
+					<span class="chip">No stack migration</span>
 					<span class="chip">Audit-ready exports</span>
-					<span class="chip">Works on top of your stack</span>
+					<span class="chip">Self-hosted or BYOC</span>
 				</div>
 
 				<div class="hero-proofbar" aria-label="What the product enables">
@@ -216,8 +272,8 @@ const pilotScopeUrl =
 
 			<aside class="hero-console surface-sunken" aria-label="Illustrative async pilot flow">
 				<div class="surface-head">
-					<span class="surface-label">Async pilot flow</span>
-					<span class="surface-state">24h scope</span>
+					<span class="surface-label">Async pilot intake</span>
+					<span class="surface-state">24h reply</span>
 				</div>
 
 				<div class="console-metrics">
@@ -230,21 +286,33 @@ const pilotScopeUrl =
 						<strong>4 Weeks</strong>
 					</div>
 					<div class="metric-tile">
-						<span class="metric-label">Start</span>
+						<span class="metric-label">Scope</span>
 						<strong>1 Flow</strong>
 					</div>
 				</div>
 
-				<pre class="console-block"><code>1. Reply with your workflow
-2. Receive async demo
-3. Get scoped pilot in 24h
+				<div class="canvas-cluster" aria-label="Stitch-inspired canvas notes">
+					{
+						heroCanvasCards.map((card) => (
+							<article class="canvas-card">
+								<span class="surface-label">{card.label}</span>
+								<strong>{card.title}</strong>
+								<p>{card.body}</p>
+							</article>
+						))
+					}
+				</div>
+
+				<pre class="console-block"><code>1. Send workflow + stack
+2. Receive async demo + scope
+3. Review pilot recommendation in 24h
 4. Approve and kick off by email
 
 No call required.</code></pre>
 
 				<p class="console-note">
-					Start with one workflow that would be painful to investigate if the agent failed
-					tomorrow. The fastest path is a scoped pilot, not a platform migration.
+					Start with the workflow that would be most painful to explain to security,
+					finance, or leadership if the agent misfired tomorrow.
 				</p>
 			</aside>
 		</section>
@@ -253,6 +321,10 @@ No call required.</code></pre>
 			{
 				signalCards.map((card) => (
 					<article class="signal-card surface">
+						<div class="card-meta">
+							<span class="card-index">{card.index}</span>
+							<span class="surface-label">{card.label}</span>
+						</div>
 						<h2>{card.title}</h2>
 						<p class="surface-copy">{card.body}</p>
 					</article>
@@ -266,7 +338,7 @@ No call required.</code></pre>
 				<h2>Logs help you inspect systems. CORTEX helps you verify the decision record.</h2>
 				<p>
 					Critical workflows need a decision record teams can verify later, not a
-					best-effort reconstruction from traces.
+					best-effort reconstruction from traces, screenshots, and operator memory.
 				</p>
 			</div>
 
@@ -286,12 +358,56 @@ No call required.</code></pre>
 			</div>
 		</section>
 
+		<section class="section-frame surface" id="fit">
+			<div class="section-heading">
+				<p class="section-kicker">Fit</p>
+				<h2>Built for teams where agent mistakes are expensive to explain.</h2>
+				<p>
+					CORTEX is not a generic “memory platform” pitch. It is a better fit for teams
+					that need stronger trust in what the agent knew when it acted.
+				</p>
+			</div>
+
+			<div class="fit-layout">
+				<div class="fit-grid">
+					{
+						fitCards.map((card) => (
+							<article class="fit-card surface-sunken">
+								<p class="surface-label">{card.label}</p>
+								<h3>{card.title}</h3>
+								<p>{card.body}</p>
+								<ul class="surface-list">
+									{card.items.map((item) => <li>{item}</li>)}
+								</ul>
+							</article>
+						))
+					}
+				</div>
+
+				<aside class="why-now surface-sunken">
+					<div class="surface-head">
+						<span class="surface-label">Why now</span>
+						<span class="surface-state">Rising</span>
+					</div>
+					<h3>More autonomy means less tolerance for vague explanations.</h3>
+					<ul class="surface-list">
+						{whyNowPoints.map((point) => <li>{point}</li>)}
+					</ul>
+					<p class="microcopy">
+						You do not need more memory volume. You need stronger evidence about the
+						memory your agent actually used.
+					</p>
+				</aside>
+			</div>
+		</section>
+
 		<section class="section-frame surface" id="pilot">
 			<div class="section-heading">
 				<p class="section-kicker">Pilot</p>
 				<h2>Start with one workflow, not a platform migration.</h2>
 				<p>
-					A scoped pilot gets you to evidence faster than a platform migration.
+					A scoped pilot gets you to evidence faster than a migration plan, committee
+					debate, or speculative platform rollout.
 				</p>
 			</div>
 
@@ -325,16 +441,23 @@ Reply and get a scoped recommendation.</code></pre>
 						<div class="proof-item">
 							<div>
 								<strong>One workflow</strong>
-								<span>Keep the pilot tight and commercially real.</span>
+								<span>Keep the pilot narrow enough to deliver real evidence, not a slide deck.</span>
 							</div>
 							<span class="proof-tag live">Scope</span>
 						</div>
 						<div class="proof-item">
 							<div>
 								<strong>One environment</strong>
-								<span>Delivery stays focused and easy to validate.</span>
+								<span>Delivery stays focused, reviewable, and easy to validate internally.</span>
 							</div>
 							<span class="proof-tag audit">4 Weeks</span>
+						</div>
+						<div class="proof-item">
+							<div>
+								<strong>24h async response</strong>
+								<span>Send the workflow, stack, and constraints. We send back a scoped recommendation.</span>
+							</div>
+							<span class="proof-tag live">Async</span>
 						</div>
 					</div>
 				</aside>
@@ -345,7 +468,7 @@ Reply and get a scoped recommendation.</code></pre>
 			<div class="section-heading">
 				<p class="section-kicker">Pricing</p>
 				<h2>Open source to start. Scoped pilot to buy.</h2>
-				<p>Start free, then buy a pilot only when the workflow is clear.</p>
+				<p>Start free. Buy a pilot only when the workflow, stakes, and owner are clear.</p>
 			</div>
 
 			<div class="pricing-grid">
@@ -353,8 +476,11 @@ Reply and get a scoped recommendation.</code></pre>
 					pricingCards.map((card) => (
 						<article class:list={['pricing-card', 'surface-sunken', card.featured && 'pricing-card-featured']}>
 							<div class="pricing-head">
-								<h3>{card.name}</h3>
-								<p class="plan-price">{card.price}</p>
+								<div class="pricing-head-copy">
+									<h3>{card.name}</h3>
+									<p class="plan-price">{card.price}</p>
+								</div>
+								{card.tag && <span class="plan-tag">{card.tag}</span>}
 							</div>
 							<p>{card.body}</p>
 							<ul class="surface-list">
@@ -398,16 +524,23 @@ Reply and get a scoped recommendation.</code></pre>
 		<section class="cta-banner surface">
 			<div>
 				<p class="section-kicker">Next Move</p>
-				<h2>If an agent made a bad decision tomorrow, could your team prove what it knew?</h2>
+				<h2>Send one workflow and get a scoped reply in 24h.</h2>
 				<p>
-					Request the async demo or send the workflow directly. We can handle the full
-					pilot scoping flow by email.
+					Send the workflow, stack, sensitive data, and hosting model. We can scope the
+					pilot asynchronously by email.
 				</p>
 			</div>
 
-			<div class="footer-actions">
-				<a class="button-primary" href={asyncDemoUrl}>Request Async Demo</a>
-				<a class="button-secondary" href={pilotScopeUrl}>Get Pilot Scope</a>
+			<div class="cta-actions">
+				<div class="cta-prompts" aria-label="Pilot scope fields">
+					{scopePrompts.map((prompt) => <span class="chip">{prompt}</span>)}
+				</div>
+				<p class="microcopy">Reply with those four fields and we can send back a scoped recommendation.</p>
+				<div class="footer-actions">
+					<a class="button-primary" href={asyncDemoUrl}>Request Async Demo</a>
+					<a class="button-secondary" href={pilotScopeUrl}>Get Pilot Scope</a>
+				</div>
+				<a class="cta-email" href="mailto:borja@cortexpersist.com">borja@cortexpersist.com</a>
 			</div>
 		</section>
 

--- a/src/pages/pilot-scope.astro
+++ b/src/pages/pilot-scope.astro
@@ -1,0 +1,236 @@
+---
+import SiteLayout from '../layouts/SiteLayout.astro';
+
+const supportEmail = 'borja@cortexpersist.com';
+const subject = 'CORTEX Pilot Scope';
+---
+
+<SiteLayout
+	title="Get Pilot Scope | CORTEX Persist"
+	description="Send your workflow, stack, and constraints to scope a CORTEX pilot asynchronously."
+	canonical="https://cortexpersist.com/pilot-scope"
+>
+	<main class="landing-shell intake-shell">
+		<a class="intake-backlink" href="/">← Back to CORTEX Persist</a>
+
+		<section class="section-frame surface intake-hero">
+			<div class="section-heading">
+				<p class="section-kicker">Pilot Scope</p>
+				<h1>Scope one workflow and get a concrete pilot recommendation.</h1>
+				<p>
+					Send the workflow, stack, risk level, and hosting constraints. We reply with a
+					scoped pilot recommendation, commercials, and next steps.
+				</p>
+			</div>
+
+			<div class="chip-row" aria-label="Pilot scope promises">
+				<span class="chip">One workflow</span>
+				<span class="chip">One environment</span>
+				<span class="chip">Reply within 24 hours</span>
+			</div>
+		</section>
+
+		<section class="intake-grid">
+			<section class="surface intake-panel">
+				<div class="surface-head">
+					<span class="surface-label">Scope inputs</span>
+					<span class="surface-state">Pilot</span>
+				</div>
+
+				<form class="intake-form" data-intake-form data-subject={subject} data-email={supportEmail}>
+					<label class="field">
+						<span>Workflow</span>
+						<textarea
+							name="workflow"
+							rows="4"
+							placeholder="Which workflow should the pilot instrument first?"
+						></textarea>
+					</label>
+
+					<label class="field">
+						<span>Current stack</span>
+						<textarea
+							name="stack"
+							rows="4"
+							placeholder="Agent orchestration, memory layer, observability, APIs, repos, or relevant systems."
+						></textarea>
+					</label>
+
+					<div class="field-grid">
+						<label class="field">
+							<span>Sensitive data</span>
+							<select name="sensitive">
+								<option>Yes</option>
+								<option>No</option>
+								<option selected>Not sure yet</option>
+							</select>
+						</label>
+
+						<label class="field">
+							<span>Hosting model</span>
+							<select name="hosting">
+								<option selected>Not sure yet</option>
+								<option>Cloud</option>
+								<option>Self-hosted</option>
+								<option>BYOC</option>
+							</select>
+						</label>
+					</div>
+
+					<div class="field-grid">
+						<label class="field">
+							<span>Target environment</span>
+							<select name="environment">
+								<option>Development</option>
+								<option>Staging</option>
+								<option>Production-like</option>
+								<option selected>Not sure yet</option>
+							</select>
+						</label>
+
+						<label class="field">
+							<span>Owner</span>
+							<select name="owner">
+								<option>Engineering</option>
+								<option>Platform</option>
+								<option>Security</option>
+								<option>Leadership</option>
+								<option selected>Not sure yet</option>
+							</select>
+						</label>
+					</div>
+
+					<label class="field">
+						<span>Success criteria</span>
+						<textarea
+							name="success"
+							rows="4"
+							placeholder="What would make the pilot clearly worth doing?"
+						></textarea>
+					</label>
+
+					<div class="field-grid">
+						<label class="field">
+							<span>Name</span>
+							<input name="name" type="text" placeholder="Your name" />
+						</label>
+						<label class="field">
+							<span>Email or company</span>
+							<input name="contact" type="text" placeholder="Email or company" />
+						</label>
+					</div>
+
+					<div class="intake-actions">
+						<button class="button-primary" type="submit">Open Scoped Email</button>
+						<button class="button-secondary" type="button" data-copy-intake>Copy Scope</button>
+					</div>
+
+					<p class="microcopy">
+						If you prefer, copy the scope and send it manually to
+						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+					</p>
+					<p class="intake-status" data-intake-status aria-live="polite"></p>
+				</form>
+			</section>
+
+			<aside class="surface-sunken intake-panel">
+				<div class="surface-head">
+					<span class="surface-label">What we send back</span>
+					<span class="surface-state">24h</span>
+				</div>
+
+				<div class="proof-stack">
+					<div class="proof-item">
+						<div>
+							<strong>Scoped recommendation</strong>
+							<span>What workflow to start with and why.</span>
+						</div>
+						<span class="proof-tag live">Scope</span>
+					</div>
+					<div class="proof-item">
+						<div>
+							<strong>Commercials</strong>
+							<span>Pilot pricing, constraints, and expected timeline.</span>
+						</div>
+						<span class="proof-tag audit">EUR</span>
+					</div>
+					<div class="proof-item">
+						<div>
+							<strong>Next step</strong>
+							<span>Approval, kickoff, or request for one missing detail.</span>
+						</div>
+						<span class="proof-tag live">Async</span>
+					</div>
+				</div>
+
+				<div class="intake-preview">
+					<p class="preview-label">Email subject</p>
+					<p class="preview-subject" data-intake-subject>{subject}</p>
+					<p class="preview-label">Email body</p>
+					<pre class="preview-body" data-intake-preview></pre>
+				</div>
+			</aside>
+		</section>
+	</main>
+
+	<script is:inline>
+		const form = document.querySelector('[data-intake-form]');
+		if (form) {
+			const preview = document.querySelector('[data-intake-preview]');
+			const subjectNode = document.querySelector('[data-intake-subject]');
+			const statusNode = document.querySelector('[data-intake-status]');
+			const copyButton = document.querySelector('[data-copy-intake]');
+			const fields = Array.from(form.querySelectorAll('input, textarea, select'));
+			const supportEmail = form.dataset.email || '';
+			const subject = form.dataset.subject || 'CORTEX intake';
+
+			const buildBody = () => {
+				const data = Object.fromEntries(new FormData(form).entries());
+				return [
+					'CORTEX pilot scope request',
+					'',
+					`Workflow: ${data.workflow || '-'}`,
+					`Current stack: ${data.stack || '-'}`,
+					`Sensitive data: ${data.sensitive || '-'}`,
+					`Hosting model: ${data.hosting || '-'}`,
+					`Target environment: ${data.environment || '-'}`,
+					`Owner: ${data.owner || '-'}`,
+					`Success criteria: ${data.success || '-'}`,
+					`Name: ${data.name || '-'}`,
+					`Contact: ${data.contact || '-'}`,
+				].join('\n');
+			};
+
+			const refreshPreview = () => {
+				const body = buildBody();
+				if (preview) preview.textContent = body;
+				if (subjectNode) subjectNode.textContent = subject;
+				return body;
+			};
+
+			fields.forEach((field) => {
+				field.addEventListener('input', refreshPreview);
+				field.addEventListener('change', refreshPreview);
+			});
+
+			form.addEventListener('submit', (event) => {
+				event.preventDefault();
+				const body = refreshPreview();
+				const href = `mailto:${supportEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+				window.location.href = href;
+			});
+
+			copyButton?.addEventListener('click', async () => {
+				const body = refreshPreview();
+				try {
+					await navigator.clipboard.writeText(body);
+					if (statusNode) statusNode.textContent = 'Copied. Paste it into any email client if mailto is not available.';
+				} catch {
+					if (statusNode) statusNode.textContent = 'Copy failed. Select the preview text manually and paste it into your email.';
+				}
+			});
+
+			refreshPreview();
+		}
+	</script>
+</SiteLayout>

--- a/src/pages/pilot-scope.astro
+++ b/src/pages/pilot-scope.astro
@@ -19,14 +19,14 @@ const subject = 'CORTEX Pilot Scope';
 				<h1>Scope one workflow and get a concrete pilot recommendation.</h1>
 				<p>
 					Send the workflow, stack, risk level, and hosting constraints. We reply with a
-					scoped pilot recommendation, commercials, and next steps.
+					scoped pilot recommendation, pricing, and next steps.
 				</p>
 			</div>
 
 			<div class="chip-row" aria-label="Pilot scope promises">
 				<span class="chip">One workflow</span>
 				<span class="chip">One environment</span>
-				<span class="chip">Reply within 24 hours</span>
+				<span class="chip">Typically within 1 business day</span>
 			</div>
 		</section>
 
@@ -37,13 +37,15 @@ const subject = 'CORTEX Pilot Scope';
 					<span class="surface-state">Pilot</span>
 				</div>
 
-				<form class="intake-form" data-intake-form data-subject={subject} data-email={supportEmail}>
+				<form class="intake-form" data-intake-form data-subject={subject} data-email={supportEmail} novalidate>
 					<label class="field">
 						<span>Workflow</span>
 						<textarea
 							name="workflow"
 							rows="4"
 							placeholder="Which workflow should the pilot instrument first?"
+							required
+							aria-required="true"
 						></textarea>
 					</label>
 
@@ -53,6 +55,8 @@ const subject = 'CORTEX Pilot Scope';
 							name="stack"
 							rows="4"
 							placeholder="Agent orchestration, memory layer, observability, APIs, repos, or relevant systems."
+							required
+							aria-required="true"
 						></textarea>
 					</label>
 
@@ -106,6 +110,8 @@ const subject = 'CORTEX Pilot Scope';
 							name="success"
 							rows="4"
 							placeholder="What would make the pilot clearly worth doing?"
+							required
+							aria-required="true"
 						></textarea>
 					</label>
 
@@ -121,16 +127,29 @@ const subject = 'CORTEX Pilot Scope';
 					</div>
 
 					<div class="intake-actions">
-						<button class="button-primary" type="submit">Open Scoped Email</button>
-						<button class="button-secondary" type="button" data-copy-intake>Copy Scope</button>
+						<button class="button-primary" type="submit">Open Email Draft</button>
+						<button class="button-secondary" type="button" data-copy-intake>Copy Scope Brief</button>
 					</div>
 
+					<p class="microcopy">
+						Required: workflow, current stack, and success criteria.
+					</p>
+					<p class="microcopy">
+						This page drafts an email. Nothing is submitted server-side from the browser.
+					</p>
 					<p class="microcopy">
 						If you prefer, copy the scope and send it manually to
 						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
 					</p>
-					<p class="intake-status" data-intake-status aria-live="polite"></p>
+					<p class="intake-status" data-intake-status role="status" aria-live="polite" aria-atomic="true"></p>
 				</form>
+				<noscript>
+					<p class="microcopy">
+						JavaScript is off. Email your workflow, current stack, and success criteria
+						directly to
+						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+					</p>
+				</noscript>
 			</section>
 
 			<aside class="surface-sunken intake-panel">
@@ -149,7 +168,7 @@ const subject = 'CORTEX Pilot Scope';
 					</div>
 					<div class="proof-item">
 						<div>
-							<strong>Commercials</strong>
+							<strong>Pilot estimate</strong>
 							<span>Pilot pricing, constraints, and expected timeline.</span>
 						</div>
 						<span class="proof-tag audit">EUR</span>
@@ -215,8 +234,16 @@ const subject = 'CORTEX Pilot Scope';
 
 			form.addEventListener('submit', (event) => {
 				event.preventDefault();
+				if (!form.reportValidity()) {
+					const firstInvalid = form.querySelector(':invalid');
+					if (firstInvalid instanceof HTMLElement) firstInvalid.focus();
+					if (statusNode) statusNode.textContent = 'Fill the required fields before opening the email draft.';
+					return;
+				}
+
 				const body = refreshPreview();
 				const href = `mailto:${supportEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+				if (statusNode) statusNode.textContent = 'Opening email draft...';
 				window.location.href = href;
 			});
 

--- a/src/pages/pilot-scope.astro
+++ b/src/pages/pilot-scope.astro
@@ -1,8 +1,20 @@
 ---
+import IntakeFormScript from '../components/IntakeFormScript.astro';
 import SiteLayout from '../layouts/SiteLayout.astro';
+import { SUPPORT_EMAIL } from '../lib/intake';
 
-const supportEmail = 'borja@cortexpersist.com';
 const subject = 'CORTEX Pilot Scope';
+const intakeLines = [
+	{ label: 'Workflow', field: 'workflow' },
+	{ label: 'Current stack', field: 'stack' },
+	{ label: 'Sensitive data', field: 'sensitive' },
+	{ label: 'Hosting model', field: 'hosting' },
+	{ label: 'Target environment', field: 'environment' },
+	{ label: 'Owner', field: 'owner' },
+	{ label: 'Success criteria', field: 'success' },
+	{ label: 'Name', field: 'name' },
+	{ label: 'Contact', field: 'contact' },
+];
 ---
 
 <SiteLayout
@@ -37,7 +49,7 @@ const subject = 'CORTEX Pilot Scope';
 					<span class="surface-state">Pilot</span>
 				</div>
 
-				<form class="intake-form" data-intake-form data-subject={subject} data-email={supportEmail} novalidate>
+				<form class="intake-form" data-intake-form data-subject={subject} data-email={SUPPORT_EMAIL} novalidate>
 					<label class="field">
 						<span>Workflow</span>
 						<textarea
@@ -139,7 +151,7 @@ const subject = 'CORTEX Pilot Scope';
 					</p>
 					<p class="microcopy">
 						If you prefer, copy the scope and send it manually to
-						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+						<a class="inline-link" href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>.
 					</p>
 					<p class="intake-status" data-intake-status role="status" aria-live="polite" aria-atomic="true"></p>
 				</form>
@@ -147,7 +159,7 @@ const subject = 'CORTEX Pilot Scope';
 					<p class="microcopy">
 						JavaScript is off. Email your workflow, current stack, and success criteria
 						directly to
-						<a class="inline-link" href={`mailto:${supportEmail}`}>{supportEmail}</a>.
+						<a class="inline-link" href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>.
 					</p>
 				</noscript>
 			</section>
@@ -192,72 +204,5 @@ const subject = 'CORTEX Pilot Scope';
 		</section>
 	</main>
 
-	<script is:inline>
-		const form = document.querySelector('[data-intake-form]');
-		if (form) {
-			const preview = document.querySelector('[data-intake-preview]');
-			const subjectNode = document.querySelector('[data-intake-subject]');
-			const statusNode = document.querySelector('[data-intake-status]');
-			const copyButton = document.querySelector('[data-copy-intake]');
-			const fields = Array.from(form.querySelectorAll('input, textarea, select'));
-			const supportEmail = form.dataset.email || '';
-			const subject = form.dataset.subject || 'CORTEX intake';
-
-			const buildBody = () => {
-				const data = Object.fromEntries(new FormData(form).entries());
-				return [
-					'CORTEX pilot scope request',
-					'',
-					`Workflow: ${data.workflow || '-'}`,
-					`Current stack: ${data.stack || '-'}`,
-					`Sensitive data: ${data.sensitive || '-'}`,
-					`Hosting model: ${data.hosting || '-'}`,
-					`Target environment: ${data.environment || '-'}`,
-					`Owner: ${data.owner || '-'}`,
-					`Success criteria: ${data.success || '-'}`,
-					`Name: ${data.name || '-'}`,
-					`Contact: ${data.contact || '-'}`,
-				].join('\n');
-			};
-
-			const refreshPreview = () => {
-				const body = buildBody();
-				if (preview) preview.textContent = body;
-				if (subjectNode) subjectNode.textContent = subject;
-				return body;
-			};
-
-			fields.forEach((field) => {
-				field.addEventListener('input', refreshPreview);
-				field.addEventListener('change', refreshPreview);
-			});
-
-			form.addEventListener('submit', (event) => {
-				event.preventDefault();
-				if (!form.reportValidity()) {
-					const firstInvalid = form.querySelector(':invalid');
-					if (firstInvalid instanceof HTMLElement) firstInvalid.focus();
-					if (statusNode) statusNode.textContent = 'Fill the required fields before opening the email draft.';
-					return;
-				}
-
-				const body = refreshPreview();
-				const href = `mailto:${supportEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-				if (statusNode) statusNode.textContent = 'Opening email draft...';
-				window.location.href = href;
-			});
-
-			copyButton?.addEventListener('click', async () => {
-				const body = refreshPreview();
-				try {
-					await navigator.clipboard.writeText(body);
-					if (statusNode) statusNode.textContent = 'Copied. Paste it into any email client if mailto is not available.';
-				} catch {
-					if (statusNode) statusNode.textContent = 'Copy failed. Select the preview text manually and paste it into your email.';
-				}
-			});
-
-			refreshPreview();
-		}
-	</script>
+	<IntakeFormScript requestTitle="CORTEX pilot scope request" lines={intakeLines} />
 </SiteLayout>

--- a/src/pages/vsa.astro
+++ b/src/pages/vsa.astro
@@ -1,308 +1,955 @@
 ---
-// CORTEX Sovereign Dashboard v3.2 — VSA Matrix Explorer
+import SiteLayout from '../layouts/SiteLayout.astro';
 ---
 
-<html lang="es">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<title>CORTEX — VSA Sovereign Explorer</title>
-		<link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Inter:wght@400;700&display=swap" rel="stylesheet">
-	</head>
-	<body>
+<SiteLayout
+	title="CORTEX Persist | VSA Sovereign Explorer"
+	description="Public VSA shell for CORTEX Persist. Deterministic demo by default, localhost live mode on demand."
+	canonical="https://cortexpersist.com/vsa"
+	bodyClass="vsa-body"
+>
+	<Fragment slot="head">
+		<script is:inline type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.183.2/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.183.2/examples/jsm/"
+				}
+			}
+		</script>
+	</Fragment>
+
+	<div id="vsa-stage">
 		<div id="vsa-canvas-container"></div>
-		
-		<div id="ui-overlay">
-			<div class="header">
-				<h1>SOVEREIGN_VSA_EXPLORER</h1>
-				<div class="status-badge">C5-REAL</div>
-			</div>
-			
-			<div class="metrics">
-				<div class="metric">
-					<label>EXERGY_YIELD</label>
-					<span id="yield-count">0.00</span>
+
+		<div id="vsa-overlay">
+			<header class="vsa-topbar surface">
+				<div class="vsa-brand">
+					<a class="brand" href="/" aria-label="Return to landing">
+						<span class="brand-mark">CP</span>
+						<span class="brand-copy">
+							<strong>CORTEX Persist</strong>
+							<span>Public shell / 400 dimensions</span>
+						</span>
+					</a>
 				</div>
-				<div class="metric">
-					<label>VSA_DIMENSIONS</label>
-					<span id="vsa-count">10,000</span>
+
+				<div class="vsa-heading">
+					<p class="eyebrow">Sovereign explorer</p>
+					<h1>VSA shell / live only when requested</h1>
 				</div>
-				<div class="metric">
-					<label>AGENT_CYCLES</label>
-					<span id="cycle-count">0</span>
+
+				<div class="vsa-actions">
+					<div class="status-badge" data-mode="standby" role="status">
+						STANDBY
+					</div>
+					<a class="button-tertiary compact" href="https://github.com/borjamoskv/Cortex-Persist" target="_blank" rel="noreferrer">
+						GitHub
+					</a>
 				</div>
-			</div>
-			
-			<div class="log-container">
-				<div id="log-monitor"></div>
-			</div>
+			</header>
+
+			<section class="vsa-grid">
+				<article class="surface vsa-lead">
+					<div class="surface-head">
+						<span class="surface-label">Telemetry shell</span>
+						<span class="surface-state" id="mode-source">Boot</span>
+					</div>
+
+					<div class="lead-copy">
+						<h2>Compact public shell. Serious signal.</h2>
+						<p>
+							Deterministic demo mode is the default public path. A localhost stream is
+							only attempted when you explicitly opt into <code>?live=1</code>.
+						</p>
+					</div>
+
+					<div class="vsa-metrics">
+						<div class="metric-card">
+							<span class="metric-label">Exergy Yield</span>
+							<strong id="yield-count">0.00</strong>
+						</div>
+						<div class="metric-card">
+							<span class="metric-label">Agent Cycles</span>
+							<strong id="cycle-count">0</strong>
+						</div>
+						<div class="metric-card">
+							<span class="metric-label">Active Nodes</span>
+							<strong id="active-count">000</strong>
+						</div>
+						<div class="metric-card">
+							<span class="metric-label">VSA Dimensions</span>
+							<strong id="vsa-count">400</strong>
+						</div>
+					</div>
+				</article>
+
+				<aside class="surface-sunken vsa-ops">
+					<div class="ops-block">
+						<span class="surface-label">Runtime phase</span>
+						<strong id="phase-value">Initializing shell</strong>
+						<p class="surface-copy">
+							The public route stays honest: demo by default, localhost live mode only
+							on local origin.
+						</p>
+					</div>
+
+					<div class="ops-pairs">
+						<div class="ops-pair">
+							<span>Drift Guard</span>
+							<strong id="drift-value">0.00</strong>
+						</div>
+						<div class="ops-pair">
+							<span>Activity</span>
+							<strong id="activity-value">0 / 400</strong>
+						</div>
+					</div>
+
+					<div class="meter-block">
+						<div class="meter-copy">
+							<span class="surface-label">Health Envelope</span>
+							<strong id="health-value">0%</strong>
+						</div>
+						<div class="meter-rail" aria-hidden="true">
+							<div id="health-fill"></div>
+						</div>
+					</div>
+				</aside>
+			</section>
+
+			<section class="vsa-footer">
+				<article class="surface-sunken log-panel">
+					<div class="surface-head">
+						<span class="surface-label">Log stream</span>
+						<span class="surface-copy">Newest state first</span>
+					</div>
+					<div id="log-monitor"></div>
+				</article>
+
+				<article class="surface hint-panel">
+					<p class="surface-label">Operator notes</p>
+					<ul class="hint-list">
+						<li>Pan is disabled. Rotate and zoom only.</li>
+						<li>Public mode runs synthetic telemetry with deterministic cadence.</li>
+						<li>Use <code>?live=1</code> on localhost to attach the daemon stream.</li>
+					</ul>
+				</article>
+			</section>
 		</div>
+	</div>
 
-		<script>
-			import * as THREE from 'three';
-			import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+	<script type="module" is:inline>
+		import * as THREE from 'three';
+		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 
-			const DIMENSIONS = 10000;
-			const SSE_URL = 'http://localhost:8000/stream';
-			
-			let scene, camera, renderer, particles, geometry, material;
-			let dataValues = new Float32Array(DIMENSIONS).fill(0);
-			let targetValues = new Float32Array(DIMENSIONS).fill(0);
+		const DIMENSIONS = 400;
+		const STAR_COUNT = 260;
+		const LOCAL_SSE_URL = 'http://127.0.0.1:8000/stream';
+		const MAX_LOG_ENTRIES = 12;
+		const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1']);
+		const LIVE_MODE = new URLSearchParams(window.location.search).get('live') === '1';
+		const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-			function init() {
-				scene = new THREE.Scene();
-				scene.background = new THREE.Color(0x000000);
+		const canvasContainer = document.getElementById('vsa-canvas-container');
+		const statusBadge = document.querySelector('.status-badge');
+		const yieldCount = document.getElementById('yield-count');
+		const cycleCount = document.getElementById('cycle-count');
+		const activeCount = document.getElementById('active-count');
+		const logMonitor = document.getElementById('log-monitor');
+		const modeSource = document.getElementById('mode-source');
+		const phaseValue = document.getElementById('phase-value');
+		const driftValue = document.getElementById('drift-value');
+		const activityValue = document.getElementById('activity-value');
+		const healthValue = document.getElementById('health-value');
+		const healthFill = document.getElementById('health-fill');
 
-				camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-				camera.position.z = 50;
+		let scene;
+		let camera;
+		let renderer;
+		let shellPoints;
+		let shellGeometry;
+		let shellMaterial;
+		let starField;
+		let starGeometry;
+		let starMaterial;
+		let coreMesh;
+		let coreGeometry;
+		let coreMaterial;
+		let haloMesh;
+		let haloGeometry;
+		let haloMaterial;
+		let controls;
+		let eventSource;
+		let simulationInterval;
 
-				renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-				renderer.setSize(window.innerWidth, window.innerHeight);
-				renderer.setPixelRatio(window.devicePixelRatio);
-				document.getElementById('vsa-canvas-container').appendChild(renderer.domElement);
+		const dataValues = new Float32Array(DIMENSIONS).fill(0);
+		const targetValues = new Float32Array(DIMENSIONS).fill(0);
+		const basePositions = new Float32Array(DIMENSIONS * 3);
 
-				// Create 10,000 Particles in a Sovereign Shell Formation
-				geometry = new THREE.BufferGeometry();
-				const positions = new Float32Array(DIMENSIONS * 3);
-				const colors = new Float32Array(DIMENSIONS * 3);
-				const sizes = new Float32Array(DIMENSIONS);
+		function clamp01(value) {
+			return Math.min(1, Math.max(0, value));
+		}
 
-				for (let i = 0; i < DIMENSIONS; i++) {
-					// Sphere formation
-					const phi = Math.acos(-1 + (2 * i) / DIMENSIONS);
-					const theta = Math.sqrt(DIMENSIONS * Math.PI) * phi;
-					
-					const r = 30 + (Math.random() * 2);
-					positions[i * 3] = r * Math.cos(theta) * Math.sin(phi);
-					positions[i * 3 + 1] = r * Math.sin(theta) * Math.sin(phi);
-					positions[i * 3 + 2] = r * Math.cos(phi);
+		function setStatus(mode, label, descriptor = {}) {
+			statusBadge.dataset.mode = mode;
+			statusBadge.textContent = label;
 
-					colors[i * 3] = 0.17; // #2B3BE5 R:43
-					colors[i * 3 + 1] = 0.23; // G:59
-					colors[i * 3 + 2] = 0.90; // B:229
-					
-					sizes[i] = 2.0;
+			if (descriptor.source) {
+				modeSource.textContent = descriptor.source;
+			}
+
+			if (descriptor.phase) {
+				phaseValue.textContent = descriptor.phase;
+			}
+		}
+
+		function appendLog(tag, value) {
+			const text = `[${tag}] ${value}`;
+			const firstEntry = logMonitor.firstElementChild?.textContent ?? '';
+
+			if (firstEntry === text) {
+				return;
+			}
+
+			const logEntry = document.createElement('div');
+			logEntry.className = 'log-entry';
+
+			const logTag = document.createElement('span');
+			logTag.className = 'log-tag';
+			logTag.textContent = `[${tag}] `;
+
+			logEntry.append(logTag, document.createTextNode(value));
+			logMonitor.prepend(logEntry);
+
+			while (logMonitor.childNodes.length > MAX_LOG_ENTRIES) {
+				logMonitor.removeChild(logMonitor.lastChild);
+			}
+		}
+
+		function updateDerivedMetrics(values) {
+			let active = 0;
+			let total = 0;
+			let peak = 0;
+
+			for (let i = 0; i < values.length; i += 1) {
+				const value = Number(values[i]) || 0;
+				total += value;
+				peak = Math.max(peak, value);
+
+				if (value > 0.18) {
+					active += 1;
+				}
+			}
+
+			const mean = values.length ? total / values.length : 0;
+			const drift = clamp01(0.05 + Math.abs(0.22 - mean) * 1.45 + (active / DIMENSIONS) * 0.32);
+			const health = clamp01(0.48 + mean * 0.42 + peak * 0.12 - drift * 0.4);
+			const healthPct = Math.round(health * 100);
+
+			activeCount.textContent = String(active).padStart(3, '0');
+			activityValue.textContent = `${active} / ${DIMENSIONS} nodes`;
+			driftValue.textContent = drift.toFixed(2);
+			healthValue.textContent = `${healthPct}%`;
+			healthFill.style.width = `${healthPct}%`;
+		}
+
+		function applyState(state) {
+			if (typeof state.global_yield === 'number') {
+				yieldCount.textContent = state.global_yield.toFixed(2);
+			}
+
+			if (typeof state.cycle_count === 'number') {
+				cycleCount.textContent = String(state.cycle_count);
+			}
+
+			if (Array.isArray(state.logs) && state.logs.length > 0) {
+				const lastLog = state.logs[state.logs.length - 1];
+				appendLog(lastLog.msg ?? 'LOG', String(lastLog.val ?? ''));
+			}
+
+			if (state.agent_states && typeof state.agent_states.length === 'number') {
+				targetValues.fill(0);
+
+				for (let i = 0; i < Math.min(DIMENSIONS, state.agent_states.length); i += 1) {
+					targetValues[i] = Number(state.agent_states[i]) || 0;
 				}
 
-				geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-				geometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
-				geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
+				updateDerivedMetrics(targetValues);
+			}
+		}
 
-				material = new THREE.PointsMaterial({
-					size: 1.2,
-					vertexColors: true,
-					transparent: true,
-					opacity: 0.8,
-					blending: THREE.AdditiveBlending,
-					sizeAttenuation: true
+		function startSimulation() {
+			if (simulationInterval) {
+				return;
+			}
+
+			let simulatedCycle = 0;
+			const phases = [
+				'Entropy shaping',
+				'Context compaction',
+				'Lineage sealing',
+				'Drift dampening',
+				'Recall rehearsal',
+			];
+			const messages = [
+				'Synthetic swarm pulse.',
+				'Checkpoint lattice sealed.',
+				'Recall window tuned.',
+				'Public shell holding steady.',
+				'Operational trace compacted.',
+			];
+
+			setStatus('demo', 'DEMO', {
+				source: 'Synthetic',
+				phase: phases[0],
+			});
+			appendLog('SIM', 'Public shell running synthetic telemetry.');
+
+			simulationInterval = window.setInterval(() => {
+				simulatedCycle += 1;
+
+				const cursorA = (simulatedCycle * 7) % DIMENSIONS;
+				const cursorB = (simulatedCycle * 13 + 57) % DIMENSIONS;
+				const states = new Float32Array(DIMENSIONS);
+
+				for (let i = 0; i < DIMENSIONS; i += 1) {
+					const distanceA = Math.abs(i - cursorA);
+					const distanceB = Math.abs(i - cursorB);
+					const wrappedA = Math.min(distanceA, DIMENSIONS - distanceA);
+					const wrappedB = Math.min(distanceB, DIMENSIONS - distanceB);
+					const waveA = Math.max(0, 1 - wrappedA / 22);
+					const waveB = Math.max(0, 1 - wrappedB / 34);
+					const harmonic = 0.5 + 0.5 * Math.sin(simulatedCycle * 0.28 + i * 0.09);
+					const micro = 0.5 + 0.5 * Math.sin(simulatedCycle * 0.51 + i * 0.21);
+
+					states[i] = clamp01(waveA * 0.56 + waveB * 0.3 + harmonic * 0.16 + micro * 0.05 - 0.19);
+				}
+
+				setStatus('demo', 'DEMO', {
+					source: 'Synthetic',
+					phase: phases[simulatedCycle % phases.length],
 				});
 
-				particles = new THREE.Points(geometry, material);
-				scene.add(particles);
+				applyState({
+					global_yield: 0.37 + (Math.sin(simulatedCycle / 3.6) + 1) * 0.16,
+					cycle_count: simulatedCycle,
+					logs: [
+						{
+							msg: `CYCLE_${String(simulatedCycle).padStart(3, '0')}`,
+							val: messages[simulatedCycle % messages.length],
+						},
+					],
+					agent_states: states,
+				});
+			}, 920);
+		}
 
-				const controls = new OrbitControls(camera, renderer.domElement);
-				controls.enableDamping = true;
-				controls.autoRotate = true;
-				controls.autoRotateSpeed = 0.5;
-
-				animate();
-				connectSSE();
+		function stopSimulation() {
+			if (!simulationInterval) {
+				return;
 			}
 
-			function connectSSE() {
-				const eventSource = new EventSource(SSE_URL);
-				eventSource.onmessage = (event) => {
-					const state = JSON.parse(event.data);
-					
-					// Update UI
-					document.getElementById('yield-count').innerText = state.global_yield.toFixed(2);
-					document.getElementById('cycle-count').innerText = state.cycle_count;
-					
-					const monitor = document.getElementById('log-monitor');
-					if (state.logs && state.logs.length > 0) {
-						const lastLog = state.logs[state.logs.length - 1];
-						const logEntry = document.createElement('div');
-						logEntry.className = 'log-entry';
-						logEntry.innerHTML = `<span class="log-tag">[${lastLog.msg}]</span> ${lastLog.val}`;
-						monitor.prepend(logEntry);
-						if (monitor.childNodes.length > 10) monitor.removeChild(monitor.lastChild);
-					}
+			window.clearInterval(simulationInterval);
+			simulationInterval = undefined;
+		}
 
-					// Map agent states to VSA Tensor (DIMENSIONS=10000)
-					if (state.agent_states) {
-						for(let i=0; i<DIMENSIONS; i++) {
-							targetValues[i] = state.agent_states[i] || 0;
-						}
-					}
-				};
+		function initScene() {
+			scene = new THREE.Scene();
+			scene.fog = new THREE.FogExp2(0x070910, 0.014);
+
+			camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+			camera.position.set(0, 0, 46);
+
+			renderer = new THREE.WebGLRenderer({
+				antialias: true,
+				alpha: true,
+				powerPreference: 'high-performance',
+			});
+			renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+			renderer.setSize(window.innerWidth, window.innerHeight);
+			canvasContainer.appendChild(renderer.domElement);
+
+			shellGeometry = new THREE.BufferGeometry();
+			const positions = new Float32Array(DIMENSIONS * 3);
+			const colors = new Float32Array(DIMENSIONS * 3);
+
+			for (let i = 0; i < DIMENSIONS; i += 1) {
+				const phi = Math.acos(-1 + (2 * i) / DIMENSIONS);
+				const theta = Math.sqrt(DIMENSIONS * Math.PI) * phi;
+				const radius = 20 + Math.sin(i * 0.12) * 0.8;
+				const x = radius * Math.cos(theta) * Math.sin(phi);
+				const y = radius * Math.sin(theta) * Math.sin(phi);
+				const z = radius * Math.cos(phi);
+
+				basePositions[i * 3] = x;
+				basePositions[i * 3 + 1] = y;
+				basePositions[i * 3 + 2] = z;
+				positions[i * 3] = x;
+				positions[i * 3 + 1] = y;
+				positions[i * 3 + 2] = z;
+
+				colors[i * 3] = 0.17;
+				colors[i * 3 + 1] = 0.23;
+				colors[i * 3 + 2] = 0.9;
 			}
 
-			function animate() {
-				requestAnimationFrame(animate);
-				
-				const sizes = geometry.attributes.size.array;
-				const colors = geometry.attributes.color.array;
+			shellGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+			shellGeometry.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+			shellGeometry.attributes.position.setUsage(THREE.DynamicDrawUsage);
+			shellGeometry.attributes.color.setUsage(THREE.DynamicDrawUsage);
 
-				for (let i = 0; i < DIMENSIONS; i++) {
-					// Smooth interpolation (Glial Decay Sim)
-					dataValues[i] += (targetValues[i] - dataValues[i]) * 0.1;
-					if (targetValues[i] > 0) targetValues[i] *= 0.95; // Local decay
-
-					const intensity = dataValues[i];
-					if (intensity > 0.1) {
-						colors[i * 3] = 0.0 + intensity; // Bluer to White
-						colors[i * 3 + 1] = 0.8 + intensity;
-						colors[i * 3 + 2] = 1.0;
-						sizes[i] = 2.0 + (intensity * 5);
-					} else {
-						colors[i * 3] = 0.17;
-						colors[i * 3 + 1] = 0.23;
-						colors[i * 3 + 2] = 0.90;
-						sizes[i] = 1.2;
-					}
-				}
-				geometry.attributes.size.needsUpdate = true;
-				geometry.attributes.color.needsUpdate = true;
-
-				renderer.render(scene, camera);
-			}
-
-			window.addEventListener('resize', () => {
-				camera.aspect = window.innerWidth / window.innerHeight;
-				camera.updateProjectionMatrix();
-				renderer.setSize(window.innerWidth, window.innerHeight);
+			shellMaterial = new THREE.PointsMaterial({
+				size: prefersReducedMotion ? 1.15 : 1.28,
+				vertexColors: true,
+				transparent: true,
+				opacity: 0.92,
+				blending: THREE.AdditiveBlending,
+				sizeAttenuation: true,
 			});
 
-			init();
-		</script>
+			shellPoints = new THREE.Points(shellGeometry, shellMaterial);
+			scene.add(shellPoints);
 
-		<style is:global>
-			:root {
-				--noir-bg: #000000;
-				--cortex-blue: #2B3BE5;
-				--industrial-white: #E0E0E0;
-				--glass-bg: rgba(0, 0, 0, 0.7);
+			starGeometry = new THREE.BufferGeometry();
+			const starPositions = new Float32Array(STAR_COUNT * 3);
+
+			for (let i = 0; i < STAR_COUNT; i += 1) {
+				const radius = 75 + (i % 9) * 6 + Math.sin(i * 1.3) * 4;
+				const theta = i * 0.34;
+				const phi = (i * 0.17) % Math.PI;
+				starPositions[i * 3] = radius * Math.cos(theta) * Math.sin(phi);
+				starPositions[i * 3 + 1] = radius * Math.sin(theta) * Math.sin(phi);
+				starPositions[i * 3 + 2] = radius * Math.cos(phi);
 			}
 
-			body, html {
-				margin: 0;
-				padding: 0;
-				width: 100%;
-				height: 100%;
-				background: var(--noir-bg);
-				color: var(--industrial-white);
-				font-family: 'Inter', sans-serif;
-				overflow: hidden;
+			starGeometry.setAttribute('position', new THREE.BufferAttribute(starPositions, 3));
+			starMaterial = new THREE.PointsMaterial({
+				color: 0x7f90ff,
+				size: 0.72,
+				transparent: true,
+				opacity: 0.28,
+				blending: THREE.AdditiveBlending,
+			});
+			starField = new THREE.Points(starGeometry, starMaterial);
+			scene.add(starField);
+
+			coreGeometry = new THREE.IcosahedronGeometry(6.8, 1);
+			coreMaterial = new THREE.MeshBasicMaterial({
+				color: 0x90a2ff,
+				wireframe: true,
+				transparent: true,
+				opacity: 0.12,
+			});
+			coreMesh = new THREE.Mesh(coreGeometry, coreMaterial);
+			scene.add(coreMesh);
+
+			haloGeometry = new THREE.TorusGeometry(17.4, 0.08, 12, 160);
+			haloMaterial = new THREE.MeshBasicMaterial({
+				color: 0x90a2ff,
+				wireframe: true,
+				transparent: true,
+				opacity: 0.1,
+			});
+			haloMesh = new THREE.Mesh(haloGeometry, haloMaterial);
+			haloMesh.rotation.x = Math.PI / 2.45;
+			scene.add(haloMesh);
+
+			controls = new OrbitControls(camera, renderer.domElement);
+			controls.enableDamping = true;
+			controls.enablePan = false;
+			controls.autoRotate = !prefersReducedMotion;
+			controls.autoRotateSpeed = 0.26;
+			controls.rotateSpeed = 0.42;
+			controls.minDistance = 32;
+			controls.maxDistance = 72;
+
+			appendLog('BOOT', 'Scene initialized.');
+			animate();
+		}
+
+		function connectSSE() {
+			const shouldConnect =
+				LIVE_MODE &&
+				LOCAL_HOSTS.has(window.location.hostname) &&
+				window.location.protocol !== 'https:' &&
+				typeof EventSource !== 'undefined';
+
+			if (!shouldConnect) {
+				startSimulation();
+				return;
 			}
 
-			#vsa-canvas-container {
-				position: fixed;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height: 100%;
-				z-index: 1;
+			setStatus('connecting', 'CONNECTING', {
+				source: 'Localhost',
+				phase: 'Awaiting daemon handshake',
+			});
+			appendLog('STREAM', 'Attempting localhost daemon handshake.');
+
+			eventSource = new EventSource(LOCAL_SSE_URL);
+
+			eventSource.onopen = () => {
+				stopSimulation();
+				setStatus('live', 'LIVE', {
+					source: 'Localhost',
+					phase: 'Daemon synchronized',
+				});
+				appendLog('STREAM', 'Connected to local daemon.');
+			};
+
+			eventSource.onmessage = (event) => {
+				try {
+					applyState(JSON.parse(event.data));
+				} catch {
+					appendLog('STREAM', 'Discarded malformed state payload.');
+				}
+			};
+
+			eventSource.onerror = () => {
+				if (eventSource) {
+					eventSource.close();
+					eventSource = undefined;
+				}
+
+				setStatus('demo', 'DEMO', {
+					source: 'Synthetic',
+					phase: 'Fallback telemetry engaged',
+				});
+				appendLog('STREAM', 'Daemon unavailable. Falling back to demo mode.');
+				startSimulation();
+			};
+		}
+
+		function animate() {
+			requestAnimationFrame(animate);
+
+			const time = performance.now() * 0.00035;
+			const positions = shellGeometry.attributes.position.array;
+			const colors = shellGeometry.attributes.color.array;
+
+			for (let i = 0; i < DIMENSIONS; i += 1) {
+				dataValues[i] += (targetValues[i] - dataValues[i]) * 0.085;
+
+				if (targetValues[i] > 0) {
+					targetValues[i] *= 0.972;
+				}
+
+				const intensity = dataValues[i];
+				const pulse = 1 + intensity * 0.045 + Math.sin(time * 3.6 + i * 0.08) * 0.008;
+
+				positions[i * 3] = basePositions[i * 3] * pulse;
+				positions[i * 3 + 1] = basePositions[i * 3 + 1] * pulse;
+				positions[i * 3 + 2] = basePositions[i * 3 + 2] * pulse;
+
+				colors[i * 3] = 0.12 + intensity * 0.7;
+				colors[i * 3 + 1] = 0.2 + intensity * 0.44;
+				colors[i * 3 + 2] = 0.58 + intensity * 0.4;
 			}
 
-			#ui-overlay {
-				position: relative;
-				z-index: 10;
-				padding: 2rem;
-				pointer-events: none;
-				height: 100%;
-				display: flex;
-				flex-direction: column;
-				justify-content: space-between;
+			shellGeometry.attributes.position.needsUpdate = true;
+			shellGeometry.attributes.color.needsUpdate = true;
+
+			shellMaterial.size = prefersReducedMotion ? 1.15 : 1.18 + Math.sin(time * 4.4) * 0.04;
+			shellPoints.rotation.y += prefersReducedMotion ? 0.00018 : 0.00046;
+			shellPoints.rotation.x = Math.sin(time * 0.7) * 0.05;
+
+			starField.rotation.y -= 0.0001;
+			coreMesh.rotation.x += 0.0007;
+			coreMesh.rotation.y += 0.0005;
+			haloMesh.rotation.z = time * 0.55;
+			haloMaterial.opacity = 0.08 + Math.sin(time * 2.5) * 0.025;
+
+			controls?.update();
+			renderer.render(scene, camera);
+		}
+
+		function handleResize() {
+			if (!camera || !renderer) {
+				return;
 			}
 
-			.header {
-				display: flex;
-				align-items: center;
-				gap: 1.5rem;
-				border-left: 2px solid var(--cortex-blue);
-				padding-left: 1rem;
+			camera.aspect = window.innerWidth / window.innerHeight;
+			camera.updateProjectionMatrix();
+			renderer.setSize(window.innerWidth, window.innerHeight);
+		}
+
+		function cleanup() {
+			if (eventSource) {
+				eventSource.close();
 			}
 
-			h1 {
-				font-family: 'Orbitron', sans-serif;
-				font-size: 1.2rem;
-				letter-spacing: 0.2rem;
-				margin: 0;
-				text-shadow: 0 0 10px var(--cortex-blue);
+			stopSimulation();
+			controls?.dispose();
+			shellGeometry?.dispose();
+			shellMaterial?.dispose();
+			starGeometry?.dispose();
+			starMaterial?.dispose();
+			coreGeometry?.dispose();
+			coreMaterial?.dispose();
+			haloGeometry?.dispose();
+			haloMaterial?.dispose();
+			renderer?.dispose();
+		}
+
+		setStatus('standby', 'STANDBY', {
+			source: 'Boot',
+			phase: 'Initializing public shell',
+		});
+		updateDerivedMetrics(targetValues);
+
+		try {
+			initScene();
+			connectSSE();
+			window.addEventListener('resize', handleResize);
+			window.addEventListener('beforeunload', cleanup);
+		} catch {
+			setStatus('error', 'ERROR', {
+				source: 'Boot',
+				phase: 'Three.js runtime failed',
+			});
+			appendLog('BOOT', 'Three.js runtime failed to load.');
+		}
+	</script>
+
+	<style is:global>
+		#vsa-stage {
+			height: 100vh;
+			position: relative;
+			width: 100%;
+			z-index: 1;
+		}
+
+		#vsa-canvas-container {
+			inset: 0;
+			position: fixed;
+			z-index: 0;
+		}
+
+		#vsa-overlay {
+			display: flex;
+			flex-direction: column;
+			gap: 1rem;
+			height: 100%;
+			padding: 1.1rem;
+			position: relative;
+			z-index: 2;
+		}
+
+		#vsa-overlay::before {
+			background:
+				radial-gradient(circle at center, rgba(43, 59, 229, 0.13), transparent 28rem),
+				linear-gradient(180deg, rgba(6, 8, 13, 0.28), rgba(6, 8, 13, 0.72));
+			content: '';
+			inset: 0;
+			position: absolute;
+			z-index: -1;
+		}
+
+		.vsa-topbar,
+		.vsa-grid,
+		.vsa-footer {
+			display: grid;
+			gap: 1rem;
+		}
+
+		.vsa-topbar {
+			align-items: center;
+			grid-template-areas: 'brand heading actions';
+			grid-template-columns: auto minmax(0, 1fr) auto;
+			padding: 1rem 1.15rem;
+		}
+
+		.vsa-brand {
+			grid-area: brand;
+		}
+
+		.vsa-heading {
+			grid-area: heading;
+		}
+
+		.vsa-heading h1,
+		.lead-copy h2 {
+			font-family: 'Orbitron', sans-serif;
+			letter-spacing: 0.06em;
+			margin: 0;
+			text-transform: uppercase;
+		}
+
+		.vsa-heading h1 {
+			font-size: clamp(1rem, 2.2vw, 1.45rem);
+		}
+
+		.vsa-actions {
+			align-items: center;
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.75rem;
+			grid-area: actions;
+			justify-content: flex-end;
+		}
+
+		.compact {
+			padding: 0.74rem 0.95rem;
+		}
+
+		.status-badge {
+			align-items: center;
+			background: rgba(255, 255, 255, 0.05);
+			border: 1px solid rgba(255, 255, 255, 0.1);
+			border-radius: 999px;
+			color: var(--accent-bright);
+			display: inline-flex;
+			font-family: 'IBM Plex Mono', monospace;
+			font-size: 0.74rem;
+			font-weight: 700;
+			letter-spacing: 0.14em;
+			padding: 0.78rem 0.92rem;
+			text-transform: uppercase;
+		}
+
+		.status-badge[data-mode='demo'] {
+			background: rgba(255, 197, 120, 0.14);
+			border-color: rgba(255, 197, 120, 0.2);
+			color: var(--warning);
+		}
+
+		.status-badge[data-mode='connecting'] {
+			background: rgba(140, 160, 255, 0.14);
+			border-color: rgba(140, 160, 255, 0.22);
+			color: var(--accent-bright);
+		}
+
+		.status-badge[data-mode='live'] {
+			background: rgba(138, 240, 196, 0.14);
+			border-color: rgba(138, 240, 196, 0.22);
+			color: var(--success);
+		}
+
+		.status-badge[data-mode='error'] {
+			background: rgba(255, 102, 122, 0.14);
+			border-color: rgba(255, 102, 122, 0.22);
+			color: #ff9ba8;
+		}
+
+		.vsa-grid {
+			align-items: stretch;
+			flex: 1;
+			grid-template-columns: minmax(0, 1.15fr) minmax(300px, 0.85fr);
+		}
+
+		.vsa-lead,
+		.vsa-ops,
+		.log-panel,
+		.hint-panel {
+			padding: 1.2rem;
+		}
+
+		.vsa-lead {
+			display: flex;
+			flex-direction: column;
+			justify-content: space-between;
+			min-height: 19rem;
+		}
+
+		.lead-copy {
+			display: grid;
+			gap: 0.8rem;
+			max-width: 34rem;
+		}
+
+		.lead-copy h2 {
+			font-size: clamp(1.45rem, 3vw, 2.65rem);
+		}
+
+		.lead-copy p,
+		.ops-block p {
+			color: var(--muted);
+			line-height: 1.7;
+			margin: 0;
+		}
+
+		.vsa-metrics {
+			display: grid;
+			gap: 0.9rem;
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+			margin-top: 1.4rem;
+		}
+
+		.metric-card {
+			background: rgba(255, 255, 255, 0.04);
+			border: 1px solid rgba(255, 255, 255, 0.07);
+			border-radius: 20px;
+			padding: 1rem;
+		}
+
+		.metric-card strong {
+			display: block;
+			font-family: 'Orbitron', sans-serif;
+			font-size: clamp(1.25rem, 3vw, 2rem);
+			margin-top: 0.45rem;
+		}
+
+		.vsa-ops {
+			display: grid;
+			gap: 1.15rem;
+		}
+
+		.ops-block {
+			display: grid;
+			gap: 0.6rem;
+		}
+
+		.ops-block strong,
+		.ops-pair strong,
+		.meter-copy strong {
+			font-size: 1.05rem;
+		}
+
+		.ops-pairs {
+			display: grid;
+			gap: 0.8rem;
+		}
+
+		.ops-pair,
+		.meter-copy {
+			align-items: center;
+			display: flex;
+			justify-content: space-between;
+			gap: 1rem;
+		}
+
+		.ops-pair span {
+			color: var(--muted);
+		}
+
+		.meter-block {
+			display: grid;
+			gap: 0.7rem;
+		}
+
+		.meter-rail {
+			background: rgba(255, 255, 255, 0.06);
+			border-radius: 999px;
+			height: 0.8rem;
+			overflow: hidden;
+		}
+
+		#health-fill {
+			background: linear-gradient(90deg, rgba(140, 160, 255, 0.5), rgba(138, 240, 196, 0.72));
+			border-radius: inherit;
+			height: 100%;
+			transition: width 240ms ease;
+			width: 0%;
+		}
+
+		.vsa-footer {
+			grid-template-columns: minmax(0, 1.1fr) minmax(260px, 0.9fr);
+		}
+
+		.log-panel {
+			min-height: 15rem;
+		}
+
+		#log-monitor {
+			color: var(--muted);
+			display: grid;
+			font-family: 'IBM Plex Mono', monospace;
+			font-size: 0.76rem;
+			gap: 0.55rem;
+			margin-top: 1rem;
+			max-height: 11.5rem;
+			overflow: hidden;
+		}
+
+		.log-entry {
+			background: rgba(255, 255, 255, 0.025);
+			border: 1px solid rgba(255, 255, 255, 0.04);
+			border-radius: 12px;
+			padding: 0.68rem 0.78rem;
+		}
+
+		.log-tag {
+			color: var(--accent-bright);
+		}
+
+		.hint-panel {
+			align-content: start;
+			display: grid;
+			gap: 0.9rem;
+		}
+
+		.hint-list {
+			color: var(--muted);
+			display: grid;
+			gap: 0.8rem;
+			line-height: 1.6;
+			margin: 0;
+			padding-left: 1.1rem;
+		}
+
+		.hint-panel code,
+		.lead-copy code {
+			background: rgba(255, 255, 255, 0.05);
+			border-radius: 8px;
+			font-family: 'IBM Plex Mono', monospace;
+			padding: 0.14rem 0.35rem;
+			white-space: nowrap;
+		}
+
+		@media (max-width: 980px) {
+			.vsa-grid,
+			.vsa-footer {
+				grid-template-columns: 1fr;
 			}
 
-			.status-badge {
-				background: var(--cortex-blue);
-				color: white;
-				font-size: 0.6rem;
-				padding: 0.2rem 0.5rem;
-				font-weight: bold;
-				letter-spacing: 0.1rem;
-				border-radius: 2px;
+			.vsa-topbar {
+				grid-template-areas:
+					'brand actions'
+					'heading heading';
+				grid-template-columns: minmax(0, 1fr) auto;
 			}
 
-			.metrics {
-				margin-top: 2rem;
-				display: flex;
-				flex-direction: column;
-				gap: 1rem;
-				pointer-events: auto;
+			.vsa-actions {
+				justify-content: flex-start;
+			}
+		}
+
+		@media (max-width: 720px) {
+			#vsa-overlay {
+				overflow-y: auto;
+				padding: 0.8rem;
 			}
 
-			.metric {
-				background: var(--glass-bg);
-				border: 1px solid rgba(43, 59, 229, 0.2);
+			.vsa-topbar,
+			.vsa-lead,
+			.vsa-ops,
+			.log-panel,
+			.hint-panel {
 				padding: 1rem;
-				width: 200px;
-				backdrop-filter: blur(10px);
 			}
 
-			.metric label {
-				display: block;
-				font-size: 0.6rem;
-				color: var(--cortex-blue);
-				margin-bottom: 0.3rem;
-				font-weight: bold;
+			.vsa-metrics {
+				grid-template-columns: repeat(2, minmax(0, 1fr));
 			}
 
-			.metric span {
-				font-family: 'Orbitron', sans-serif;
-				font-size: 1.4rem;
+			.vsa-actions {
+				display: grid;
+				grid-template-columns: repeat(2, minmax(0, 1fr));
+				width: 100%;
 			}
 
-			.log-container {
-				margin-top: auto;
-				width: 400px;
-				background: var(--glass-bg);
-				border-top: 1px solid var(--cortex-blue);
-				padding: 1rem;
-				backdrop-filter: blur(10px);
-				pointer-events: auto;
+			.status-badge,
+			.compact {
+				width: auto;
 			}
 
-			#log-monitor {
-				font-size: 0.7rem;
-				height: 150px;
-				overflow-y: hidden;
-				font-family: monospace;
-				color: #888;
+			.vsa-brand .brand-copy span {
+				display: none;
 			}
 
-			.log-entry {
-				margin-bottom: 0.5rem;
-				animation: fadeIn 0.3s ease-out;
+			.vsa-heading h1 {
+				font-size: 1.08rem;
+				line-height: 1.15;
 			}
-
-			.log-tag {
-				color: var(--cortex-blue);
-				font-weight: bold;
-			}
-
-			@keyframes fadeIn {
-				from { opacity: 0; transform: translateX(-10px); }
-				to { opacity: 1; transform: translateX(0); }
-			}
-		</style>
-	</body>
-</html>
+		}
+	</style>
+</SiteLayout>

--- a/src/pages/vsa.astro
+++ b/src/pages/vsa.astro
@@ -8,17 +8,6 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 	canonical="https://cortexpersist.com/vsa"
 	bodyClass="vsa-body"
 >
-	<Fragment slot="head">
-		<script is:inline type="importmap">
-			{
-				"imports": {
-					"three": "https://unpkg.com/three@0.183.2/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.183.2/examples/jsm/"
-				}
-			}
-		</script>
-	</Fragment>
-
 	<div id="vsa-stage">
 		<div id="vsa-canvas-container"></div>
 
@@ -138,9 +127,9 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 		</div>
 	</div>
 
-	<script type="module" is:inline>
+	<script>
 		import * as THREE from 'three';
-		import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+		import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 		const DIMENSIONS = 400;
 		const STAR_COUNT = 260;
@@ -185,6 +174,7 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 		const dataValues = new Float32Array(DIMENSIONS).fill(0);
 		const targetValues = new Float32Array(DIMENSIONS).fill(0);
 		const basePositions = new Float32Array(DIMENSIONS * 3);
+		const simulationStates = new Float32Array(DIMENSIONS);
 
 		function clamp01(value) {
 			return Math.min(1, Math.max(0, value));
@@ -310,7 +300,8 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 
 				const cursorA = (simulatedCycle * 7) % DIMENSIONS;
 				const cursorB = (simulatedCycle * 13 + 57) % DIMENSIONS;
-				const states = new Float32Array(DIMENSIONS);
+				const states = simulationStates;
+				states.fill(0);
 
 				for (let i = 0; i < DIMENSIONS; i += 1) {
 					const distanceA = Math.abs(i - cursorA);
@@ -949,6 +940,12 @@ import SiteLayout from '../layouts/SiteLayout.astro';
 			.vsa-heading h1 {
 				font-size: 1.08rem;
 				line-height: 1.15;
+			}
+		}
+
+		@media (prefers-reduced-motion: reduce) {
+			#health-fill {
+				transition: none;
 			}
 		}
 	</style>

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -70,6 +70,7 @@ img {
 }
 
 .site-glow-a {
+	animation: glow-drift-a 18s ease-in-out infinite alternate;
 	background: rgba(43, 59, 229, 0.18);
 	height: 28rem;
 	left: -8rem;
@@ -78,6 +79,7 @@ img {
 }
 
 .site-glow-b {
+	animation: glow-drift-b 20s ease-in-out infinite alternate;
 	background: rgba(129, 146, 255, 0.12);
 	height: 24rem;
 	right: -6rem;
@@ -282,6 +284,7 @@ img {
 }
 
 .hero-section {
+	animation: reveal-rise 520ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 	display: grid;
 	gap: 1rem;
 	grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
@@ -455,6 +458,12 @@ img {
 	padding: 1.35rem;
 }
 
+.signal-card,
+.section-frame,
+.cta-banner {
+	animation: reveal-rise 520ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+}
+
 .signal-card h2,
 .architecture-card h3,
 .path-card h3,
@@ -471,6 +480,7 @@ img {
 	gap: 1.2rem;
 	margin-top: 1rem;
 	padding: 1.5rem;
+	scroll-margin-top: 6.5rem;
 }
 
 .section-heading {
@@ -491,7 +501,7 @@ img {
 	align-content: start;
 	display: grid;
 	gap: 0.7rem;
-	min-height: 14rem;
+	min-height: 12.5rem;
 }
 
 .architecture-card ul {
@@ -600,7 +610,7 @@ img {
 
 .pricing-card {
 	align-content: start;
-	min-height: 23rem;
+	min-height: 20.5rem;
 }
 
 .pricing-card-featured {
@@ -666,6 +676,38 @@ img {
 
 .footer-links a {
 	color: var(--muted);
+}
+
+@keyframes reveal-rise {
+	from {
+		opacity: 0;
+		transform: translateY(14px);
+	}
+
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@keyframes glow-drift-a {
+	from {
+		transform: translate3d(0, 0, 0) scale(1);
+	}
+
+	to {
+		transform: translate3d(2.5rem, 1.2rem, 0) scale(1.06);
+	}
+}
+
+@keyframes glow-drift-b {
+	from {
+		transform: translate3d(0, 0, 0) scale(1);
+	}
+
+	to {
+		transform: translate3d(-2rem, 1.5rem, 0) scale(1.08);
+	}
 }
 
 body.vsa-body {
@@ -764,7 +806,14 @@ body.vsa-body {
 	.button-secondary,
 	.button-tertiary,
 	.nav-link,
-	.brand {
+	.brand,
+	.hero-section,
+	.signal-card,
+	.section-frame,
+	.cta-banner,
+	.site-glow-a,
+	.site-glow-b {
 		transition: none;
+		animation: none;
 	}
 }

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -673,7 +673,7 @@ img {
 	letter-spacing: 0.2em;
 }
 
-.flow-console .proof-stack {
+.proof-stack {
 	display: grid;
 	gap: 0.85rem;
 }

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1,19 +1,21 @@
 :root {
-	--bg-0: #06070b;
-	--bg-1: #0a0a0a;
-	--bg-2: #121523;
-	--panel: rgba(10, 13, 23, 0.78);
-	--panel-strong: rgba(7, 9, 18, 0.92);
+	--bg-0: #060914;
+	--bg-1: #0a1020;
+	--bg-2: #121b31;
+	--panel: rgba(10, 16, 33, 0.8);
+	--panel-strong: rgba(8, 12, 25, 0.93);
 	--panel-soft: rgba(255, 255, 255, 0.04);
-	--line: rgba(105, 126, 255, 0.22);
-	--line-strong: rgba(105, 126, 255, 0.48);
-	--text: #edf2ff;
-	--muted: #9ea7c5;
-	--accent: #2b3be5;
-	--accent-soft: #8ca0ff;
-	--accent-bright: #d6dcff;
-	--success: #8af0c4;
-	--warning: #ffc578;
+	--line: rgba(102, 128, 255, 0.24);
+	--line-strong: rgba(102, 128, 255, 0.5);
+	--text: #edf5ff;
+	--muted: #a6b3d2;
+	--accent: #3f63ff;
+	--accent-soft: #97acff;
+	--accent-bright: #e8f0ff;
+	--success: #7fe3b2;
+	--warning: #d8b56a;
+	--gold: #d8b56a;
+	--green: #7fe3b2;
 	--shadow: 0 28px 80px rgba(0, 0, 0, 0.42);
 	--radius-xl: 30px;
 	--radius-lg: 22px;
@@ -33,16 +35,17 @@ body.site-body {
 	margin: 0;
 	min-height: 100vh;
 	background:
-		radial-gradient(circle at top left, rgba(43, 59, 229, 0.18), transparent 24rem),
-		radial-gradient(circle at 85% 12%, rgba(111, 127, 255, 0.12), transparent 22rem),
-		linear-gradient(180deg, #090a10 0%, #06070b 56%, #090b12 100%);
+		radial-gradient(circle at top left, rgba(63, 99, 255, 0.2), transparent 24rem),
+		radial-gradient(circle at 85% 12%, rgba(216, 181, 106, 0.1), transparent 20rem),
+		radial-gradient(circle at 74% 80%, rgba(127, 227, 178, 0.09), transparent 24rem),
+		linear-gradient(180deg, #09101f 0%, #060914 56%, #0a1122 100%);
 	color: var(--text);
 	font-family: 'Manrope', sans-serif;
 	overflow-x: hidden;
 }
 
 body.site-body::selection {
-	background: rgba(140, 160, 255, 0.28);
+	background: rgba(127, 227, 178, 0.24);
 }
 
 a {
@@ -71,7 +74,7 @@ img {
 
 .site-glow-a {
 	animation: glow-drift-a 18s ease-in-out infinite alternate;
-	background: rgba(43, 59, 229, 0.18);
+	background: rgba(63, 99, 255, 0.2);
 	height: 28rem;
 	left: -8rem;
 	top: -7rem;
@@ -80,7 +83,7 @@ img {
 
 .site-glow-b {
 	animation: glow-drift-b 20s ease-in-out infinite alternate;
-	background: rgba(129, 146, 255, 0.12);
+	background: rgba(127, 227, 178, 0.12);
 	height: 24rem;
 	right: -6rem;
 	top: 18rem;
@@ -89,8 +92,8 @@ img {
 
 .site-grid {
 	background-image:
-		linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
-		linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+		linear-gradient(rgba(151, 172, 255, 0.035) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(151, 172, 255, 0.035) 1px, transparent 1px);
 	background-position: center;
 	background-size: 72px 72px;
 	inset: 0;
@@ -187,9 +190,10 @@ img {
 }
 
 .button-primary {
-	background: linear-gradient(135deg, #6a7cff, var(--accent));
+	background: linear-gradient(135deg, var(--accent), var(--green));
 	border: 1px solid rgba(255, 255, 255, 0.15);
-	color: #f8faff;
+	box-shadow: 0 14px 34px rgba(63, 99, 255, 0.18);
+	color: #06101f;
 }
 
 .button-secondary,
@@ -198,7 +202,7 @@ img {
 }
 
 .button-secondary {
-	background: rgba(255, 255, 255, 0.035);
+	background: rgba(216, 181, 106, 0.08);
 }
 
 .button-tertiary {
@@ -218,7 +222,7 @@ img {
 	align-items: center;
 	backdrop-filter: blur(16px);
 	background: rgba(7, 9, 17, 0.68);
-	border: 1px solid rgba(105, 126, 255, 0.16);
+	border: 1px solid rgba(102, 128, 255, 0.18);
 	border-radius: 999px;
 	display: grid;
 	gap: 1rem;
@@ -238,7 +242,7 @@ img {
 
 .brand-mark {
 	align-items: center;
-	background: linear-gradient(135deg, rgba(43, 59, 229, 0.28), rgba(120, 138, 255, 0.16));
+	background: linear-gradient(135deg, rgba(63, 99, 255, 0.3), rgba(127, 227, 178, 0.12));
 	border: 1px solid rgba(255, 255, 255, 0.1);
 	border-radius: 18px;
 	display: inline-flex;
@@ -319,6 +323,8 @@ img {
 .microcopy,
 .section-heading p,
 .architecture-card p,
+.fit-card p,
+.why-now p,
 .flow-step p,
 .path-card p,
 .pricing-card p,
@@ -345,7 +351,7 @@ img {
 
 .chip {
 	background: rgba(255, 255, 255, 0.05);
-	border: 1px solid rgba(255, 255, 255, 0.08);
+	border: 1px solid rgba(216, 181, 106, 0.14);
 	border-radius: 999px;
 	padding: 0.6rem 0.82rem;
 }
@@ -353,7 +359,22 @@ img {
 .hero-console {
 	display: grid;
 	gap: 1.25rem;
+	overflow: hidden;
 	padding: 1.4rem;
+}
+
+.hero-console::after {
+	background:
+		radial-gradient(circle at 20% 20%, rgba(140, 160, 255, 0.08), transparent 14rem),
+		linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+		linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+	background-size: auto, 2.9rem 2.9rem, 2.9rem 2.9rem;
+	content: '';
+	inset: 0;
+	mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.55), transparent 92%);
+	opacity: 0.55;
+	pointer-events: none;
+	position: absolute;
 }
 
 .hero-proofbar {
@@ -366,6 +387,14 @@ img {
 	display: grid;
 	gap: 0.5rem;
 	padding: 0.95rem 1rem;
+}
+
+.hero-proof:nth-child(2) {
+	transform: translateY(0.5rem);
+}
+
+.hero-proof:nth-child(3) {
+	transform: translateY(0.15rem);
 }
 
 .hero-proof strong {
@@ -389,7 +418,7 @@ img {
 }
 
 .surface-state {
-	border: 1px solid rgba(138, 240, 196, 0.2);
+	border: 1px solid rgba(127, 227, 178, 0.22);
 	border-radius: 999px;
 	color: var(--success);
 	font-family: 'IBM Plex Mono', monospace;
@@ -419,6 +448,46 @@ img {
 	margin-top: 0.45rem;
 }
 
+.canvas-cluster {
+	display: grid;
+	gap: 0.8rem;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	position: relative;
+	z-index: 1;
+}
+
+.canvas-card {
+	background: rgba(255, 255, 255, 0.045);
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 18px;
+	display: grid;
+	gap: 0.45rem;
+	padding: 0.9rem;
+}
+
+.canvas-card:nth-child(1) {
+	transform: rotate(-1.5deg);
+}
+
+.canvas-card:nth-child(2) {
+	transform: translateY(0.6rem) rotate(1.25deg);
+}
+
+.canvas-card:nth-child(3) {
+	transform: rotate(-0.75deg);
+}
+
+.canvas-card strong {
+	font-size: 0.92rem;
+}
+
+.canvas-card p {
+	color: var(--muted);
+	font-size: 0.82rem;
+	line-height: 1.55;
+	margin: 0;
+}
+
 .console-block {
 	background:
 		linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
@@ -438,7 +507,8 @@ img {
 .architecture-grid,
 .path-grid,
 .pricing-grid,
-.faq-grid {
+.faq-grid,
+.fit-grid {
 	display: grid;
 	gap: 1rem;
 }
@@ -453,7 +523,9 @@ img {
 .path-card,
 .pricing-card,
 .faq-card,
+.fit-card,
 .flow-console,
+.why-now,
 .cta-banner {
 	padding: 1.35rem;
 }
@@ -464,11 +536,46 @@ img {
 	animation: reveal-rise 520ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
 
+.signal-card {
+	overflow: hidden;
+}
+
+.signal-card::after {
+	background: linear-gradient(135deg, rgba(63, 99, 255, 0.14), rgba(127, 227, 178, 0.05) 40%, transparent 68%);
+	content: '';
+	inset: 0;
+	opacity: 0.75;
+	pointer-events: none;
+	position: absolute;
+}
+
+.card-meta {
+	align-items: center;
+	display: flex;
+	gap: 0.7rem;
+	margin-bottom: 0.9rem;
+}
+
+.card-index {
+	align-items: center;
+	border: 1px solid rgba(216, 181, 106, 0.18);
+	border-radius: 999px;
+	color: var(--gold);
+	display: inline-flex;
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.7rem;
+	letter-spacing: 0.14em;
+	padding: 0.34rem 0.52rem;
+	text-transform: uppercase;
+}
+
 .signal-card h2,
 .architecture-card h3,
 .path-card h3,
 .pricing-card h3,
 .faq-card h3,
+.fit-card h3,
+.why-now h3,
 .flow-step h3,
 .cta-banner h2 {
 	font-size: 1.04rem;
@@ -510,6 +617,36 @@ img {
 	gap: 0.4rem;
 	margin: 0;
 	padding-left: 1rem;
+}
+
+.fit-layout {
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
+}
+
+.fit-grid {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.fit-card,
+.why-now {
+	display: grid;
+	gap: 0.8rem;
+}
+
+.fit-card {
+	align-content: start;
+	min-height: 15.5rem;
+}
+
+.why-now {
+	align-content: start;
+	background:
+		radial-gradient(circle at top left, rgba(63, 99, 255, 0.08), transparent 15rem),
+		radial-gradient(circle at 88% 18%, rgba(216, 181, 106, 0.06), transparent 11rem),
+		linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0)),
+		var(--panel-strong);
 }
 
 .flow-layout {
@@ -572,14 +709,14 @@ img {
 }
 
 .proof-tag.live {
-	background: rgba(138, 240, 196, 0.12);
-	border: 1px solid rgba(138, 240, 196, 0.18);
+	background: rgba(127, 227, 178, 0.12);
+	border: 1px solid rgba(127, 227, 178, 0.2);
 	color: var(--success);
 }
 
 .proof-tag.audit {
-	background: rgba(255, 197, 120, 0.12);
-	border: 1px solid rgba(255, 197, 120, 0.18);
+	background: rgba(216, 181, 106, 0.14);
+	border: 1px solid rgba(216, 181, 106, 0.2);
 	color: var(--warning);
 }
 
@@ -614,13 +751,20 @@ img {
 }
 
 .pricing-card-featured {
-	border-color: rgba(140, 160, 255, 0.42);
+	border-color: rgba(127, 227, 178, 0.24);
 	box-shadow:
 		0 28px 80px rgba(0, 0, 0, 0.42),
-		0 0 0 1px rgba(140, 160, 255, 0.18);
+		0 0 0 1px rgba(216, 181, 106, 0.18);
 }
 
 .pricing-head {
+	align-items: flex-start;
+	display: flex;
+	gap: 0.8rem;
+	justify-content: space-between;
+}
+
+.pricing-head-copy {
 	display: grid;
 	gap: 0.45rem;
 }
@@ -632,6 +776,19 @@ img {
 	letter-spacing: 0.06em;
 	margin: 0;
 	text-transform: uppercase;
+}
+
+.plan-tag {
+	background: rgba(216, 181, 106, 0.14);
+	border: 1px solid rgba(216, 181, 106, 0.24);
+	border-radius: 999px;
+	color: var(--gold);
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.72rem;
+	letter-spacing: 0.14em;
+	padding: 0.42rem 0.66rem;
+	text-transform: uppercase;
+	white-space: nowrap;
 }
 
 .surface-list {
@@ -658,6 +815,26 @@ img {
 	margin-top: 1rem;
 }
 
+.cta-actions {
+	display: grid;
+	gap: 0.9rem;
+	justify-items: start;
+	max-width: 24rem;
+}
+
+.cta-prompts {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.65rem;
+}
+
+.cta-email {
+	color: var(--accent-bright);
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.82rem;
+	letter-spacing: 0.08em;
+}
+
 .site-footer {
 	align-items: center;
 	display: flex;
@@ -676,6 +853,128 @@ img {
 
 .footer-links a {
 	color: var(--muted);
+}
+
+.intake-shell {
+	display: grid;
+	gap: 1rem;
+}
+
+.intake-backlink,
+.inline-link {
+	color: var(--accent-bright);
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.82rem;
+	letter-spacing: 0.08em;
+}
+
+.intake-hero h1 {
+	font-family: 'Orbitron', sans-serif;
+	font-size: clamp(2rem, 4.4vw, 3.6rem);
+	letter-spacing: 0.05em;
+	line-height: 1;
+	margin: 0;
+	text-transform: uppercase;
+}
+
+.intake-grid {
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: minmax(0, 1.05fr) minmax(280px, 0.95fr);
+}
+
+.intake-panel {
+	display: grid;
+	gap: 1rem;
+}
+
+.intake-form {
+	display: grid;
+	gap: 1rem;
+}
+
+.field-grid {
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field {
+	display: grid;
+	gap: 0.55rem;
+}
+
+.field span,
+.preview-label {
+	color: var(--accent-soft);
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.72rem;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+}
+
+.field input,
+.field textarea,
+.field select {
+	background: rgba(255, 255, 255, 0.03);
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: var(--radius-md);
+	color: var(--text);
+	font: inherit;
+	padding: 0.95rem 1rem;
+	resize: vertical;
+}
+
+.field input::placeholder,
+.field textarea::placeholder {
+	color: rgba(158, 167, 197, 0.8);
+}
+
+.field input:focus,
+.field textarea:focus,
+.field select:focus {
+	border-color: rgba(140, 160, 255, 0.58);
+	box-shadow: 0 0 0 3px rgba(140, 160, 255, 0.12);
+	outline: none;
+}
+
+.intake-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.85rem;
+}
+
+.intake-status {
+	color: var(--accent-bright);
+	font-size: 0.9rem;
+	min-height: 1.2rem;
+}
+
+.intake-preview {
+	display: grid;
+	gap: 0.75rem;
+}
+
+.preview-subject {
+	color: var(--text);
+	font-weight: 700;
+	margin: 0;
+}
+
+.preview-body {
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
+		rgba(255, 255, 255, 0.02);
+	border: 1px solid rgba(255, 255, 255, 0.06);
+	border-radius: var(--radius-lg);
+	color: var(--accent-bright);
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.8rem;
+	line-height: 1.7;
+	margin: 0;
+	min-height: 16rem;
+	padding: 1rem 1.1rem;
+	white-space: pre-wrap;
 }
 
 @keyframes reveal-rise {
@@ -717,7 +1016,9 @@ body.vsa-body {
 @media (max-width: 1040px) {
 	.masthead,
 	.hero-section,
+	.fit-layout,
 	.flow-layout,
+	.intake-grid,
 	.cta-banner {
 		grid-template-columns: 1fr;
 	}
@@ -730,8 +1031,13 @@ body.vsa-body {
 	.path-grid,
 	.pricing-grid,
 	.faq-grid,
+	.fit-grid,
 	.hero-proofbar {
 		grid-template-columns: 1fr;
+	}
+
+	.pricing-head {
+		flex-direction: column;
 	}
 }
 
@@ -750,8 +1056,21 @@ body.vsa-body {
 	}
 
 	.console-metrics,
-	.architecture-grid {
+	.architecture-grid,
+	.canvas-cluster {
 		grid-template-columns: 1fr;
+	}
+
+	.field-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.hero-proof:nth-child(2),
+	.hero-proof:nth-child(3),
+	.canvas-card:nth-child(1),
+	.canvas-card:nth-child(2),
+	.canvas-card:nth-child(3) {
+		transform: none;
 	}
 
 	.hero-copy h1 {
@@ -787,7 +1106,13 @@ body.vsa-body {
 
 	.footer-actions,
 	.masthead-actions,
-	.action-row {
+	.action-row,
+	.intake-actions {
+		width: 100%;
+	}
+
+	.cta-actions {
+		max-width: none;
 		width: 100%;
 	}
 

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1,0 +1,770 @@
+:root {
+	--bg-0: #06070b;
+	--bg-1: #0a0a0a;
+	--bg-2: #121523;
+	--panel: rgba(10, 13, 23, 0.78);
+	--panel-strong: rgba(7, 9, 18, 0.92);
+	--panel-soft: rgba(255, 255, 255, 0.04);
+	--line: rgba(105, 126, 255, 0.22);
+	--line-strong: rgba(105, 126, 255, 0.48);
+	--text: #edf2ff;
+	--muted: #9ea7c5;
+	--accent: #2b3be5;
+	--accent-soft: #8ca0ff;
+	--accent-bright: #d6dcff;
+	--success: #8af0c4;
+	--warning: #ffc578;
+	--shadow: 0 28px 80px rgba(0, 0, 0, 0.42);
+	--radius-xl: 30px;
+	--radius-lg: 22px;
+	--radius-md: 16px;
+	--max-width: 1180px;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+html {
+	scroll-behavior: smooth;
+}
+
+body.site-body {
+	margin: 0;
+	min-height: 100vh;
+	background:
+		radial-gradient(circle at top left, rgba(43, 59, 229, 0.18), transparent 24rem),
+		radial-gradient(circle at 85% 12%, rgba(111, 127, 255, 0.12), transparent 22rem),
+		linear-gradient(180deg, #090a10 0%, #06070b 56%, #090b12 100%);
+	color: var(--text);
+	font-family: 'Manrope', sans-serif;
+	overflow-x: hidden;
+}
+
+body.site-body::selection {
+	background: rgba(140, 160, 255, 0.28);
+}
+
+a {
+	color: inherit;
+	text-decoration: none;
+}
+
+img {
+	max-width: 100%;
+	display: block;
+}
+
+.site-ambience {
+	inset: 0;
+	pointer-events: none;
+	position: fixed;
+	z-index: 0;
+}
+
+.site-glow {
+	border-radius: 999px;
+	filter: blur(80px);
+	opacity: 0.55;
+	position: absolute;
+}
+
+.site-glow-a {
+	background: rgba(43, 59, 229, 0.18);
+	height: 28rem;
+	left: -8rem;
+	top: -7rem;
+	width: 28rem;
+}
+
+.site-glow-b {
+	background: rgba(129, 146, 255, 0.12);
+	height: 24rem;
+	right: -6rem;
+	top: 18rem;
+	width: 24rem;
+}
+
+.site-grid {
+	background-image:
+		linear-gradient(rgba(255, 255, 255, 0.025) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(255, 255, 255, 0.025) 1px, transparent 1px);
+	background-position: center;
+	background-size: 72px 72px;
+	inset: 0;
+	mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.55), transparent 78%);
+	position: absolute;
+}
+
+.landing-shell {
+	margin: 0 auto;
+	max-width: calc(var(--max-width) + 3rem);
+	padding: 1.5rem;
+	position: relative;
+	z-index: 1;
+}
+
+.surface,
+.surface-sunken {
+	backdrop-filter: blur(18px);
+	border: 1px solid var(--line);
+	border-radius: var(--radius-xl);
+	box-shadow: var(--shadow);
+	position: relative;
+}
+
+.surface {
+	background:
+		linear-gradient(145deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.015)),
+		var(--panel);
+}
+
+.surface-sunken {
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
+		var(--panel-strong);
+}
+
+.surface::before,
+.surface-sunken::before {
+	background: linear-gradient(90deg, transparent, rgba(140, 160, 255, 0.28), transparent);
+	content: '';
+	height: 1px;
+	left: 1.4rem;
+	position: absolute;
+	right: 1.4rem;
+	top: 0;
+}
+
+.eyebrow,
+.section-kicker,
+.surface-label,
+.footer-note,
+.brand-label,
+.nav-link,
+.chip,
+.metric-label {
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.74rem;
+	letter-spacing: 0.16em;
+	text-transform: uppercase;
+}
+
+.eyebrow,
+.section-kicker,
+.surface-label,
+.brand-label,
+.metric-label {
+	color: var(--accent-soft);
+}
+
+.button-row,
+.action-row,
+.masthead-actions,
+.footer-actions {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.85rem;
+}
+
+.button-primary,
+.button-secondary,
+.button-tertiary {
+	align-items: center;
+	border-radius: 999px;
+	display: inline-flex;
+	font-weight: 700;
+	gap: 0.55rem;
+	justify-content: center;
+	padding: 0.92rem 1.3rem;
+	transition:
+		transform 180ms ease,
+		border-color 180ms ease,
+		background 180ms ease;
+}
+
+.button-primary {
+	background: linear-gradient(135deg, #6a7cff, var(--accent));
+	border: 1px solid rgba(255, 255, 255, 0.15);
+	color: #f8faff;
+}
+
+.button-secondary,
+.button-tertiary {
+	border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.button-secondary {
+	background: rgba(255, 255, 255, 0.035);
+}
+
+.button-tertiary {
+	background: rgba(255, 255, 255, 0.02);
+	color: var(--muted);
+}
+
+.button-primary:hover,
+.button-secondary:hover,
+.button-tertiary:hover,
+.nav-link:hover,
+.brand:hover {
+	transform: translateY(-1px);
+}
+
+.masthead {
+	align-items: center;
+	backdrop-filter: blur(16px);
+	background: rgba(7, 9, 17, 0.68);
+	border: 1px solid rgba(105, 126, 255, 0.16);
+	border-radius: 999px;
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: auto 1fr auto;
+	margin-bottom: 1.35rem;
+	padding: 0.85rem 1rem;
+	position: sticky;
+	top: 1rem;
+	z-index: 20;
+}
+
+.brand {
+	align-items: center;
+	display: inline-flex;
+	gap: 0.9rem;
+}
+
+.brand-mark {
+	align-items: center;
+	background: linear-gradient(135deg, rgba(43, 59, 229, 0.28), rgba(120, 138, 255, 0.16));
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: 18px;
+	display: inline-flex;
+	font-family: 'Orbitron', sans-serif;
+	font-size: 0.9rem;
+	height: 3rem;
+	justify-content: center;
+	letter-spacing: 0.22em;
+	width: 3rem;
+}
+
+.brand-copy {
+	display: grid;
+	gap: 0.18rem;
+}
+
+.brand-copy strong {
+	font-size: 0.98rem;
+	letter-spacing: 0.04em;
+}
+
+.brand-copy span {
+	color: var(--muted);
+	font-size: 0.88rem;
+}
+
+.site-nav {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.95rem;
+	justify-content: center;
+	overflow-x: auto;
+	scrollbar-width: none;
+}
+
+.site-nav::-webkit-scrollbar {
+	display: none;
+}
+
+.nav-link {
+	color: var(--muted);
+	padding: 0.3rem 0;
+}
+
+.hero-section {
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+	padding: clamp(1.6rem, 3vw, 2.2rem);
+}
+
+.hero-copy {
+	display: flex;
+	flex-direction: column;
+	gap: 1.2rem;
+	padding: 0.45rem;
+}
+
+.hero-copy h1,
+.section-heading h2,
+.cta-banner h2 {
+	font-family: 'Orbitron', sans-serif;
+	font-weight: 800;
+	letter-spacing: 0.05em;
+	line-height: 0.98;
+	margin: 0;
+	text-transform: uppercase;
+}
+
+.hero-copy h1 {
+	font-size: clamp(2.8rem, 6.4vw, 5.2rem);
+	max-width: 10.5ch;
+	text-wrap: balance;
+}
+
+.hero-text,
+.microcopy,
+.section-heading p,
+.architecture-card p,
+.flow-step p,
+.path-card p,
+.pricing-card p,
+.faq-card p,
+.cta-banner p,
+.footer-note,
+.console-note,
+.surface-copy {
+	color: var(--muted);
+	font-size: 1.02rem;
+	line-height: 1.7;
+	margin: 0;
+}
+
+.microcopy {
+	font-size: 0.92rem;
+}
+
+.chip-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+}
+
+.chip {
+	background: rgba(255, 255, 255, 0.05);
+	border: 1px solid rgba(255, 255, 255, 0.08);
+	border-radius: 999px;
+	padding: 0.6rem 0.82rem;
+}
+
+.hero-console {
+	display: grid;
+	gap: 1.25rem;
+	padding: 1.4rem;
+}
+
+.hero-proofbar {
+	display: grid;
+	gap: 0.85rem;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.hero-proof {
+	display: grid;
+	gap: 0.5rem;
+	padding: 0.95rem 1rem;
+}
+
+.hero-proof strong {
+	font-family: 'Orbitron', sans-serif;
+	font-size: 0.9rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+
+.hero-proof span {
+	color: var(--muted);
+	font-size: 0.86rem;
+	line-height: 1.55;
+}
+
+.surface-head {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+	gap: 0.8rem;
+}
+
+.surface-state {
+	border: 1px solid rgba(138, 240, 196, 0.2);
+	border-radius: 999px;
+	color: var(--success);
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.72rem;
+	letter-spacing: 0.14em;
+	padding: 0.42rem 0.66rem;
+	text-transform: uppercase;
+}
+
+.console-metrics {
+	display: grid;
+	gap: 0.8rem;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.metric-tile {
+	background: rgba(255, 255, 255, 0.03);
+	border: 1px solid rgba(255, 255, 255, 0.06);
+	border-radius: var(--radius-md);
+	padding: 0.9rem;
+}
+
+.metric-tile strong {
+	display: block;
+	font-family: 'Orbitron', sans-serif;
+	font-size: 1.4rem;
+	margin-top: 0.45rem;
+}
+
+.console-block {
+	background:
+		linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0)),
+		rgba(255, 255, 255, 0.02);
+	border: 1px solid rgba(255, 255, 255, 0.06);
+	border-radius: var(--radius-lg);
+	color: var(--accent-bright);
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.82rem;
+	line-height: 1.85;
+	margin: 0;
+	overflow-x: auto;
+	padding: 1rem 1.1rem;
+}
+
+.signal-grid,
+.architecture-grid,
+.path-grid,
+.pricing-grid,
+.faq-grid {
+	display: grid;
+	gap: 1rem;
+}
+
+.signal-grid {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	margin-top: 1rem;
+}
+
+.signal-card,
+.architecture-card,
+.path-card,
+.pricing-card,
+.faq-card,
+.flow-console,
+.cta-banner {
+	padding: 1.35rem;
+}
+
+.signal-card h2,
+.architecture-card h3,
+.path-card h3,
+.pricing-card h3,
+.faq-card h3,
+.flow-step h3,
+.cta-banner h2 {
+	font-size: 1.04rem;
+	margin: 0 0 0.6rem;
+}
+
+.section-frame {
+	display: grid;
+	gap: 1.2rem;
+	margin-top: 1rem;
+	padding: 1.5rem;
+}
+
+.section-heading {
+	display: grid;
+	gap: 0.8rem;
+	max-width: 44rem;
+}
+
+.section-heading h2 {
+	font-size: clamp(1.8rem, 4.2vw, 3.2rem);
+}
+
+.architecture-grid {
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.architecture-card {
+	align-content: start;
+	display: grid;
+	gap: 0.7rem;
+	min-height: 14rem;
+}
+
+.architecture-card ul {
+	color: var(--muted);
+	display: grid;
+	gap: 0.4rem;
+	margin: 0;
+	padding-left: 1rem;
+}
+
+.flow-layout {
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: minmax(0, 1.1fr) minmax(280px, 0.9fr);
+}
+
+.flow-list {
+	display: grid;
+	gap: 1rem;
+}
+
+.flow-step {
+	display: grid;
+	gap: 0.55rem;
+	padding: 1.2rem 1.25rem;
+}
+
+.step-index {
+	color: var(--accent-bright);
+	font-family: 'Orbitron', sans-serif;
+	font-size: 0.9rem;
+	letter-spacing: 0.2em;
+}
+
+.flow-console .proof-stack {
+	display: grid;
+	gap: 0.85rem;
+}
+
+.proof-item {
+	align-items: center;
+	display: flex;
+	justify-content: space-between;
+	gap: 0.8rem;
+	padding: 0.78rem 0;
+}
+
+.proof-item + .proof-item {
+	border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.proof-item strong {
+	font-size: 0.95rem;
+}
+
+.proof-item span {
+	color: var(--muted);
+	font-size: 0.88rem;
+}
+
+.proof-tag {
+	border-radius: 999px;
+	font-family: 'IBM Plex Mono', monospace;
+	font-size: 0.72rem;
+	letter-spacing: 0.14em;
+	padding: 0.44rem 0.66rem;
+	text-transform: uppercase;
+}
+
+.proof-tag.live {
+	background: rgba(138, 240, 196, 0.12);
+	border: 1px solid rgba(138, 240, 196, 0.18);
+	color: var(--success);
+}
+
+.proof-tag.audit {
+	background: rgba(255, 197, 120, 0.12);
+	border: 1px solid rgba(255, 197, 120, 0.18);
+	color: var(--warning);
+}
+
+.path-grid {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.path-card {
+	display: grid;
+	gap: 0.75rem;
+	min-height: 16rem;
+}
+
+.path-card a {
+	color: var(--accent-bright);
+	font-weight: 700;
+}
+
+.pricing-grid {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.pricing-card,
+.faq-card {
+	display: grid;
+	gap: 0.9rem;
+}
+
+.pricing-card {
+	align-content: start;
+	min-height: 23rem;
+}
+
+.pricing-card-featured {
+	border-color: rgba(140, 160, 255, 0.42);
+	box-shadow:
+		0 28px 80px rgba(0, 0, 0, 0.42),
+		0 0 0 1px rgba(140, 160, 255, 0.18);
+}
+
+.pricing-head {
+	display: grid;
+	gap: 0.45rem;
+}
+
+.plan-price {
+	color: var(--accent-bright);
+	font-family: 'Orbitron', sans-serif;
+	font-size: 1.3rem;
+	letter-spacing: 0.06em;
+	margin: 0;
+	text-transform: uppercase;
+}
+
+.surface-list {
+	color: var(--muted);
+	display: grid;
+	gap: 0.45rem;
+	margin: 0;
+	padding-left: 1rem;
+}
+
+.pricing-cta {
+	margin-top: auto;
+}
+
+.faq-grid {
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.cta-banner {
+	align-items: center;
+	display: grid;
+	gap: 1rem;
+	grid-template-columns: minmax(0, 1fr) auto;
+	margin-top: 1rem;
+}
+
+.site-footer {
+	align-items: center;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 1rem;
+	justify-content: space-between;
+	margin: 1rem 0 0;
+	padding: 1rem 0 1.5rem;
+}
+
+.footer-links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.9rem;
+}
+
+.footer-links a {
+	color: var(--muted);
+}
+
+body.vsa-body {
+	overflow: hidden;
+}
+
+@media (max-width: 1040px) {
+	.masthead,
+	.hero-section,
+	.flow-layout,
+	.cta-banner {
+		grid-template-columns: 1fr;
+	}
+
+	.site-nav {
+		justify-content: flex-start;
+	}
+
+	.signal-grid,
+	.path-grid,
+	.pricing-grid,
+	.faq-grid,
+	.hero-proofbar {
+		grid-template-columns: 1fr;
+	}
+}
+
+@media (max-width: 820px) {
+	.landing-shell {
+		padding: 1rem;
+	}
+
+	.masthead {
+		margin-bottom: 0.8rem;
+		top: 0.75rem;
+	}
+
+	.masthead-actions {
+		justify-content: flex-start;
+	}
+
+	.console-metrics,
+	.architecture-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.hero-copy h1 {
+		font-size: clamp(2.4rem, 12vw, 4rem);
+	}
+}
+
+@media (max-width: 640px) {
+	.hero-section,
+	.signal-card,
+	.section-frame,
+	.path-card,
+	.cta-banner {
+		padding: 1.1rem;
+	}
+
+	.brand-copy span {
+		display: none;
+	}
+
+	.site-nav {
+		gap: 0.75rem;
+		justify-content: flex-start;
+		padding-bottom: 0.15rem;
+		white-space: nowrap;
+	}
+
+	.button-primary,
+	.button-secondary,
+	.button-tertiary {
+		width: 100%;
+	}
+
+	.footer-actions,
+	.masthead-actions,
+	.action-row {
+		width: 100%;
+	}
+
+	.masthead {
+		border-radius: 28px;
+		padding: 0.9rem;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	html {
+		scroll-behavior: auto;
+	}
+
+	.button-primary,
+	.button-secondary,
+	.button-tertiary,
+	.nav-link,
+	.brand {
+		transition: none;
+	}
+}


### PR DESCRIPTION
## Summary
- turn the root landing into an async-first site for verifiable memory / decision-record positioning
- add the public intake routes `/async-demo` and `/pilot-scope` so pilot qualification can happen without calls
- harden `/vsa` by bundling `three` locally, reusing the simulation buffer, and honoring reduced-motion for the health meter
- remove unused Astro site dependencies and add `.vercelignore` so Vercel deploys only the landing slice
- classify Astro/Vercel-only PRs as `release_only` in CI and deploy workflows so landing PRs do not fail on unrelated repo-wide Python gates

## Verification
- `npm run build`
- `python3 scripts/repo_health_changed.py`

## Notes
- This PR remains isolated on `codex/site-cutover` and only carries site-facing changes plus the minimum workflow scoping needed to keep a web-only PR mergeable.
