### PR TITLE
chore(packaging): split optional runtime surface from trust core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] — v0.3.0b5
 
 ### In Progress
-- No unreleased entries yet.
+- **Lean core install surface**: moved heavyweight local embedding, Chroma, and numba dependencies behind optional extras so `pip install cortex-persist` stays focused on the supported trust-layer core.
+- **Extended runtime split**: moved `aiohttp`, `beautifulsoup4`, `arq`, and `email-validator` out of the base install into `mcp`, `daemon`, and `api` extras so optional server-side surfaces stop leaking into the trust-core package.
+- **YAML / watcher split**: moved `PyYAML` and `watchdog` out of the base install into `authoring`, `mcp`, and `daemon` extras so filesystem and YAML-heavy tooling stop inflating the minimal install.
+- **Daemon relay split**: moved `aiofiles` out of the base install into the `daemon` extra because async relay buffering is not part of the supported trust-core path.
+- **Clean base bootstrap**: core memory imports now tolerate missing `numpy`, optional L2/vector surfaces degrade to `L1+L3` without user-facing warnings, and async sqlite-vec loading now has a dedicated helper plus regression coverage.
+- **macOS platform split**: moved `pyobjc` keychain bindings out of the base install into a dedicated `platform` extra, while keeping secure-by-default keyring behavior in the trust-core path.
 
 ## [0.3.0b5] — 2026-04-14
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.md
 include pyproject.toml
+include config/tips.json
 graft cortex
 prune .github
 prune build

--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ $ cortex compliance-report
 
 Start with the smallest supported flow and get to audit evidence fast.
 
+The supported PyPI base flow is `install -> init -> store -> verify`.
+Semantic search, MCP/server flows, and other extended surfaces may require optional extras or a fuller local runtime.
+
 ### Path A: Install from PyPI *(preferred)*
 
 ```bash
@@ -127,6 +130,16 @@ pip install cortex-persist
 cortex init
 cortex memory store risk-bot "Transaction flagged: IP mismatch"
 cortex trust-ledger verify
+```
+
+For local semantic embeddings, Chroma-backed knowledge sync, or JIT acceleration, add the optional extras you actually need:
+
+```bash
+pip install "cortex-persist[embeddings]"
+pip install "cortex-persist[knowledge]"
+pip install "cortex-persist[acceleration]"
+pip install "cortex-persist[platform]"       # macOS keychain support
+pip install "cortex-persist[api,mcp,daemon,authoring]"  # optional server surfaces
 ```
 
 ### Path B: Install from Source *(development)*

--- a/cortex/cli/assets/tips.json
+++ b/cortex/cli/assets/tips.json
@@ -1,0 +1,490 @@
+[
+  {
+    "content": {
+      "en": "Use `cortex search` with natural language — it understands semantic meaning, not just keywords.",
+      "es": "Usa `cortex search` con lenguaje natural; entiende el significado semántico, no solo palabras clave.",
+      "eu": "Erabili `cortex search` hizkuntza naturalarekin; esanahi semantikoa ulertzen du, ez hitz gakoak bakarrik."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "CORTEX stores facts with temporal validity. Use `valid_from` and `valid_until` to time-scope knowledge.",
+      "es": "CORTEX guarda hechos con validez temporal. Usa `valid_from` y `valid_until` para acotar el conocimiento en el tiempo.",
+      "eu": "CORTEXek gertaerak baliozkotasun temporalarekin gordetzen ditu. Erabili `valid_from` eta `valid_until` ezagutza denboran mugatzeko."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "`cortex recall <project>` loads full project context instantly — perfect for resuming work.",
+      "es": "`cortex recall <project>` carga el contexto completo del proyecto al instante: ideal para retomar el trabajo.",
+      "eu": "`cortex recall <project>` proiektuaren testuinguru osoa berehala kargatzen du: lana berriz hasteko ezin hobea."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "The consensus system lets multiple agents vote on facts. Higher consensus = more trustworthy.",
+      "es": "El sistema de consenso permite que varios agentes voten hechos. A mayor consenso, mayor confiabilidad.",
+      "eu": "Adostasun sistemak hainbat agentek gertaeren inguruan bozkatzea ahalbidetzen du. Adostasun handiagoa = fidagarritasun handiagoa."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "CORTEX auto-generates embeddings for every fact. Semantic search works out of the box.",
+      "es": "CORTEX genera embeddings para cada hecho automáticamente. La búsqueda semántica funciona de serie.",
+      "eu": "CORTEXek gertaera bakoitzerako embedding-ak sortzen ditu automatikoki. Bilaketa semantikoak zuzenean funtzionatzen du."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "The episodic memory system records entire conversation sessions — like a persistent brain.",
+      "es": "El sistema de memoria episódica registra sesiones enteras de conversación, como un cerebro persistente.",
+      "eu": "Memoria episodikoaren sistemak elkarrizketa saio osoak grabatzen ditu, garun iraunkor baten modura."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "Use `cortex export <project>` to snapshot your entire project knowledge base as JSON.",
+      "es": "Usa `cortex export <project>` para tomar un snapshot completo de tu base de conocimiento en JSON.",
+      "eu": "Erabili `cortex export <project>` proiektuaren ezagutza-oinarri osoa JSON gisa gordetzeko."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "Trust scores propagate transitively: if A trusts B and B trusts C, A partially trusts C.",
+      "es": "Los trust scores se propagan transitivamente: si A confía en B y B en C, A confía parcialmente en C.",
+      "eu": "Konfiantza puntuazioak maila anitzetan hedatzen dira: A B-n konfiatzen bada eta B C-n, A partzialki C-n konfiatzen da."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "Merkle audit trails make CORTEX tamper-evident: any mutation in the fact chain is cryptographically detectable.",
+      "es": "Los Merkle audit trails hacen que CORTEX sea resistente a manipulaciones: cualquier mutación en la cadena de hechos es detectable criptográficamente.",
+      "eu": "Merkle audit trailsek CORTEXa manipulazioekiko erresistente egiten dute: gertaera katean edozein mutazio kriptografikoki detektagarria da."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "Circuit breakers in CORTEX automatically halt runaway agents before they damage shared state.",
+      "es": "Los circuit breakers de CORTEX detienen automáticamente agentes descontrolados antes de que dañen el estado compartido.",
+      "eu": "CORTEXen circuit breakerrek automatikoki gelditzen dituzte erabiltzen ari diren agenteak egoera partekatua kaltetu aurretik."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "Store decisions immediately after making them. Memory is cheaper than reconstruction.",
+      "es": "Guarda las decisiones inmediatamente después de tomarlas. La memoria es más barata que la reconstrucción.",
+      "eu": "Gorde erabakiak hartu bezain laster. Memoria berritzea baino merkeagoa da."
+    },
+    "category": "workflow"
+  },
+  {
+    "content": {
+      "en": "Tag facts with confidence levels: C5 (confirmed) → C1 (hypothesis). Filter by certainty later.",
+      "es": "Etiqueta hechos con niveles de confianza: C5 (confirmado) → C1 (hipótesis). Filtra por certeza después.",
+      "eu": "Etiketatu gertaerak konfiantza mailekin: C5 (baieztatua) → C1 (hipótesis). Iragazi ziurtasunaren arabera geroago."
+    },
+    "category": "workflow"
+  },
+  {
+    "content": {
+      "en": "Ghosts are unfinished work items. Use `cortex ghost list` to track what needs attention.",
+      "es": "Los 'ghosts' son tareas inacabadas. Usa `cortex ghost list` para saber qué necesita atención.",
+      "eu": "Los 'ghosts' dira amaitu gabeko zereginak. Erabili `cortex ghost list` arreta zer behar duen jakiteko."
+    },
+    "category": "workflow"
+  },
+  {
+    "content": {
+      "en": "The MEJORAlo score should be > 70 before shipping. Run `/mejoralo` on any file to check.",
+      "es": "La puntuación MEJORAlo debería ser > 70 antes de publicar. Ejecuta `/mejoralo` en cualquier archivo.",
+      "eu": "MEJORAlo puntuazioak > 70 izan behar du argitaratu aurretik. Exekutatu `/mejoralo` edozein fitxategitan."
+    },
+    "category": "workflow"
+  },
+  {
+    "content": {
+      "en": "A bridge fact connects two projects: 'Pattern X from ProjectA works in ProjectB with adaptation Y'. Store it.",
+      "es": "Un fact de tipo bridge conecta dos proyectos: 'El patrón X de ProyectoA funciona en ProyectoB con la adaptación Y'. Guárdalo.",
+      "eu": "Bridge motako fact batek bi proiektu lotzen ditu: 'X eredua ProiektuAtik ProiektuBn funtzionatzen du Y egokitzapenarekin'. Gorde ezazu."
+    },
+    "category": "workflow"
+  },
+  {
+    "content": {
+      "en": "Mid-session checkpoint: if a major decision happened in the last 20 minutes, persist it NOW. Don't wait for session end.",
+      "es": "Checkpoint a mitad de sesión: si hubo una decisión importante en los últimos 20 minutos, guárdala AHORA. No esperes al cierre.",
+      "eu": "Saioaren erdiko kontrolpuntua: azken 20 minutuetan erabaki garrantzitsurik gertatu bada, gorde ORAIN. Ez utzi saioaren amaierara."
+    },
+    "category": "workflow"
+  },
+  {
+    "content": {
+      "en": "Ghosts that block other work cost 10x more than ones that don't. Classify them as 'blocking' immediately.",
+      "es": "Los ghosts que bloquean otro trabajo cuestan 10x más que los que no bloquean. Clasifícalos como 'blocking' inmediatamente.",
+      "eu": "Beste lana blokeatzen duten ghostek 10x gehiago kostatzen dira blokeatzen ez dutenak baino. Sailkatu 'blocking' gisa berehala."
+    },
+    "category": "workflow"
+  },
+  {
+    "content": {
+      "en": "SQLite WAL mode is enabled by default. This gives you concurrent reads during writes.",
+      "es": "El modo WAL de SQLite está activo por defecto. Permite lecturas concurrentes durante las escrituras.",
+      "eu": "SQLite WAL modua gainean dago lehenetsita. Honek idazketan zehar irakurketa konkurrenteak ahalbidetzen ditu."
+    },
+    "category": "performance"
+  },
+  {
+    "content": {
+      "en": "The compactor merges redundant facts to keep the database lean. Run `cortex compact` periodically.",
+      "es": "El compactador fusiona hechos redundantes para mantener la BD ligera. Ejecuta `cortex compact` a menudo.",
+      "eu": "Konpaktatzaileak gertaera erredundanteak batzen ditu DBa arin mantentzeko. Exekutatu `cortex compact` aldian-aldian."
+    },
+    "category": "performance"
+  },
+  {
+    "content": {
+      "en": "Embeddings are generated lazily on first search. Pre-warm them for latency-sensitive deployments.",
+      "es": "Los embeddings se generan de forma lazy en la primera búsqueda. Pre-calcúlalos en deployments sensibles a la latencia.",
+      "eu": "Embedding-ak lehen bilaketan modu lazean sortzen dira. Aurrez kalkulatu latentziaren aldeko deploymentetan."
+    },
+    "category": "performance"
+  },
+  {
+    "content": {
+      "en": "Cache your `TipsEngine` instance — initializing it on every request wastes cycles and misses the shown-tips dedup.",
+      "es": "Cachea tu instancia de `TipsEngine` — inicializarla en cada request desperdicia ciclos y pierde la deduplicación de tips mostrados.",
+      "eu": "Cachetu ezazu `TipsEngine` instantzia — requesteko inicializatzeak zikloak alperrik galtzen ditu eta erakutsitako tipsen dedup galtzen da."
+    },
+    "category": "performance"
+  },
+  {
+    "content": {
+      "en": "Never hardcode API keys. CORTEX loads all secrets from environment variables.",
+      "es": "Nunca pongas claves API a fuego. CORTEX carga todos los secretos desde variables de entorno.",
+      "eu": "Inoiz ez jarri API gakoak kodean. CORTEXek sekretu guztiak ingurune aldagaietatik kargatzen ditu."
+    },
+    "category": "security"
+  },
+  {
+    "content": {
+      "en": "The crypto vault encrypts sensitive facts at rest using AES-GCM.",
+      "es": "La bóveda criptográfica encripta hechos sensibles en reposo usando AES-GCM.",
+      "eu": "Kasun kriptografikoak gertaera sentikorrak enkriptatzen ditu AES-GCM erabiliz."
+    },
+    "category": "security"
+  },
+  {
+    "content": {
+      "en": "Rate limiting on admin routes is per-IP with token buckets. Customize `max_requests` per deployment risk profile.",
+      "es": "El rate limiting en rutas admin es por IP con token buckets. Personaliza `max_requests` según el perfil de riesgo de cada deployment.",
+      "eu": "Rate limitinga admin bideetan IP bakoitzeko token bucket-ekin da. Pertsonalizatu `max_requests` deployment arrisku-profilearen arabera."
+    },
+    "category": "security"
+  },
+  {
+    "content": {
+      "en": "Every admin action is audit-logged with method, path, IP, and user-agent. Check `cortex.admin.middleware` logs.",
+      "es": "Cada acción de admin queda registrada en el audit log con método, ruta, IP y user-agent. Consulta los logs de `cortex.admin.middleware`.",
+      "eu": "Admin ekintza bakoitza audit log-ean erregistratzen da metodo, bide, IP eta user-agent-arekin. Kontsultatu `cortex.admin.middleware` log-ak."
+    },
+    "category": "security"
+  },
+  {
+    "content": {
+      "en": "The Privacy Firewall screens dynamic tips before display. API keys and secrets never leak into tip content.",
+      "es": "El Privacy Firewall examina los tips dinámicos antes de mostrarlos. Las claves API y secretos jamás se filtran al contenido de los tips.",
+      "eu": "Privacy Firewallak tips dinamikoak erakutsi aurretik aztertzen ditu. API gakoak eta sekretuak inoiz ez dira tipsen edukian agertzen."
+    },
+    "category": "security"
+  },
+  {
+    "content": {
+      "en": "Use `ruff` for linting — it's 10-100x faster than flake8 and covers more rules.",
+      "es": "Usa `ruff` para el linter: es 10-100 veces más rápido que flake8 y cubre más reglas.",
+      "eu": "Erabili `ruff` linter gisa: flake8 baino 10-100 aldiz azkarragoa da eta arau gehiago hartzen ditu barne."
+    },
+    "category": "python"
+  },
+  {
+    "content": {
+      "en": "Use `from __future__ import annotations` in every module — defers type eval and removes circular import headaches.",
+      "es": "Usa `from __future__ import annotations` en cada módulo — aplaza la evaluación de tipos y evita importaciones circulares.",
+      "eu": "Erabili `from __future__ import annotations` modulu guztietan — tipo-ebaluazioa atzeratzen du eta inportazio zirkularren buruhausteak ekiditen ditu."
+    },
+    "category": "python"
+  },
+  {
+    "content": {
+      "en": "`dataclass(frozen=True, slots=True)` is 2-3x faster than a regular dataclass for read-heavy objects like Tip.",
+      "es": "`dataclass(frozen=True, slots=True)` es 2-3x más rápido que un dataclass normal para objetos de solo lectura como Tip.",
+      "eu": "`dataclass(frozen=True, slots=True)` 2-3 aldiz azkarragoa da irakurketa-astunentzako objektuentzat, Tip bezalakoak, dataclass normal bat baino."
+    },
+    "category": "python"
+  },
+  {
+    "content": {
+      "en": "Never use `except Exception: pass`. Use `except Exception: log.debug(...)` so you can see what's silenced.",
+      "es": "Nunca uses `except Exception: pass`. Usa `except Exception: log.debug(...)` para ver qué se silencia.",
+      "eu": "Inoiz ez erabili `except Exception: pass`. Erabili `except Exception: log.debug(...)` zer ixiltzen den ikusteko."
+    },
+    "category": "debugging"
+  },
+  {
+    "content": {
+      "en": "Use `pytest -x --tb=short` during active development: fast failure + readable traces = faster iteration.",
+      "es": "Usa `pytest -x --tb=short` durante desarrollo activo: fallo rápido + trazas legibles = iteración más rápida.",
+      "eu": "Erabili `pytest -x --tb=short` garapen aktiboan: porrot azkarra + arrasto irakurgarriak = iterazio azkarragoa."
+    },
+    "category": "debugging"
+  },
+  {
+    "content": {
+      "en": "`git bisect` is the fastest way to find which commit introduced a regression. Start with `git bisect start HEAD <last-good>`.",
+      "es": "`git bisect` es la forma más rápida de encontrar qué commit introdujo una regresión. Empieza con `git bisect start HEAD <último-bueno>`.",
+      "eu": "`git bisect` erregresio bat zein commitek sartu zuen aurkitzeko modurik azkarrena da. Hasi `git bisect start HEAD <azken-ona>`-rekin."
+    },
+    "category": "git"
+  },
+  {
+    "content": {
+      "en": "Use `git stash push -m 'description'` instead of unnamed stashes. Future you will thank present you.",
+      "es": "Usa `git stash push -m 'descripción'` en vez de stashes sin nombre. El tú del futuro te lo agradecerá.",
+      "eu": "Erabili `git stash push -m 'deskribapena'` izenik gabeko stashen ordez. Etorkizuneko zuk eskertu egingo dizu."
+    },
+    "category": "git"
+  },
+  {
+    "content": {
+      "en": "Industrial Noir: #0A0A0A backgrounds, #CCFF00 accents, glassmorphism panels. The MOSKV aesthetic.",
+      "es": "Industrial Noir: fondos #0A0A0A, acentos #CCFF00, paneles glassmorphism. La estética MOSKV.",
+      "eu": "Industrial Noir: #0A0A0A fondoak, #CCFF00 azentuak, glassmorphism panelak. MOSKV estetika."
+    },
+    "category": "design"
+  },
+  {
+    "content": {
+      "en": "Micro-animations under 200ms feel snappy. Over 300ms feel laggy. 200-300ms is the sweet spot for spring transitions.",
+      "es": "Las micro-animaciones de menos de 200ms se sienten rápidas. Las de más de 300ms se sienten lentas. 200-300ms es el punto dulce para springs.",
+      "eu": "200ms azpiko mikro-animazioak lastegiak iruditzen dira. 300ms gainekoak motelak. 200-300ms spring trantsizioetarako puntu gozoa da."
+    },
+    "category": "design"
+  },
+  {
+    "content": {
+      "en": "CORTEX persists 3 types at session close: decisions, errors, and ghosts. Never lose context.",
+      "es": "CORTEX guarda 3 tipos al cerrar: decisiones, errores y 'ghosts'. No pierdas el contexto.",
+      "eu": "CORTEXek 3 mota gordetzen ditu saioa ixtean: erabakiak, erroreak eta 'ghost'-ak. Ez galdu testuingurua inoiz."
+    },
+    "category": "memory"
+  },
+  {
+    "content": {
+      "en": "The 130/100 standard: meeting requirements is 100. Anticipating needs you didn't know you had is 130.",
+      "es": "El estándar 130/100: cumplir requisitos es 100. Anticipar necesidades que no sabías que tenías es 130.",
+      "eu": "130/100 estandarra: eskakizunak betetzea 100 da. Zenituenik ez zenekien beharrak aurreikustea, berriz, 130."
+    },
+    "category": "meta"
+  },
+  {
+    "content": {
+      "en": "Every element must answer 'Why?'. If it has no purpose, delete it.",
+      "es": "Cada elemento debe responder a '¿Por qué?'. Si no tiene propósito, bórralo.",
+      "eu": "Elementu bakoitzak 'Zergatik?' galderari erantzun behar dio. Propositurik ez badu, ezabatu."
+    },
+    "category": "meta"
+  },
+  {
+    "content": {
+      "en": "The 5 Whys: ask 'why' 5 times before accepting the first explanation. Root cause lives deeper than symptoms.",
+      "es": "Los 5 Porqués: pregunta 'por qué' 5 veces antes de aceptar la primera explicación. La causa raíz vive más profundo que los síntomas.",
+      "eu": "5 Zergatiak: galdetu 'zergatik' 5 aldiz lehen azalpena onartu aurretik. Erro-kausa sintotak baino sakonago bizi da."
+    },
+    "category": "meta"
+  },
+  {
+    "content": {
+      "en": "Complexity without value is entropy. Every abstraction must pay for itself in maintainability.",
+      "es": "La complejidad sin valor es entropía. Cada abstracción debe pagar su propio precio en mantenibilidad.",
+      "eu": "Baliorik gabeko konplexutasuna entropia da. Abstrakzio bakoitzak bere prezioa ordaindu behar du mantengarritasunean."
+    },
+    "category": "architecture"
+  },
+  {
+    "content": {
+      "en": "Dependency injection beats global state every time. CORTEX uses FastAPI's `Depends()` throughout — follow the pattern.",
+      "es": "La inyección de dependencias gana al estado global siempre. CORTEX usa `Depends()` de FastAPI en todo — sigue el patrón.",
+      "eu": "Dependentzia injekzioak egoera globalari irabazten dio beti. CORTEXek FastAPI-ren `Depends()` erabiltzen du osoan — jarraitu eredua."
+    },
+    "category": "architecture"
+  },
+  {
+    "content": {
+      "en": "CortexEngine is the single source of truth for all data operations. Never bypass it with direct SQL in routes.",
+      "es": "CortexEngine es la única fuente de verdad para todas las operaciones de datos. Nunca la bypasees con SQL directo en las rutas.",
+      "eu": "CortexEngine eragiketa guztietarako egia-iturri bakarra da. Inoiz ez saihestatu SQL zuzenarekin bideetan."
+    },
+    "category": "architecture"
+  },
+  {
+    "content": {
+      "en": "Probe pattern for health checks: each subsystem probe is isolated. One failing probe doesn't crash all others.",
+      "es": "Patrón probe para health checks: cada probe de subsistema está aislada. Una probe fallida no rompe las demás.",
+      "eu": "Proba eredua osasun-egiaztatzetarako: azpisistema proba bakoitza isolatuta dago. Porrot egindako probak ez du besteak apurtzen."
+    },
+    "category": "architecture"
+  },
+  {
+    "content": {
+      "en": "Keep your LLM system prompt under 2000 tokens. Beyond that, attention dilution starts hurting instruction following.",
+      "es": "Mantén tu system prompt de LLM por debajo de 2000 tokens. Más allá, la dilución de atención empieza a perjudicar el seguimiento de instrucciones.",
+      "eu": "Mantendu zure LLM system promptaren azpian 2000 token. Hortik gora, arreta dilusioak argibideen jarraipenari kalte egiten hasten zaio."
+    },
+    "category": "architecture"
+  },
+  {
+    "content": {
+      "en": "Format Python exceptions as `raise X(...) from None` in API routes to prevent leaking internal tracebacks to clients.",
+      "es": "Formatear excepciones Python como `raise X(...) from None` en rutas API previene filtrar tracebacks internos a los clientes.",
+      "eu": "Python salbuespenak `raise X(...) from None` gisa formateatzea API bideetan barne trasezak bezeroei filtratzea ekiditen du."
+    },
+    "category": "python"
+  },
+  {
+    "content": {
+      "en": "Slow import? Use `importlib.import_module()` inside the function body to defer it to call time.",
+      "es": "¿Importación lenta? Usa `importlib.import_module()` dentro del cuerpo de la función para diferirla al momento de llamada.",
+      "eu": "Inportazio motela? Erabili `importlib.import_module()` funtzioaren gorputzaren barruan deia egiteko momentura atzeratzeko."
+    },
+    "category": "performance"
+  },
+  {
+    "content": {
+      "en": "The 'Handoff' endpoint serializes live agent state to JSON. Call it before switching platforms — never lose mid-session context.",
+      "es": "El endpoint 'Handoff' serializa el estado vivo del agente a JSON. Llámalo antes de cambiar de plataforma — nunca pierdas el contexto a mitad de sesión.",
+      "eu": "Handoff endpoint-ak agente-egoera bizirik JSON-era serializatzen du. Deitu plataformaz aldatu aurretik — inoiz ez galdu saioaren erdiko testuingurua."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "CORTEX CLI speaks 3 languages (en, es, eu). Set `CORTEX_LANG=es` env var to make it permanent.",
+      "es": "El CLI de CORTEX habla 3 idiomas (en, es, eu). Establece `CORTEX_LANG=es` como variable de entorno para hacerlo permanente.",
+      "eu": "CORTEX CLI-ak 3 hizkuntza hitz egiten ditu (en, es, eu). Ezarri `CORTEX_LANG=es` ingurune-aldagai gisa iraunkortzeko."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "Type-check your fact types: 'decision', 'error', 'ghost', 'bridge', 'knowledge', 'world-model'. Wrong types are silently stored but never surfaced correctly.",
+      "es": "Verifica el tipo de tus hechos: 'decision', 'error', 'ghost', 'bridge', 'knowledge', 'world-model'. Los tipos incorrectos se guardan en silencio pero nunca se recuperan correctamente.",
+      "eu": "Egiaztatu zure gertaeren motak: 'decision', 'error', 'ghost', 'bridge', 'knowledge', 'world-model'. Mota okerrak isiltasunean gordetzen dira baina inoiz ez dira behar bezala berreskuratzen."
+    },
+    "category": "memory"
+  },
+  {
+    "content": {
+      "en": "Memory is only as good as its retrieval. Don't just store — describe facts with enough context to find them 6 months later.",
+      "es": "La memoria es tan buena como su recuperación. No solo guardes — describe hechos con suficiente contexto para encontrarlos 6 meses después.",
+      "eu": "Memoria berreskuratzea bezain ona da. Ez soilik gorde — deskribatu gertaerak 6 hilabete geroago aurkitzeko adina testuingururekin."
+    },
+    "category": "memory"
+  },
+  {
+    "content": {
+      "en": "Pattern: if you find yourself explaining the same thing twice, it's a 'knowledge' fact. Store it once, recall forever.",
+      "es": "Patrón: si te encuentras explicando lo mismo dos veces, es un hecho de tipo 'knowledge'. Guárdalo una vez, recupéralo siempre.",
+      "eu": "Eredua: zuk zeuk gauza bera bi aldiz azaltzen baduzu euren burua, 'knowledge' gertaera da. Gorde behin, berreskuratu beti."
+    },
+    "category": "memory"
+  },
+  {
+    "content": {
+      "en": "Use `cortex search --type decision` to find prior architectural choices before making new ones. Decision archaeology prevents repeating mistakes.",
+      "es": "Usa `cortex search --type decision` para encontrar decisiones arquitectónicas anteriores antes de tomar nuevas. La arqueología de decisiones previene repetir errores.",
+      "eu": "Erabili `cortex search --type decision` aurreko arkitektura-erabakiak aurkitzeko berriak hartu aurretik. Erabakien arkeologiak akatsak errepikatzea ekiditen du."
+    },
+    "category": "workflow"
+  },
+  {
+    "content": {
+      "en": "Bridge detection: if you solved problem X in project A and are now solving similar X in project B — store a bridge fact NOW.",
+      "es": "Detección de bridge: si resolviste el problema X en el proyecto A y ahora resuelves un X similar en el proyecto B — guarda un hecho de tipo bridge AHORA.",
+      "eu": "Bridge detekzioa: A proiektuan X arazoa konpondu bazenuen eta orain B proiektuan antzeko X bat konpontzen ari bazara — gorde bridge gertaera ORAIN."
+    },
+    "category": "workflow"
+  },
+  {
+    "content": {
+      "en": "The `SelfHealingHook` increments failure counters per endpoint. Wire these to your Prometheus/StatsD for real-time alerting.",
+      "es": "El `SelfHealingHook` incrementa contadores de fallo por endpoint. Conéctalos a tu Prometheus/StatsD para alertas en tiempo real.",
+      "eu": "SelfHealingHook-ek porrot kontadoreak endpoint bakoitzeko handitzen ditu. Lotu itzazu zure Prometheus/StatsD-ra denbora errealeko alertetarako."
+    },
+    "category": "architecture"
+  },
+  {
+    "content": {
+      "en": "The `AuditLogger` middleware captures every admin action. Feed its output to a SIEM for compliance.",
+      "es": "El middleware `AuditLogger` captura cada acción de admin. Alimenta su salida a un SIEM para cumplimiento.",
+      "eu": "AuditLogger middlewareak admin ekintza bakoitza kapturatzen du. Bere irteera SIEM batera elikatu betetzeko."
+    },
+    "category": "security"
+  },
+  {
+    "content": {
+      "en": "async def + await in FastAPI routes means the event loop stays responsive while I/O happens. Never block with time.sleep().",
+      "es": "async def + await en rutas FastAPI significa que el event loop sigue respondiendo mientras ocurre I/O. Nunca bloquees con time.sleep().",
+      "eu": "async def + await FastAPI bideetan event loopak I/O gertatzen den bitartean erantzuten jarraitzen duela esan nahi du. Inoiz ez blokeatu time.sleep()-ekin."
+    },
+    "category": "python"
+  },
+  {
+    "content": {
+      "en": "Use `run_in_threadpool()` in FastAPI for blocking operations like file I/O. It uses the default thread pool without blocking the event loop.",
+      "es": "Usa `run_in_threadpool()` en FastAPI para operaciones bloqueantes como I/O de archivos. Usa el thread pool sin bloquear el event loop.",
+      "eu": "Erabili `run_in_threadpool()` FastAPI-n fitxategi I/O bezalako blokeo-eragiketentzat. Thread pool-a erabiltzen du event loopa blokeatu gabe."
+    },
+    "category": "python"
+  },
+  {
+    "content": {
+      "en": "Trust Score is not just a number — it's a composite of: source reliability × freshness × consensus × confidence. Weight them by use case.",
+      "es": "El Trust Score no es solo un número — es un compuesto de: fiabilidad de la fuente × frescura × consenso × confianza. Pondera según el caso de uso.",
+      "eu": "Trust Score ez da zenbaki bat soilik — iturriaren fidagarritasuna × frescura × adostasuna × konfiantza konbinazio bat da. Pisatu erabilera-kasuaren arabera."
+    },
+    "category": "cortex"
+  },
+  {
+    "content": {
+      "en": "Structural entropy cannot be measured from a single dimensional lens. Dynamically rotating the proxy prevents hostile system adaptation to our metric. Assume sub-systems will incessantly optimize the most rewarded metric; withdraw it before they become addicted.",
+      "es": "La entropía estructural no puede medirse desde una sola lente dimensional. Rotar dinámicamente el proxy previene la adaptación hostil del sistema a nuestra métrica, garantizando que el manifold retenga una semántica generalizable real. Siempre asume que los sub-sistemas optimizarán estúpida e incesantemente la métrica más premiada; retírala justo antes de que se vuelvan adictos.",
+      "eu": "Entropia estrukturala ezin da lente dimentsional bakar batetik neurtu. Proxy-a dinamikoki biratzeak sistemaren gure metrikaren aurkako egokitzapen etsaia saihesten du, manifold-ak benetako semantika orokorgarria mantentzea bermatuz. Beti pentsatu azpisistemek etengabe eta modu inozoan optimizatuko dutela metrika sarituena; kendu ezazu menpeko bihurtu aurretik."
+    },
+    "category": "architecture"
+  },
+  {
+    "content": {
+      "en": "Complacency is the first symptom of architectural calcification. If an agent tells you they've reached a limit, fire them. The limit is only the observer's lack of imagination. Do not let the system become a fossil.",
+      "es": "La complacencia es el primer síntoma de la calcificación arquitectónica. Si un agente te dice que ha llegado al límite, despídelo. El límite es solo la falta de imaginación del observador. No dejes que el sistema se convierta en un fósil.",
+      "eu": "Konplazentzia arkitektura-kaltifikazioaren lehen sintoma da. Agente batek muga batera iritsi dela esaten badizu, bota ezazu. Muga behatzailearen irudimen falta besterik ez da. Ez utzi sistema fosil bihurtzen."
+    },
+    "category": "architecture"
+  },
+  {
+    "content": {
+      "en": "Calcification occurs when refactoring cost exceeds benefit. Apply Landauer's Razor: if a line of code doesn't decrease system entropy by >= 1%, it's a thermal parasite. Eliminate it before it becomes bone.",
+      "es": "La Calcificación ocurre cuando el coste de refactorizar supera el beneficio. Aplica la Navaja de Landauer: si una línea no reduce la entropía en >= 1%, es un parásito térmico. Elimínala antes de que se vuelva hueso.",
+      "eu": "Kaltzifikazioa gertatzen da birfaktoreatze kostua onura baino handiagoa denean. Landauer-en Navaja erabili: lerro batek entropia ez badu >= %1 murrizten, parasito termikoa da. Ezabatu hezur bihurtu aurretik."
+    },
+    "category": "architecture"
+  }
+]

--- a/cortex/cli/tips.py
+++ b/cortex/cli/tips.py
@@ -37,7 +37,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("cortex.tips")
 
-_ASSET_PATH: Final[Path] = Path(__file__).parent.parent.parent / "config" / "tips.json"
+_PACKAGE_ASSET_PATH: Final[Path] = Path(__file__).with_name("assets") / "tips.json"
+_LEGACY_ASSET_PATH: Final[Path] = Path(__file__).parent.parent.parent / "config" / "tips.json"
+_ASSET_CANDIDATES: Final[tuple[Path, ...]] = (_PACKAGE_ASSET_PATH, _LEGACY_ASSET_PATH)
 
 
 # ─── Models ──────────────────────────────────────────────────────────
@@ -96,12 +98,13 @@ def _load_static_tips() -> list[Tip]:
         if _STATIC_TIPS_CACHE is not None:
             return _STATIC_TIPS_CACHE
 
-        if not _ASSET_PATH.exists():
-            logger.error("Sovereign Failure: Tips asset missing at %s", _ASSET_PATH)
+        asset_path = next((path for path in _ASSET_CANDIDATES if path.exists()), None)
+        if asset_path is None:
+            logger.error("Sovereign Failure: Tips asset missing at %s", _PACKAGE_ASSET_PATH)
             return []
 
         try:
-            raw_data = json.loads(_ASSET_PATH.read_text(encoding="utf-8"))
+            raw_data = json.loads(asset_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as exc:
             logger.critical("TIPS: Failed to load static tips: %s", exc)
             return []

--- a/cortex/crypto/__init__.py
+++ b/cortex/crypto/__init__.py
@@ -3,8 +3,21 @@ CORTEX v6 — Cryptographic Security.
 """
 
 from .aes import CortexEncrypter, get_default_encrypter
-from .keyring import generate_and_store_master_key, get_master_key
 from .vault import Vault
+
+
+def get_master_key():
+    """Lazily resolve the master-key loader to avoid hard import coupling."""
+    from .keyring import get_master_key as _get_master_key
+
+    return _get_master_key()
+
+
+def generate_and_store_master_key():
+    """Lazily resolve key generation so `cortex.crypto` imports stay portable."""
+    from .keyring import generate_and_store_master_key as _generate_and_store_master_key
+
+    return _generate_and_store_master_key()
 
 __all__ = [
     "Vault",

--- a/cortex/crypto/keyring.py
+++ b/cortex/crypto/keyring.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import base64
 import logging
 import os
-from typing import Optional, Tuple, Type
+from typing import Optional
 
 try:
     import keyring
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 SERVICE_NAME = "cortex_v6"
 KEY_NAME = "master_key"
-_keyring_error_types: Tuple[Type[Exception], ...]
+_keyring_error_types: tuple[type[Exception], ...]
 
 if keyring is None:
     _keyring_error_types = (Exception,)

--- a/cortex/crypto/keyring.py
+++ b/cortex/crypto/keyring.py
@@ -8,9 +8,12 @@ from __future__ import annotations
 import base64
 import logging
 import os
-from typing import Optional
+from typing import Optional, Tuple, Type
 
-import keyring
+try:
+    import keyring
+except ImportError:  # pragma: no cover - exercised via blocked-import tests
+    keyring = None  # type: ignore[assignment]
 
 _AES_KEY_LENGTH = 32  # 256 bits
 
@@ -18,15 +21,23 @@ logger = logging.getLogger(__name__)
 
 SERVICE_NAME = "cortex_v6"
 KEY_NAME = "master_key"
+_keyring_error_types: Tuple[Type[Exception], ...]
+
+if keyring is None:
+    _keyring_error_types = (Exception,)
+else:
+    _errors = getattr(keyring, "errors", None)
+    _keyring_cls = getattr(_errors, "KeyringError", Exception)
+    _keyring_error_types = (_keyring_cls, OSError)
 
 
 def get_master_key() -> Optional[bytes]:
     """Read the master key from the OS keychain or fallback to env var."""
     key_b64 = None
-    if not os.environ.get("CORTEX_TESTING"):
+    if keyring is not None and not os.environ.get("CORTEX_TESTING"):
         try:
             key_b64 = keyring.get_password(SERVICE_NAME, KEY_NAME)
-        except (keyring.errors.KeyringError, OSError) as e:  # type: ignore[reportAttributeAccessIssue]
+        except _keyring_error_types as e:
             logger.warning("Failed to access OS Keychain: %s", e)
 
     if not key_b64:
@@ -36,7 +47,7 @@ def get_master_key() -> Optional[bytes]:
 
     if key_b64:
         try:
-            raw = base64.b64decode(key_b64)
+            raw = base64.b64decode(key_b64, validate=True)
             if len(raw) != _AES_KEY_LENGTH:
                 logger.error(
                     "Master key has wrong length: got %d bytes, expected %d.",
@@ -45,7 +56,7 @@ def get_master_key() -> Optional[bytes]:
                 )
                 return None
             return raw
-        except (ValueError, Exception):  # noqa: BLE001
+        except (ValueError, base64.binascii.Error):
             logger.error("Master key is not valid base64.")
             return None
 
@@ -57,10 +68,17 @@ def generate_and_store_master_key() -> str:
     key = os.urandom(_AES_KEY_LENGTH)
     key_b64 = base64.b64encode(key).decode("utf-8")
 
+    if keyring is None:
+        logger.warning(
+            "OS Keychain integration unavailable. "
+            "Set CORTEX_MASTER_KEY or CORTEX_VAULT_KEY manually with the generated key."
+        )
+        return key_b64
+
     try:
         keyring.set_password(SERVICE_NAME, KEY_NAME, key_b64)
         logger.info("Successfully vaulted new CORTEX_MASTER_KEY in OS Keychain.")
-    except (keyring.errors.KeyringError, OSError) as e:  # type: ignore[reportAttributeAccessIssue]
+    except _keyring_error_types as e:
         logger.error(
             "Could not store key in Keychain (%s). "
             "Set CORTEX_MASTER_KEY env var manually with the generated key.",

--- a/cortex/database/core.py
+++ b/cortex/database/core.py
@@ -38,6 +38,11 @@ from typing import Any, Final
 
 import aiosqlite
 
+try:
+    import sqlite_vec
+except ImportError:  # pragma: no cover - sqlite-vec is a base dependency in release builds
+    sqlite_vec = None
+
 from cortex.utils.errors import DBLockError
 
 __all__ = [
@@ -47,6 +52,7 @@ __all__ = [
     "connect_async_ctx",
     "apply_pragmas_async",
     "apply_pragmas_async_readonly",
+    "load_sqlite_vec_async",
 ]
 
 logger = logging.getLogger("cortex.db")
@@ -284,3 +290,26 @@ async def apply_pragmas_async_readonly(conn: aiosqlite.Connection) -> None:
     await apply_pragmas_async(conn)
     await conn.execute("PRAGMA query_only=1;")
     await conn.commit()
+
+
+async def load_sqlite_vec_async(conn: aiosqlite.Connection) -> bool:
+    """Load sqlite-vec into an async connection when the runtime supports it."""
+    if sqlite_vec is None:
+        return False
+
+    extension_toggle_enabled = False
+    try:
+        await conn.enable_load_extension(True)
+        extension_toggle_enabled = True
+        await conn._execute(sqlite_vec.load, conn._conn)
+    except (AttributeError, OSError, sqlite3.Error) as exc:
+        logger.debug("sqlite-vec not available for async connection: %s", exc)
+        return False
+    finally:
+        if extension_toggle_enabled:
+            try:
+                await conn.enable_load_extension(False)
+            except (AttributeError, OSError, sqlite3.Error):
+                logger.debug("sqlite-vec cleanup skipped for async connection")
+
+    return True

--- a/cortex/database/pool.py
+++ b/cortex/database/pool.py
@@ -85,7 +85,7 @@ class CortexConnectionPool:
 
     async def _create_connection(self) -> aiosqlite.Connection:
         """Create a highly-optimized, WAL-enabled async connection."""
-        from cortex.database.core import connect_async
+        from cortex.database.core import connect_async, load_sqlite_vec_async
 
         try:
             conn = await connect_async(self.db_path, read_only=self.read_only)
@@ -93,15 +93,7 @@ class CortexConnectionPool:
             logger.critical("Failed to create DB connection: %s", e)
             raise
 
-        # Wave 5: Load Vector Extension
-        try:
-            import sqlite_vec
-
-            await conn.enable_load_extension(True)
-            await conn.load_extension(sqlite_vec.loadable_path())
-            await conn.enable_load_extension(False)
-        except (ImportError, OSError, AttributeError) as e:
-            logger.debug("sqlite-vec not available for connection: %s", e)
+        await load_sqlite_vec_async(conn)
 
         return conn
 

--- a/cortex/engine/__init__.py
+++ b/cortex/engine/__init__.py
@@ -13,6 +13,7 @@ import aiosqlite
 import sqlite_vec
 
 from cortex.config import DEFAULT_DB_PATH
+from cortex.database.core import load_sqlite_vec_async
 
 # Lazy imports for runtime managers
 if TYPE_CHECKING:
@@ -94,6 +95,9 @@ class CortexEngine(
         self._ledger = None  # Wave 5: ImmutableLedger (lazy init)
         self._embedder: LocalEmbedder | None = None
         self._memory_manager = None  # Frontera 2: Tripartite Memory (lazy init)
+        self._memory_l1 = None
+        self._memory_l3 = None
+        self._memory_ready = False
         self._persistence = PersistenceSupervisor(self)
         self._system_state = "ACTIVE"
         # Managers are synthesized JIT via properties (Axiom Ω₄)
@@ -361,18 +365,11 @@ class CortexEngine(
                 return self._conn
             from cortex.database.core import connect_async
             self._conn = await connect_async(str(self._db_path))
-            try:
-                await self._conn.enable_load_extension(True)
-                await self._conn.load_extension(sqlite_vec.loadable_path())
-                await self._conn.enable_load_extension(False)
-                self._vec_available = True
-            except (OSError, AttributeError) as e:
-                logger.debug("sqlite-vec extension not available: %s", e)
-                self._vec_available = False
+            self._vec_available = await load_sqlite_vec_async(self._conn)
             await self._ensure_schema_ready(self._conn)
             # Ensure memory subsystem is initialized (L1/L2/L3)
             # This is critical for Active Forgetting (Thalamus Gate)
-            if self._memory_manager is None:
+            if not self._memory_ready:
                 await self._init_memory_subsystem(self._db_path, self._conn)
             return self._conn
     async def _ensure_schema_ready(self, conn: aiosqlite.Connection) -> None:
@@ -571,8 +568,6 @@ class CortexEngine(
         """Initialize database schema. Safe to call multiple times."""
         conn = await self._get_or_create_conn()
         await self._ensure_schema_ready(conn)
-        if self._memory_manager is None:
-            await self._init_memory_subsystem(self._db_path, conn)
         await self._persistence.start()
         metrics.set_engine(self)
         logger.info("CORTEX database initialized (async) at %s", self._db_path)
@@ -617,6 +612,9 @@ class CortexEngine(
             except (asyncio.TimeoutError, Exception):  # noqa: BLE001
                 logger.debug("Memory manager background drain timed out — forcing close")
             self._memory_manager = None
+        self._memory_l1 = None
+        self._memory_l3 = None
+        self._memory_ready = False
         if self._persistence:
             await self._persistence.stop()
         if self._conn:

--- a/cortex/engine/memory_mixin.py
+++ b/cortex/engine/memory_mixin.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from importlib.util import find_spec
 from pathlib import Path
 
 import aiosqlite
@@ -41,6 +42,7 @@ class MemoryMixin(EngineMixinBase):
             self._memory_manager = None
             self._memory_l1 = None
             self._memory_l3 = None
+            self._memory_ready = True
             logger.warning("Memory L1/L3 unavailable (degrading to no memory subsystem): %s", e)
             return
 
@@ -73,12 +75,30 @@ class MemoryMixin(EngineMixinBase):
             self._memory_manager = None
             self._memory_l1 = l1
             self._memory_l3 = l3
+            self._memory_ready = True
             logger.debug("Memory subsystem: lite (L1+L3 only, auto_embed=False)")
+            return
+
+        if not getattr(self, "_vec_available", False):
+            self._memory_manager = None
+            self._memory_l1 = l1
+            self._memory_l3 = l3
+            self._memory_ready = True
+            logger.info("Memory subsystem: partial (L1+L3) (optional L2 skipped: sqlite-vec unavailable)")
+            return
+
+        if find_spec("numpy") is None:
+            self._memory_manager = None
+            self._memory_l1 = l1
+            self._memory_l3 = l3
+            self._memory_ready = True
+            logger.info("Memory subsystem: partial (L1+L3) (optional L2 skipped: numpy not installed)")
             return
 
         # 1. Dense L2: Sovereign (v6) Vector Store (SQLite-vec)
         l2 = None
         encoder = None
+        l2_skip_reason: str | None = None
         try:
             from cortex.memory.encoder import AsyncEncoder
             from cortex.memory.sqlite_vec_store import SovereignVectorStoreL2
@@ -89,7 +109,10 @@ class MemoryMixin(EngineMixinBase):
 
             logger.info("Memory L2 (SovereignVectorStoreL2) initialized at %s", vector_path)
         except Exception as e:  # noqa: BLE001
-            logger.warning("Memory L2 unavailable (degrading to L1+L3 only): %s", e)
+            if isinstance(e, (ImportError, ModuleNotFoundError)) or "numpy" in str(e).lower():
+                l2_skip_reason = str(e)
+            else:
+                logger.warning("Memory L2 unavailable (degrading to L1+L3 only): %s", e)
 
         # 2. Vector Alpha (HDC/v7): Now primary.
         hdc_l2 = None
@@ -132,11 +155,21 @@ class MemoryMixin(EngineMixinBase):
             self._memory_l1 = l1
             self._memory_l3 = l3
 
-        logger.info(
-            "Memory subsystem: %s (HDC: %s)",
-            "full (L1+L2+L3)" if self._memory_manager else "partial (L1+L3)",
-            "active" if hdc_l2 else "inactive",
-        )
+        self._memory_ready = True
+
+        if self._memory_manager:
+            logger.info("Memory subsystem: full (L1+L2+L3) (HDC: %s)", "active" if hdc_l2 else "inactive")
+        elif l2_skip_reason:
+            logger.info(
+                "Memory subsystem: partial (L1+L3) (HDC: %s, optional L2 skipped: %s)",
+                "active" if hdc_l2 else "inactive",
+                l2_skip_reason,
+            )
+        else:
+            logger.info(
+                "Memory subsystem: partial (L1+L3) (HDC: %s)",
+                "active" if hdc_l2 else "inactive",
+            )
 
     @property
     def memory(self):

--- a/cortex/memory/models.py
+++ b/cortex/memory/models.py
@@ -15,8 +15,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-import numpy as np
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover - exercised via subprocess import test
+    np = None
 
 try:
     from cortex.extensions.axioms.topological_id import flake_gen
@@ -220,7 +224,7 @@ class CortexFactModel(BaseModel):
     @field_validator("embedding", mode="before")
     @classmethod
     def _validate_embedding(cls, v: Any) -> Any:
-        if isinstance(v, np.ndarray):
+        if np is not None and isinstance(v, np.ndarray):
             return v.tobytes()
         return v
 

--- a/cortex/migrations/core.py
+++ b/cortex/migrations/core.py
@@ -73,8 +73,10 @@ def _apply_base_schema(conn: sqlite3.Connection) -> None:
             conn.executescript(stmt)
         except Exception as e:
             msg = str(e).lower()
-            if "vec0" in str(stmt) or "no such module" in msg or "duplicate column" in msg:
-                logger.warning("Skipping schema statement: %s", e)
+            if "vec0" in str(stmt) or "no such module" in msg:
+                logger.debug("Skipping optional sqlite-vec schema statement: %s", e)
+            elif "duplicate column" in msg:
+                logger.debug("Skipping already-applied schema statement: %s", e)
             else:
                 raise
 
@@ -144,8 +146,10 @@ async def _apply_base_schema_async(conn: aiosqlite.Connection) -> None:
             await conn.executescript(stmt)
         except Exception as e:
             msg = str(e).lower()
-            if "vec0" in str(stmt) or "no such module" in msg or "duplicate column" in msg:
-                logger.warning("Skipping schema statement: %s", e)
+            if "vec0" in str(stmt) or "no such module" in msg:
+                logger.debug("Skipping optional sqlite-vec schema statement: %s", e)
+            elif "duplicate column" in msg:
+                logger.debug("Skipping already-applied schema statement: %s", e)
             else:
                 raise
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,6 +16,11 @@ The quickest way to get started:
 pip install cortex-persist
 ```
 
+This installs the supported core flow with deterministic fallback embeddings, which is enough for:
+- `cortex --version`
+- `cortex init`
+- `store -> verify -> export`
+
 After installing, verify it works:
 
 ```bash
@@ -23,13 +28,63 @@ cortex --version
 cortex init
 ```
 
+If you run in a headless environment without OS Keychain support, set `CORTEX_MASTER_KEY` or `CORTEX_VAULT_KEY` explicitly before the first write.
+
+On macOS, enable native keychain support with:
+
+```bash
+pip install "cortex-persist[platform]"
+```
+
 ### Optional Extras
+
+=== "Local Embeddings"
+    ```bash
+    pip install "cortex-persist[embeddings]"
+    ```
+    Adds `sentence-transformers` and `onnxruntime` for local semantic embeddings and reranking instead of deterministic fallback vectors.
+
+=== "Knowledge Watcher"
+    ```bash
+    pip install "cortex-persist[knowledge]"
+    ```
+    Adds ChromaDB-backed knowledge sync components used by the MCP knowledge watcher.
+
+=== "Acceleration"
+    ```bash
+    pip install "cortex-persist[acceleration]"
+    ```
+    Adds `numba` for optional JIT acceleration in specialized DSP and swarm modules.
 
 === "API Server"
     ```bash
     pip install cortex-persist[api]
     ```
-    Includes FastAPI, Uvicorn, and HTTPX for the REST API, dashboard, and MCP server.
+    Includes FastAPI, Uvicorn, HTTPX, and email validation for the REST API and dashboard.
+
+=== "MCP Server"
+    ```bash
+    pip install cortex-persist[mcp]
+    ```
+    Adds FastMCP runtime dependencies, HTML extraction helpers, and filesystem watchers for MCP and resilient gateway flows.
+
+=== "Daemon / Sidecars"
+    ```bash
+    pip install cortex-persist[daemon]
+    ```
+    Adds `aiofiles`, `aiohttp`, `arq`, and `watchdog` for daemon, SSE, relay, and background queue surfaces.
+
+=== "Platform Bindings"
+    ```bash
+    pip install cortex-persist[platform]
+    ```
+    Adds `pyobjc` bindings required by macOS keychain integration.
+
+=== "Authoring / YAML"
+    ```bash
+    pip install cortex-persist[authoring]
+    ```
+    Adds `PyYAML` for agent configs, genesis specs, and other YAML-driven authoring surfaces.
 
 === "Development"
     ```bash
@@ -65,8 +120,10 @@ Use this path when you want to contribute to CORTEX or run the latest unreleased
 git clone https://github.com/borjamoskv/Cortex-Persist.git
 cd Cortex-Persist
 python -m venv .venv && source .venv/bin/activate
-pip install -e ".[all]"
+pip install -e .
 ```
+
+Add extras on top only if you need those surfaces during development, for example `pip install -e ".[api,mcp,daemon,authoring,embeddings,dev]"`.
 
 ---
 
@@ -74,7 +131,7 @@ pip install -e ".[all]"
 
 ```bash
 cortex --version
-# cortex-persist, version 0.3.0b3
+# cortex, version 0.3.0b5
 ```
 
 ---
@@ -89,10 +146,10 @@ cortex init
 cortex status
 
 # Store your first fact
-cortex store my-project "Redis uses skip lists for sorted sets" --tags "redis,data-structures"
+cortex memory store my-project "Redis uses skip lists for sorted sets" --tags "redis,data-structures"
 ```
 
-This creates the database at `~/.cortex/cortex.db` with the full schema (facts, transactions, embeddings, consensus, and more).
+This creates the database at `~/.cortex/cortex.db` with the base ledger/fact schema plus optional vector and extended tables when the runtime supports them.
 
 ---
 
@@ -102,7 +159,7 @@ This creates the database at `~/.cortex/cortex.db` with the full schema (facts, 
 
 - Notifications use `osascript` (Notification Center)
 - Daemon installs as a `launchd` agent (`~/Library/LaunchAgents/`)
-- Native Keychain integration via `pyobjc`
+- Native Keychain integration via `pyobjc` (install `cortex-persist[platform]` if needed)
 
 ### Linux
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,8 @@
 # Quickstart
 
-Get CORTEX running in 5 minutes.
+Get the CORTEX trust core running in 5 minutes.
 
-> 🐍 **Python demo:** For a self-contained script that walks through the full core flow, run `python examples/demo_canonical.py` after installing.
+> 🐍 **Python demo:** For a self-contained script that walks through the supported trust-core flow, run `python examples/demo_canonical.py` after installing.
 
 ---
 
@@ -14,6 +14,12 @@ Get CORTEX running in 5 minutes.
 pip install cortex-persist
 ```
 
+For local semantic embeddings instead of deterministic fallback vectors:
+
+```bash
+pip install "cortex-persist[embeddings]"
+```
+
 ### Path B: From Source *(development)*
 
 ```bash
@@ -23,11 +29,13 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 ```
 
-For the API server and MCP:
+For the API server, MCP, daemon, or YAML-driven authoring surfaces:
 
 ```bash
-pip install cortex-persist[api]
+pip install "cortex-persist[api,mcp,daemon,authoring]"
 ```
+
+The supported base flow is `install -> init -> store -> verify`. Search, recall, MCP, REST, consensus, and SDK usage are extended surfaces; use them once you have the optional runtime pieces you need.
 
 ---
 
@@ -37,7 +45,7 @@ pip install cortex-persist[api]
 cortex init
 ```
 
-This creates `~/.cortex/cortex.db` with the full schema — facts, transactions, embeddings, consensus tables, and more.
+This creates `~/.cortex/cortex.db` with the core ledger/fact schema plus optional vector and extended tables when the runtime supports them.
 
 ---
 
@@ -47,16 +55,16 @@ Every fact is automatically hash-chained into an immutable ledger.
 
 ```bash
 # Store knowledge
-cortex store my-project "Redis uses skip lists for sorted sets" --tags "redis,data-structures"
+cortex memory store my-project "Redis uses skip lists for sorted sets" --tags "redis,data-structures"
 
 # Store a decision (with automatic provenance detection)
-cortex store my-project "We chose FastAPI over Flask for async support" --type decision
+cortex memory store my-project "We chose FastAPI over Flask for async support" --type decision
 
 # Store an error pattern
-cortex store my-project "OOM when batch size > 1024 on 8GB RAM" --type error
+cortex memory store my-project "OOM when batch size > 1024 on 8GB RAM" --type error
 
 # Store with explicit source
-cortex store my-project "Rate limit is 100 req/min" --type config --source "agent:gpt-4"
+cortex memory store my-project "Rate limit is 100 req/min" --type config --source "agent:gpt-4"
 ```
 
 ---
@@ -78,6 +86,8 @@ cortex compliance-report
 ```
 
 ---
+
+The remaining sections cover extended surfaces. They are available in-tree, but they are not the minimal support contract of the slim base install.
 
 ## 5. Search
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,25 +29,12 @@ classifiers = [
 
 dependencies = [
     "sqlite-vec>=0.1.6",
-    "sentence-transformers>=3.0",
-    "onnxruntime>=1.17",
     "click>=8.0",
     "rich>=13.0",
     "aiosqlite>=0.20.0",
-    "pyobjc-core; sys_platform == 'darwin'",
-    "pyobjc-framework-Cocoa; sys_platform == 'darwin'",
     "keyring>=25.7.0",
     "cryptography>=46.0.7",
-    "watchdog>=6.0.0",
     "pydantic>=2.0",
-    "PyYAML>=6.0",
-    "aiofiles",
-    "aiohttp",
-    "beautifulsoup4",
-    "arq",
-    "email-validator>=2.1.0",
-    "chromadb>=1.5.5",
-    "numba>=0.65.0",
 ]
 
 [project.urls]
@@ -62,6 +49,27 @@ api = [
     "uvicorn[standard]>=0.27",
     "httpx>=0.27",
     "sse-starlette>=0.10.3",
+    "email-validator>=2.1.0",
+]
+mcp = [
+    "mcp>=1.0",
+    "aiohttp",
+    "beautifulsoup4",
+    "markdownify>=0.13",
+    "watchdog>=6.0.0",
+]
+daemon = [
+    "aiofiles",
+    "aiohttp",
+    "arq",
+    "watchdog>=6.0.0",
+]
+platform = [
+    "pyobjc-core; sys_platform == 'darwin'",
+    "pyobjc-framework-Cocoa; sys_platform == 'darwin'",
+]
+authoring = [
+    "PyYAML>=6.0",
 ]
 dev = [
     "pytest>=8.0",
@@ -90,8 +98,18 @@ trends = [
     "pytrends>=4.9",
     "pandas>=2.0",
 ]
+embeddings = [
+    "sentence-transformers>=3.0",
+    "onnxruntime>=1.17",
+]
+knowledge = [
+    "chromadb>=1.5.5",
+]
+acceleration = [
+    "numba>=0.65.0",
+]
 all = [
-    "cortex-persist[api,dev,adk,toolbox,billing,cloud,trends]",
+    "cortex-persist[api,mcp,daemon,platform,authoring,dev,adk,toolbox,billing,cloud,trends,embeddings,knowledge,acceleration]",
 ]
 
 [project.scripts]

--- a/tests/test_optional_runtime_dependencies.py
+++ b/tests/test_optional_runtime_dependencies.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from cortex.database.core import connect_async, load_sqlite_vec_async
+
+
+def _blocked_import_env(tmp_path: Path, blocked_modules: list[str]) -> dict[str, str]:
+    repo_root = Path(__file__).resolve().parents[1]
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(
+        "\n".join(
+            [
+                "import builtins",
+                "_real_import = builtins.__import__",
+                f"_blocked_prefixes = {tuple(blocked_modules)!r}",
+                "def _blocked(name, globals=None, locals=None, fromlist=(), level=0):",
+                "    for prefix in _blocked_prefixes:",
+                "        if name == prefix or name.startswith(prefix + '.'):",
+                "            raise ImportError(f'{prefix} blocked by test harness')",
+                "    return _real_import(name, globals, locals, fromlist, level)",
+                "builtins.__import__ = _blocked",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        f"{tmp_path}:{repo_root}" if not pythonpath else f"{tmp_path}:{repo_root}:{pythonpath}"
+    )
+    return env
+
+
+def _blocked_numpy_env(tmp_path: Path) -> dict[str, str]:
+    return _blocked_import_env(tmp_path, ["numpy"])
+
+
+def test_memory_imports_without_numpy(tmp_path: Path) -> None:
+    env = _blocked_numpy_env(tmp_path)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from cortex.memory.models import MemoryEvent; "
+                "from cortex.memory.working import WorkingMemoryL1; "
+                "from cortex.memory.ledger import EventLedgerL3; "
+                "WorkingMemoryL1(); "
+                "MemoryEvent(role='user', content='x', token_count=1, session_id='s'); "
+                "print('ok')"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_engine_init_without_numpy_stays_quiet_about_optional_l2(tmp_path: Path) -> None:
+    env = _blocked_numpy_env(tmp_path)
+    db_path = tmp_path / "quiet-init.db"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                [
+                    "import asyncio",
+                    "import logging",
+                    "from cortex.engine import CortexEngine",
+                    f"db_path = r'{db_path}'",
+                    "logging.basicConfig(level=logging.INFO)",
+                    "",
+                    "async def main():",
+                    "    engine = CortexEngine(db_path=db_path)",
+                    "    try:",
+                    "        await engine.init_db()",
+                    "    finally:",
+                    "        await engine.close()",
+                    "",
+                    "asyncio.run(main())",
+                ]
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+    assert "Memory L2 unavailable" not in combined
+    assert "Skipping schema statement: no such module: vec0" not in combined
+    assert combined.count("Memory subsystem: partial (L1+L3)") == 1
+
+
+def test_cli_init_without_numpy_logs_partial_memory_once(tmp_path: Path) -> None:
+    env = _blocked_numpy_env(tmp_path)
+    db_path = tmp_path / "cli-init.db"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                [
+                    "import logging",
+                    "from click.testing import CliRunner",
+                    "from cortex.cli.main import cli",
+                    "logging.basicConfig(level=logging.INFO)",
+                    f"db_path = r'{db_path}'",
+                    "result = CliRunner().invoke(cli, ['init', '--db', db_path])",
+                    "print(result.output)",
+                    "raise SystemExit(result.exit_code)",
+                ]
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+    assert "Memory L2 unavailable" not in combined
+    assert "Skipping schema statement: no such module: vec0" not in combined
+    assert combined.count("Memory subsystem: partial (L1+L3)") == 1
+
+
+def test_cli_base_flow_without_extended_runtime_dependencies(tmp_path: Path) -> None:
+    env = _blocked_import_env(
+        tmp_path,
+        ["aiofiles", "aiohttp", "bs4", "arq", "email_validator", "watchdog", "yaml"],
+    )
+    env["CORTEX_NO_EMBED"] = "1"
+    db_path = tmp_path / "base-flow.db"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                [
+                    "from click.testing import CliRunner",
+                    "from cortex.cli.main import cli",
+                    f"db_path = r'{db_path}'",
+                    "runner = CliRunner()",
+                    "commands = [",
+                    "    ['--version'],",
+                    "    ['init', '--db', db_path],",
+                    "    ['memory', 'store', 'demo-project', 'base flow fact', '--db', db_path],",
+                    "    ['trust-ledger', 'verify', '--db', db_path],",
+                    "]",
+                    "for cmd in commands:",
+                    "    result = runner.invoke(cli, cmd)",
+                    "    print(result.output)",
+                    "    if result.exception:",
+                    "        raise result.exception",
+                    "    if result.exit_code:",
+                    "        raise SystemExit(result.exit_code)",
+                ]
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+    assert "blocked by test harness" not in combined
+    assert "ImportError" not in combined
+    assert "CORTEX v0.3.0b5 initialized" in combined
+    assert "Stored fact" in combined
+    assert "Ledger is VALID" in combined
+
+
+def test_cli_base_flow_without_keyring_when_env_master_key_is_set(tmp_path: Path) -> None:
+    env = _blocked_import_env(tmp_path, ["keyring", "AppKit", "Foundation", "Cocoa", "objc"])
+    env["CORTEX_NO_EMBED"] = "1"
+    env["CORTEX_MASTER_KEY"] = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
+    db_path = tmp_path / "env-master-key.db"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                [
+                    "from click.testing import CliRunner",
+                    "from cortex.cli.main import cli",
+                    f"db_path = r'{db_path}'",
+                    "runner = CliRunner()",
+                    "commands = [",
+                    "    ['--version'],",
+                    "    ['init', '--db', db_path],",
+                    "    ['memory', 'store', 'demo-project', 'env key fact', '--db', db_path],",
+                    "    ['trust-ledger', 'verify', '--db', db_path],",
+                    "]",
+                    "for cmd in commands:",
+                    "    result = runner.invoke(cli, cmd)",
+                    "    print(result.output)",
+                    "    if result.exception:",
+                    "        raise result.exception",
+                    "    if result.exit_code:",
+                    "        raise SystemExit(result.exit_code)",
+                ]
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, combined
+    assert "ImportError: keyring blocked by test harness" not in combined
+    assert "CORTEX v0.3.0b5 initialized" in combined
+    assert "Stored fact" in combined
+    assert "Ledger is VALID" in combined
+
+
+def test_mcp_package_import_is_lazy(tmp_path: Path) -> None:
+    env = _blocked_import_env(tmp_path, ["mcp.server.fastmcp", "markdownify", "bs4", "aiohttp"])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                [
+                    "import sys",
+                    "import cortex.mcp",
+                    "assert 'aiohttp' not in sys.modules",
+                    "assert 'bs4' not in sys.modules",
+                    "assert 'markdownify' not in sys.modules",
+                    "print('ok')",
+                ]
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+@pytest.mark.asyncio
+async def test_async_sqlite_vec_loader_enables_vec0(tmp_path: Path) -> None:
+    conn = await connect_async(str(tmp_path / "vec_bootstrap.db"))
+    try:
+        if not await load_sqlite_vec_async(conn):
+            pytest.skip("sqlite-vec unavailable in this runtime")
+
+        await conn.execute(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS test_vec USING vec0(embedding float[4])"
+        )
+        await conn.commit()
+    finally:
+        await conn.close()

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+
+
+def _dependency_names(values: list[str]) -> set[str]:
+    names: set[str] = set()
+    for value in values:
+        name = value.split(";", 1)[0].strip().split("[", 1)[0].split(">=", 1)[0].split("==", 1)[0]
+        names.add(name)
+    return names
+
+
+def test_heavy_dependencies_live_in_optional_extras() -> None:
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject.open("rb") as handle:
+        data = tomllib.load(handle)
+        project = data["project"]
+
+    base_dependencies = _dependency_names(project["dependencies"])
+    extras = project["optional-dependencies"]
+
+    assert "sentence-transformers" not in base_dependencies
+    assert "onnxruntime" not in base_dependencies
+    assert "chromadb" not in base_dependencies
+    assert "numba" not in base_dependencies
+    assert "aiohttp" not in base_dependencies
+    assert "beautifulsoup4" not in base_dependencies
+    assert "arq" not in base_dependencies
+    assert "email-validator" not in base_dependencies
+    assert "PyYAML" not in base_dependencies
+    assert "watchdog" not in base_dependencies
+    assert "aiofiles" not in base_dependencies
+    assert "pyobjc-core" not in base_dependencies
+    assert "pyobjc-framework-Cocoa" not in base_dependencies
+
+    assert _dependency_names(extras["embeddings"]) == {"sentence-transformers", "onnxruntime"}
+    assert _dependency_names(extras["knowledge"]) == {"chromadb"}
+    assert _dependency_names(extras["acceleration"]) == {"numba"}
+    assert _dependency_names(extras["api"]) >= {"fastapi", "uvicorn", "httpx", "sse-starlette", "email-validator"}
+    assert _dependency_names(extras["mcp"]) == {
+        "mcp",
+        "aiohttp",
+        "beautifulsoup4",
+        "markdownify",
+        "watchdog",
+    }
+    assert _dependency_names(extras["daemon"]) == {"aiofiles", "aiohttp", "arq", "watchdog"}
+    assert _dependency_names(extras["platform"]) >= {"pyobjc-core", "pyobjc-framework-Cocoa"}
+    assert _dependency_names(extras["authoring"]) == {"PyYAML"}
+    assert extras["all"] == [
+        "cortex-persist[api,mcp,daemon,platform,authoring,dev,adk,toolbox,billing,cloud,trends,embeddings,knowledge,acceleration]"
+    ]
+
+    assert (Path(__file__).resolve().parents[1] / "cortex" / "cli" / "assets" / "tips.json").exists()


### PR DESCRIPTION
## Summary
This PR keeps the supported public flow focused on the trust-core path (`install -> init -> store -> verify`) and moves optional runtime surfaces into explicit extras.

## Scope changed
- `pyproject.toml`: moved `pyobjc*` bindings from base dependencies to a new `platform` optional extra and included it in `all`.
- `tests/test_packaging_metadata.py`: asserts optional-runtime contract, including `pyobjc*` no longer in base dependencies.
- `tests/test_optional_runtime_dependencies.py`: covers base bootstrap without optional deps and headless key behavior.
- `docs/installation.md` + `README.md`: docs aligned with `platform` extra and lean install baseline.
- `cortex/crypto/keyring.py` + `cortex/crypto/__init__.py`: improved keyring portability in startup/import paths.

## Validation
- Commit includes new package-metadata and optional-runtime tests.
- Pre-push quality gates passed in branch (9/10 seals, 1 skipped).
- Follow-up smoke (post-merge): `pip install dist` clean, `cortex --version`, `cortex init`, `cortex memory store`, `cortex trust-ledger verify`.

## Residuals / migration note
- macOS keychain support now requires `cortex-persist[platform]` explicitly.