### PR TITLE
docs: align current trust and architecture surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
         with:
           files: coverage.xml
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **Trust infrastructure for autonomous AI: cryptographic verification, audit trails, epistemic containment, and agent memory.**
 
-> **Package:** `cortex-persist v0.3.1-b1` | **Engine:** `v8` | **License:** `Apache-2.0` | **Python:** `>=3.10`
+> **Package:** `cortex-persist v0.3.0b2` | **Engine:** `v8` | **License:** `Apache-2.0` | **Python:** `>=3.10`
 
 **Quick Navigation:** [SYSTEM DIRECTIVES](#11-agent-manifest--roles--authority-boundaries) · Agent Manifest §1.1 · Axioms §2 · Invariants §3 · Write-Path §4 · Read-Path §4.1 · Architecture §5 · Dev Protocol §6 · Failure Signatures §8
 
@@ -26,7 +26,7 @@
 | :---: | :--- | :--- |
 | **[P0]** | **Treat Generative Output as Conjecture** — route ALL state mutations through deterministic guards before persistence | Always |
 | **[P0]** | **Never Bypass Guards** — do not write code that circumvents the Write-Path Contract or downgrades validation errors | Always |
-| **[P0]** | **Verify Hash Continuity** — do not mutate `ledger.py` or any state-persisting path without ensuring cryptographic auditability | Any ledger/engine change |
+| **[P0]** | **Verify Hash Continuity** — do not mutate `cortex/ledger/` or any state-persisting path without ensuring cryptographic auditability | Any ledger/engine change |
 | **[P2]** | **Enforce Axioms** — apply AX-041 to AX-046 (see §2) in all architectural decisions | Architecture work |
 
 ### Decision Gate §0 — Agent Routing Tree (execute before any action)
@@ -35,7 +35,7 @@
 Am I reading this file for the first time?  → Read §1, §2, §3 in full. No action until done.
 Am I about to write code?                   → STOP. Is it on a CRITICAL surface? → Read affected tests first.
 Am I debugging a failure?                   → Go to §8 (Failure Signatures) before touching state.
-Am I performing a schema migration?         → Run `alembic history --verbose` NOW. Abort if output is unclear.
+Am I performing a schema migration?         → Review `cortex/migrations/` and `cortex/migrations/registry.py` NOW. Abort if rollback path is unclear.
 Am I starting a new session on this repo?   → Execute Multi-Session Handoff Protocol (§6.4) first.
 ```
 
@@ -46,7 +46,7 @@ Am I starting a new session on this repo?   → Execute Multi-Session Handoff Pr
 **CORTEX Persist** is a local-first trust substrate for autonomous, tool-using, and multi-agent AI systems. It persists facts, enforces deterministic validation boundaries, maintains cryptographic auditability, and treats generative output as conjecture until externally verified.
 
 - **Epistemic Containment:** Generative output is a probabilistic proposal — useful, invalid, partial, or dangerous. System state may only be mutated after crossing deterministic validation boundaries: guards, typed interfaces, schemas, tests, cryptographic logging, and external verification when required.
-- **The Python Paradox (🛑):** CORTEX is built in Python to maximize *Shipping Velocity* and *Developer Adoption*. Mitigation is the **Byzantine Boundary**: Python as orchestration glue, Rust (via `rustchain-mcp`), SQLite-Vec, and ONNX as immutable cores. We prioritize **Tamper-Evidence** over language-level safety. Trust model: `f < n/3` faulty nodes tolerated; cryptographic primitives are Ed25519 (signatures) and SHA3-256 (hashing).
+- **The Python Paradox (🛑):** CORTEX is built in Python to maximize *Shipping Velocity* and *Developer Adoption*. Mitigation is the **Byzantine Boundary**: Python as orchestration glue, Rust (via `rustchain-mcp`), SQLite-Vec, and ONNX as immutable cores. We prioritize **Tamper-Evidence** over language-level safety. Trust model: `f < n/3` faulty nodes tolerated; the current sovereign ledger path uses Ed25519 for signatures and SHA-256 for continuity, while some audit/signature subsystems also use SHA3-256.
 - **Audit Trails vs. Authorization (📜):** CORTEX is a **Forensic Audit Sidecar** for MCP — not “Tamper-Proof” (an architectural illusion), but **Tamper-Evident**. The Master Ledger commits every action to an immutable hash chain. The cost of non-compliance is infinite.
 
 ---
@@ -94,7 +94,7 @@ All agents operating in this repository MUST self-identify by role before acting
 5. **Encryption:** Sensitive data MUST NOT be stored unencrypted.
 6. **Deterministic State:** Stochastic outputs MUST NOT mutate persistent state without deterministic validation.
 7. **Migration Safety:** Schema changes MUST preserve migration safety, auditability, and rollback awareness.
-8. **Architectural Boundaries:** CLI modules are thin wrappers. Business logic belongs in `engine/`, `services/`, or `managers/`.
+8. **Architectural Boundaries:** CLI modules are thin wrappers. Business logic belongs in `cortex/engine/`, `cortex/services/`, or other package-level modules under `cortex/`.
 9. **Failure Locality:** Invalid state must be rejectable and safely abortable at any point.
 
 ### ❌ Never-Do (Anti-Patterns)
@@ -102,8 +102,8 @@ All agents operating in this repository MUST self-identify by role before acting
 - **NO** `float` for finance or scoring-sensitive paths — use `Decimal`.
 - **NO** `time.sleep()` in async code — use `asyncio.sleep()`.
 - **NO** bare `print()` in core paths — use standard `logging` or Rich.
-- **NO** business logic in `cli/*_cmds.py`.
-- **NO** modifications to `ledger.py` without understanding hash continuity and test coverage.
+- **NO** business logic in `cortex/cli/*_cmds.py`.
+- **NO** modifications to `cortex/ledger/` without understanding hash continuity and test coverage.
 - **NO** schema changes without a migration review.
 - **NO** storing secrets in plaintext metadata.
 - **NO** bypassing guards on write paths.
@@ -118,9 +118,9 @@ All agents operating in this repository MUST self-identify by role before acting
 
 All non-trivial state mutations MUST follow this unidirectional flow.
 
-> 🛑 **ABORT CONDITION:** If a proposal fails validation or lacks a valid `CORTEX-TAINT` signature, execute the compensating Saga sequence in reverse and abort immediately.
+> 🛑 **ABORT CONDITION:** If a proposal fails validation or reaches a taint-enforced ingest path without a valid `CORTEX-TAINT` signature, execute the compensating Saga sequence in reverse and abort immediately.
 >
-> **`CORTEX-TAINT` Format:** `taint:{agent_id}:{session_id}:{timestamp_iso8601}:{sha3_256_of_payload}` — A cryptographic attribution token that must be present on every fact insert. Generated by the taint engine at proposal time. Absence = automatic SAGA-1 rejection.
+> **`CORTEX-TAINT` Target Format:** `taint:{agent_id}:{session_id}:{timestamp_iso8601}:{sha3_256_of_payload}` — The intended universal attribution token format for provenance-aware inserts. Some ingestion paths already attach or enforce taint explicitly; others do not yet hard-fail on absence. Treat full universal enforcement as a target-state invariant until all write paths are aligned.
 
 ```text
 [Generative Proposal]
@@ -165,7 +165,7 @@ Read operations are NOT free. They MUST follow these rules:
 
 1. **Query Authorization:** All read requests MUST be scoped to the caller's `tenant_id`. Cross-tenant reads are a P0 violation.
 2. **Taint Propagation:** Facts retrieved from a tainted source MUST carry the taint flag in the response. Callers MUST NOT strip taint metadata.
-3. **Consistency Level:** Default read consistency is `READ_COMMITTED`. Reads on `ledger.py` MUST use `SERIALIZABLE` isolation.
+3. **Consistency Level:** Default read consistency is `READ_COMMITTED`. Reads on `cortex/ledger/` MUST use `SERIALIZABLE` isolation.
 4. **Cache Coherence:** Cached reads MUST be invalidated on any write to the same `tenant_id` scope. Stale cache serving tainted-as-clean data is a Write-Path Contract violation.
 5. **No Inference from Reads:** Read results MUST NOT be used to infer or reconstruct facts that were not explicitly persisted. Speculation from read data = epistemic containment breach.
 
@@ -190,17 +190,16 @@ Read operations are NOT free. They MUST follow these rules:
 
 | Path | Risk | Operational Notes |
 | :--- | :---: | :--- |
-| `engine/` | **CRITICAL** | Core CRUD, Kinetic Engines (Annihilator/Crystallizer). |
-| `ledger.py` | **CRITICAL** | Hash-chain integrity and trust continuity. |
-| `migrations/` | **CRITICAL** | Irreversible production impact. |
-| `memory/` | **CRITICAL** | Large public API surface. Highly sensitive to state corruption. |
-| `guards/` | **HIGH** | Admission, contradiction, and dependency surfaces. |
-| `verification/` | **HIGH** | Formal or deterministic validation surfaces. |
-| `ops/` | **HIGH** | Git-Ledger entanglement & KV-Aware routing. |
-| `routes/` | **HIGH** | External API contract. Must remain typed and stable. |
-| `cli/` | *Medium* | Thin wrappers only. No business logic. |
-| `daemon/` | *Medium* | Core Daemons: Chaos (Immunity), Maxwell (Exergy). |
-| `llm/` | *Medium* | Provider routing, caching, hedging, validation. |
+| `cortex/engine/` | **CRITICAL** | Core CRUD, Kinetic Engines (Annihilator/Crystallizer). |
+| `cortex/ledger/` | **CRITICAL** | Hash-chain integrity and trust continuity. |
+| `cortex/migrations/` | **CRITICAL** | Irreversible production impact. |
+| `cortex/memory/` | **CRITICAL** | Large public API surface. Highly sensitive to state corruption. |
+| `cortex/guards/` | **HIGH** | Admission, contradiction, and dependency surfaces. |
+| `cortex/verification/` | **HIGH** | Formal or deterministic validation surfaces. |
+| `cortex/routes/` | **HIGH** | External API contract. Must remain typed and stable. |
+| `cortex/cli/` | *Medium* | Thin wrappers only. No business logic. |
+| `cortex/extensions/daemon/` | *Medium* | Core daemon and background-runtime surfaces. |
+| `cortex/extensions/llm/` | *Medium* | Provider routing, caching, hedging, validation. |
 
 ---
 
@@ -235,7 +234,7 @@ A change is **INCOMPLETE** and will be rejected if any step is missing:
 
 1. - [ ] **Tests** — coverage for modified or new behavior.
 2. - [ ] **Typing** — explicit type hints on all public surfaces.
-3. - [ ] **Migrations** — for schema changes: `alembic history --verbose`, document exact downgrade target, assess backward compat, confirm irreversibility.
+3. - [ ] **Migrations** — for schema changes: review the affected files in `cortex/migrations/`, document exact downgrade/rollback strategy, assess backward compat, and confirm irreversibility.
 4. - [ ] **Trust Impact** — ledger/audit impact review for any guard, encryption, taint, or tenant isolation change.
 5. - [ ] **Async Correctness** — no blocking calls, proper timeout/cancellation, resource cleanup verified.
 6. - [ ] **Documentation** — update if public behavior, API route contract, or CLI/API parity changes.
@@ -280,7 +279,7 @@ To govern domain-specific agent behavior without inflating this root file, place
 ```text
 cortex/engine/AGENTS.md      → Engine mutation rules (Annihilator/Crystallizer safety gates)
 cortex/memory/AGENTS.md      → Memory surface constraints (tenant isolation, fact aging)
-cortex/migrations/AGENTS.md  → Migration safety protocol (alembic invariants, rollback targets)
+cortex/migrations/AGENTS.md  → Migration safety protocol (migration invariants, rollback targets)
 ```
 
 **Rule:** Root AGENTS.md always takes precedence. Sub-files **augment** global rules — never contradict them.
@@ -295,10 +294,10 @@ When auditing existing code, these observable signals indicate a violation has a
 | :--- | :--- | :---: | :--- |
 | `float` in financial or scoring variable | Anti-Pattern #1 | HIGH | Replace `float` → `Decimal`; audit all callers. |
 | `time.sleep()` inside `async def` | Anti-Pattern #2 | CRITICAL | Replace → `asyncio.sleep()`. |
-| Bare `print()` in `engine/`, `memory/`, `guards/` | Anti-Pattern #3 | MEDIUM | Replace → `logging.getLogger(__name__)`. |
+| Bare `print()` in `cortex/engine/`, `cortex/memory/`, `cortex/guards/` | Anti-Pattern #3 | MEDIUM | Replace → `logging.getLogger(__name__)`. |
 | Bare `except Exception:` anywhere in core paths | Coding Rule #2 | MEDIUM | Narrow to specific exception type. |
-| Business logic found in `cli/*_cmds.py` | Arch. Boundary | HIGH | Refactor to `services/` or `managers/`. |
+| Business logic found in `cortex/cli/*_cmds.py` | Arch. Boundary | HIGH | Refactor to `cortex/services/` or another package-level runtime module. |
 | Ledger write with no prior guard call in call stack | Write-Path Contract | CRITICAL | Insert guard invocation before all writes. |
-| Missing `CORTEX-TAINT` on any fact insert | Write-Path Contract | CRITICAL | Audit `engine/` — add taint to all write paths. |
-| Schema change with no alembic revision entry | Migration Safety | CRITICAL | Run `alembic revision --autogenerate`; review diff before apply. |
+| Missing `CORTEX-TAINT` on a taint-enforced or provenance-critical fact insert | Write-Path Contract | CRITICAL | Audit the ingest path — enforce taint there or narrow doctrine to the actual enforcement scope. |
+| Schema change with no matching `cortex/migrations/` entry | Migration Safety | CRITICAL | Add or update the corresponding migration module or SQL artifact; review rollback path before apply. |
 | Plaintext secret in any metadata dict or JSON field | Encryption Invariant | **P0** | Rotate secret immediately; encrypt at rest; audit exposure window. |

--- a/README.es.md
+++ b/README.es.md
@@ -28,17 +28,28 @@ CORTEX es una **capa de confianza (drop-in trust layer)** para la memoria de IA.
 pip install cortex-persist
 cortex init
 
-# 2. Almacenar una memoria (con hash SHA-256 y encadenada)
-cortex memory store --agent "risk-bot" --content "Transacción marcada: Discordancia de IP"
+# 2. Guardar un hecho
+cortex store mi-proyecto "Redis usa skip lists para sorted sets" --tags "redis,data-structures"
 
-# 3. Verificar integridad (detecta manipulación manual de la base de datos)
-cortex verify ledger
+# 3. Guardar una decisión
+cortex store mi-proyecto "Elegimos FastAPI sobre Flask por soporte async" --type decision
+
+# 4. Buscar y recordar
+cortex search "framework web async" --project mi-proyecto
+cortex recall mi-proyecto
+
+# 5. Verificar integridad
+cortex verify 1
+cortex trust-ledger verify
+
+# 6. Generar un snapshot de compliance
+cortex compliance-report
 ```
 
 **¿Qué acaba de pasar?**
--   **Libro de Contabilidad Inmutable**: El hecho se almacenó en un registro criptográfico de solo adición.
--   **Encadenamiento de Hash**: El registro fue encadenado mediante SHA-256 al bloque anterior.
--   **Sello Merkle**: Todo el estado fue sellado con una prueba de linaje verificable.
+-   **Persistencia verificable**: Los hechos y decisiones se guardaron con recibos auditables.
+-   **Encadenamiento de hash**: Las escrituras quedaron enlazadas en el ledger criptográfico.
+-   **Verificación explícita**: Puedes validar un hecho concreto o toda la cadena cuando necesites evidencia.
 
 ---
 
@@ -50,15 +61,23 @@ from cortex import CortexEngine
 
 async def main():
     engine = CortexEngine()
-    
-    # Almacenar con recibo criptográfico
-    receipt = await engine.store_fact(
-        content="Usuario aprobó transacción de $5,000",
+
+    fact_id = await engine.store(
+        project="demo-agent",
+        content="Usuario aprobó una transacción de $5,000",
         fact_type="decision"
     )
-    
-    # Verificar prueba de integridad
-    assert await engine.verify(receipt.hash) == True
+
+    results = await engine.search(
+        "aprobación de transacción",
+        top_k=3,
+        project="demo-agent",
+    )
+    ledger = await engine.verify_ledger()
+
+    assert fact_id
+    assert results
+    assert ledger.get("valid") is True
 
 asyncio.run(main())
 ```
@@ -80,9 +99,12 @@ asyncio.run(main())
 
 ### Documentación
 
-- [**Arquitectura**](docs/ARCHITECTURE.md) — Sellos Merkle y encadenamiento de hash.
+- [**Superficie pública del producto**](docs/product-surface.md) — Límite recomendado entre producto y tooling amplio del repo.
+- [**Inicio rápido**](docs/quickstart.md) — Ruta guiada de adopción.
+- [**Referencia CLI**](docs/cli.md) — Comandos públicos recomendados.
+- [**Referencia API REST**](docs/api.md) — Superficie HTTP core y capas experimentales.
 - [**Seguridad y Confianza**](docs/SECURITY_TRUST_MODEL.md) — Invariantes criptográficas.
-- [**Referencia de API**](docs/api.md) — Documentación completa de SDK y CLI.
+- [**Arquitectura**](docs/architecture.md) — Vista amplia del sistema y del repo.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,12 +1,12 @@
 # ROADMAP
 
 > **Tamper-Evident Decision Lineage for AI Systems**
-> *Updated: Spring 2026 · Status: v0.3.0 in active development*
+> *Updated: Spring 2026 · Status: planning snapshot for the current `0.3.x` release line*
 > *Classification: Planning snapshot. Current release truth lives in `CHANGELOG.md`.*
 
 ---
 
-## ✅ v0.3.0 — Current (Foundation & Integrity)
+## ✅ Current 0.3.x Line (Foundation & Integrity)
 
 **Local-First Sovereign Trust layer.**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,19 +19,26 @@ You will receive an acknowledgment within 48 hours and a detailed response withi
 
 CORTEX is built security-first:
 
-- **SHA-256 hash-chained ledger** — tamper-evident fact storage
+- **SHA-256 sovereign ledger continuity** — tamper-evident fact storage
 - **Merkle tree checkpoints** — batch integrity verification
 - **Privacy Shield** — 11-pattern secret detection at ingress
 - **AST Sandbox** — safe LLM code execution without `eval()`
 - **RBAC** — 4-role access control (admin, editor, viewer, auditor)
 - **Security Headers Middleware** — CSP, HSTS, X-Frame-Options
-- **Input Sanitization** — all user inputs validated and escaped
+- **Input Sanitization** — validated ingress surfaces apply sanitization and schema checks
 
 ## Supply Chain Security
 
+### Cryptographic Contract
+
+The current shipped package uses **SHA-256** for sovereign ledger continuity and
+Merkle lineage. Some audit or signature-oriented subsystems also use
+**SHA3-256**, but those should not be read as redefining the canonical ledger
+continuity algorithm unless the implementation is explicitly migrated.
+
 ### Release Signing
 
-All CORTEX releases published to PyPI are **cryptographically signed using [Sigstore](https://sigstore.dev/)**. This provides:
+The release workflow **signs the built distribution artifacts using [Sigstore](https://sigstore.dev/)** after the publish step. This provides:
 
 - **Provenance verification** — Confirm artifacts were built by our CI pipeline
 - **Tamper detection** — Verify packages haven't been modified after signing
@@ -43,8 +50,8 @@ To verify a release:
 pip install sigstore
 sigstore verify identity \
   --cert-oidc-issuer https://token.actions.githubusercontent.com \
-  --cert-identity https://github.com/borjamoskv/Cortex-Persist/.github/workflows/release.yml@refs/tags/v0.3.0 \
-  cortex_persist-0.3.0.tar.gz
+  --cert-identity https://github.com/borjamoskv/Cortex-Persist/.github/workflows/release.yml@refs/tags/v0.3.0b2 \
+  cortex_persist-0.3.0b2.tar.gz
 ```
 
 ### Container Image Scanning
@@ -73,10 +80,10 @@ CORTEX assumes:
 
 | Vector | Mitigation |
 | :--- | :--- |
-| Tampered package on PyPI | Sigstore signature verification |
+| Tampered release artifact | Sigstore signature verification |
 | Vulnerable dependency | pip-audit in CI, Dependabot alerts |
 | Compromised container image | Trivy scan (CRITICAL/HIGH block) |
-| Memory tampering | SHA-256 hash chain + Merkle checkpoints |
+| Memory tampering | SHA-256 sovereign hash chain + Merkle checkpoints |
 | Unauthorized access | RBAC + API key + JWT authentication |
 | Secret leakage | Privacy Shield (11 regex patterns at ingress) |
 | **Composition leakage** | **Holistic cross-field correlation analysis at ingress** |

--- a/docs/MEJORALO-MAC-TELEMETRY-RFC.md
+++ b/docs/MEJORALO-MAC-TELEMETRY-RFC.md
@@ -1,8 +1,13 @@
 # RFC: MEJORAlo Mac Telemetry (mac_control)
 
-**Status:** Implemented (v8.0)  
+**Status:** Concept / target-state RFC
 **Author:** Sovereign CORTEX (Antigravity-Omega)  
 **Context:** MEJORAlo X-Ray engine extension  
+
+> This RFC still describes a proposed `mac_control` module and companion
+> `mac-maestro-omega` architecture. Neither is present as a current code surface in
+> this repository snapshot, so read the document as design intent rather than as an
+> implemented feature map.
 
 ---
 

--- a/docs/RFC-CORTEX-MEMORY-OS.md
+++ b/docs/RFC-CORTEX-MEMORY-OS.md
@@ -33,16 +33,16 @@ The Memory OS is composed of four heavily isolated modules:
 Responsible for preventing unverified, low-exergy conversational data from entering the CORTEX Ledger. 
 - **Extract:** Parses entities, intent, and relationships from the episodic context.
 - **Consolidate:** Resolves collisions, contradictions, and redundancy (compresses `H(X)`).
-- **Store:** Commits to the `ledger.py` explicitly as semantic/persistent memory.
+- **Store:** Commits to the local L3 memory ledger in `cortex/memory/ledger.py` as semantic/persistent memory.
 - **Impact:** Expected 90% reduction in token retrieval overhead (Mem0 baseline).
 
-### 3.2. `cortex/policy/memory_os.py` (The OS Hypervisor)
+### 3.2. `cortex/extensions/policy/memory_os.py` (The OS Hypervisor)
 Enforces access and mutation policies across distinct memory domains.
 - **Clases:** `[Working]`, `[Episodic]`, `[Semantic]`
 - Agents do not run a "global search". The `MemoryOS` daemon routes exact requests to the required tier, metering token budgets.
 
-### 3.3. `cortex/context/hiagent.py` (Subgoal Compression)
-Prevents attention collapse during long-horizon loops (e.g., NightShift).
+### 3.3. Subgoal Compression (target-state concept)
+This RFC proposed a `cortex/context/hiagent.py` surface, but that module is not present in the current tree snapshot. Treat this section as target-state design, not as implemented topology.
 - Aggregates action-observation loops during a given step.
 - Once the step succeeds, it forces **Amnesia Local**: compressing the trace into a single derivative crystal and flushing the raw trace.
 - Leaves zero "code ghosts" behind.
@@ -60,4 +60,4 @@ Coordinates the RAG bypass. Replaces standard vector search with a targeted caus
 4. Unification via the `cortex.engine` RAG interface.
 
 ## 5. Security & Trust Impact
-Continues strictly relying on `ledger.py` for immutable writes. The new admission pipeline serves as a pre-ledger Guard, enhancing the verification described in `SECURITY_TRUST_MODEL.md`. No changes permitted to core crypto boundaries.
+Continues relying on `cortex/memory/ledger.py` for L3 memory event writes and on the canonical `cortex/ledger/` package for trust-ledger integrity surfaces. The new admission pipeline serves as a pre-ledger guard, enhancing the verification described in `SECURITY_TRUST_MODEL.md`. No changes permitted to core crypto boundaries.

--- a/docs/STATUS_WAVE5_V6.md
+++ b/docs/STATUS_WAVE5_V6.md
@@ -25,16 +25,17 @@ y qué ha sido superado por la arquitectura v6.
 | Feature | Estado | Evidencia |
 |---|---|---|
 | Merkle Tree (MerkleTree class) | ✅ **IMPLEMENTADO** | `cortex/consensus/merkle.py` — CORTEX v5.0 header, producción |
-| Hash-chain ledger | ✅ **IMPLEMENTADO** | `cortex/consensus/ledger.py` |
+| Hash-chain ledger | ✅ **IMPLEMENTADO** | `cortex/ledger/` (canónico) + `cortex/consensus/ledger.py` (bridge de compatibilidad) |
 | Vote ledger | ✅ **IMPLEMENTADO** | `cortex/consensus/vote_ledger.py` |
 | Byzantine consensus | ✅ **IMPLEMENTADO** | `cortex/consensus/byzantine.py` + `cortex/swarm/byzantine.py` |
 | Merkle checkpoints periódicos (cada 1000 tx) | ⚠️ **PARCIAL** | Merkle existe; scheduler de checkpoints automáticos — verificar |
-| CLI `cortex ledger checkpoint/verify/export` | ❌ **PENDIENTE** | No encontrado en `cortex/cli/` |
+| CLI `cortex trust-ledger verify` | ✅ **IMPLEMENTADO** | `cortex/cli/ledger.py` se monta como `trust-ledger verify` en la surface core |
+| CLI checkpoint/export de ledger | ⚠️ **PARCIAL** | `checkpoint` existe en `cortex/cli/ledger.py`, pero la surface core actual no lo expone por defecto; `export` no aparece en la CLI actual |
 | External anchoring (blockchain/timestamp) | ❌ **NO APLICA** | Deferido a Wave 6+ |
-| `merkle_roots` table in schema | ⚠️ **VERIFICAR** | `mig_ledger.py` existe — contenido a auditar |
+| `merkle_roots` table in schema | ✅ **IMPLEMENTADO** | `cortex/ledger/ledger_core.py` + `cortex/migrations/mig_ledger.py` |
 
-**Deuda concreta:** Falta el CLI `cortex ledger` con subcomandos `checkpoint`, `verify`, `export`.  
-El código Merkle existe; solo falta la interfaz de usuario.
+**Deuda concreta:** La interfaz ya no está ausente, pero sí fragmentada.
+La surface core expone `cortex trust-ledger verify`; `checkpoint` existe en `cortex/cli/ledger.py` pero queda fuera del allowlist core actual, y `export` no aparece en la CLI vigente.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,10 +11,18 @@ CORTEX is a **trust infrastructure engine** that provides cryptographic verifica
 
 To enforce this, it combines a relational database with vector embeddings, hash-chained transactions, Merkle tree integrity, multi-agent consensus, and privacy protection — running locally on SQLite or scaling to AlloyDB + Qdrant + Redis for enterprise deployments.
 
+This page describes the broader repository and system architecture. For the recommended product
+boundary and first integration surface, start with [Public Product Surface](product-surface.md).
+For the agent-layer vocabulary used in this repo, see [Agent Taxonomy](agents/AGENT-TAXONOMY.md).
+
+Today, the default FastAPI core bootstrap still fails closed unless `CORTEX_STORAGE=local`.
+Postgres/Turso storage paths exist in the repository, but they remain storage/tooling surfaces rather
+than the default public API bootstrap contract.
+
 ```mermaid
 graph TB
     subgraph Interfaces
-        CLI["CLI<br/>90+ commands"]
+        CLI["CLI<br/>Broad command surface"]
         API["REST API<br/>FastAPI"]
         MCP["MCP Server<br/>Model Context Protocol"]
         GraphQL["GraphQL<br/>(coming Q2)"]
@@ -22,7 +30,7 @@ graph TB
 
     subgraph Gateway["Trust Gateway"]
         Auth["Auth Manager<br/>HMAC-SHA256 + RBAC"]
-        Privacy["Privacy Shield<br/>11 secret patterns"]
+        Privacy["Privacy Shield<br/>Multiple secret patterns"]
         RateLimit["Rate Limiter<br/>Sliding window"]
         Security["Security Headers<br/>CSP, HSTS"]
     end
@@ -49,7 +57,7 @@ graph TB
     end
 
     subgraph Services["Platform Services"]
-        Daemon["Self-Healing Daemon<br/>13 monitors"]
+        Daemon["Self-Healing Daemon<br/>Multiple monitors"]
         Compactor["Compaction Sidecar"]
         Sync["Sync Engine"]
         Notifications["Notification Bus"]
@@ -159,17 +167,19 @@ Para más detalles, consulta: [**OMEGA_MANIFOLD.md**](https://github.com/borjamo
 
 ## Module Reference
 
+Paths below are relative to the `cortex/` package root unless noted otherwise.
+
 ### Engine Layer
 
 | Module | Purpose |
 |:---|:---|
 | `engine/__init__.py` | `CortexEngine` — Composite orchestrator (sync + async) |
-| `engine_async.py` | `AsyncCortexEngine` — Native async for REST API |
+| `engine/search_mixin.py` | Semantic search over persisted facts |
 | `engine/store_mixin.py` | `store()`, `store_many()`, `deprecate()`, `update()` |
 | `engine/query_mixin.py` | `search()`, `recall()`, `history()` |
-| `engine/consensus_mixin.py` | `vote()`, `get_votes()` |
-| `engine/sync_compat.py` | Synchronous fallbacks for CLI |
-| `ledger.py` | Hash chain + Merkle tree management (`SovereignLedger`) |
+| `engine/transaction_mixin.py` | Transaction history, checkpoints, and ledger verification |
+| `engine/sync_mixin.py` | Synchronous compatibility helpers |
+| `ledger/` | Hash chain + Merkle tree management (`SovereignLedger`) |
 | `engine/snapshots.py` | Database snapshot creation/restoration |
 | `engine/models.py` | `Fact` data model and row mapping |
 
@@ -177,13 +187,13 @@ Para más detalles, consulta: [**OMEGA_MANIFOLD.md**](https://github.com/borjamo
 
 | Module | Purpose |
 |:---|:---|
-| `api/` | FastAPI application with CORS, rate limiting, security headers |
-| `routes/facts.py` | CRUD + Voting endpoints |
-| `routes/search.py` | Semantic + Graph-RAG search |
+| `api/core.py` | FastAPI bootstrap, middleware, and fail-closed local storage gating |
+| `routes/__init__.py` | Core vs experimental route mounting |
+| `routes/facts.py` | Core fact CRUD, recall, and verification-adjacent endpoints |
+| `routes/ledger.py` | Ledger status, verification, and checkpoint endpoints |
 | `routes/admin.py` | API key management + system status |
-| `routes/stripe.py` | Stripe webhook handler for billing |
 | `auth/` | HMAC-SHA256 authentication + RBAC |
-| `gate/` | Rate limiting, validation, request filtering |
+| `api/middleware.py` | Rate limiting, validation, and request filtering |
 
 ### Search & Embeddings
 
@@ -223,7 +233,7 @@ Para más detalles, consulta: [**OMEGA_MANIFOLD.md**](https://github.com/borjamo
 | `timing/` | Heartbeat-based time tracking |
 | `telemetry/` | OpenTelemetry-compatible span tracing |
 | `mcp/` | Model Context Protocol server |
-| `cli/` | 90+ CLI commands via Click |
+| `cli/` | Broad Click-based CLI surface |
 | `migrations/` | Versioned schema migrations |
 | `storage/` | SQLite + Turso storage backends |
 
@@ -414,7 +424,7 @@ erDiagram
 | **Authorization** | RBAC: `SYSTEM`, `ADMIN`, `AGENT`, `VIEWER` |
 | **Tenant Isolation** | All queries scoped by `tenant_id` |
 | **Data Integrity** | SHA-256 hash chain + Merkle trees |
-| **Privacy** | 11-pattern secret detection at ingress |
+| **Privacy** | Multi-pattern secret detection at ingress |
 | **Secrets** | AES-256-GCM encrypted vault |
 | **Code Safety** | AST Sandbox for LLM-generated code |
 | **Rate Limiting** | Sliding window per IP |
@@ -425,7 +435,7 @@ erDiagram
 ## Testing
 
 ```bash
-# All tests (1,621+ functions, 60s timeout)
+# Full test suite
 make test
 
 # Fast tests only (no torch imports)
@@ -437,4 +447,4 @@ make test-slow
 
 **Isolation**: Tests use `config.reload()` + autouse fixtures for zero state leakage.
 
-**Coverage**: 1,621+ test functions covering engine, API, CLI, consensus, search, and security.
+**Coverage**: Broad automated coverage across engine, API, CLI, consensus, search, and security.

--- a/docs/architecture/ARCHITECTURAL_AUDIT.md
+++ b/docs/architecture/ARCHITECTURAL_AUDIT.md
@@ -4,6 +4,12 @@
 **Scope:** `./cortex/` (42,613+ LOC)  
 **Auditor:** Kimi Code CLI  
 
+> Historical audit snapshot. The file paths cited in findings below reflect the
+> audited February 2026 layout and should not be read as the current package map.
+> Nearby present-day surfaces usually live under `cortex/routes/`,
+> `cortex/events/`, `cortex/extensions/daemon/`, `cortex/extensions/llm/`, and
+> `cortex/ledger/`.
+
 ---
 
 ## Executive Summary

--- a/docs/architecture/CORTEX-CAPABILITIES.md
+++ b/docs/architecture/CORTEX-CAPABILITIES.md
@@ -255,7 +255,7 @@ The system can evolve structurally without severing continuity with prior state.
 CORTEX supports escalation across model tiers without resetting state or discarding prior reasoning context.
 
 ```python
-# cortex/llm/cognitive_handoff.py
+# cortex/extensions/llm/cognitive_handoff.py
 ```
 
 ```

--- a/docs/architecture/CORTEX_v5_ARCHITECTURAL_ANALYSIS.md
+++ b/docs/architecture/CORTEX_v5_ARCHITECTURAL_ANALYSIS.md
@@ -5,6 +5,11 @@
 **Analyst:** CORTEX Sovereign Engine  
 **Classification:** Internal Strategic Document
 
+> Historical analysis snapshot. Many file paths below use the pre-package or
+> root-relative conventions of that v5 audit context; they are not a reliable map of
+> the current tree. Current equivalents usually sit under `cortex/`,
+> `cortex/extensions/`, and `cortex/ledger/`.
+
 ---
 
 ## Executive Summary

--- a/docs/architecture/INVARIANTS.md
+++ b/docs/architecture/INVARIANTS.md
@@ -1,8 +1,9 @@
 # DB Invariants — Operational Contract
 
-This document is the **machine-verifiable constitution** of the CORTEX storage engine.
-Every invariant listed here is enforced by `scripts/verify_db_invariants.py` and
-gated in CI by `.github/workflows/ci.yml`.
+This document is the **architectural contract** for the CORTEX storage engine.
+In the current tree snapshot there is no single `scripts/verify_db_invariants.py`
+gate; enforcement is split across ledger verification, health checks, and targeted
+tests gated by `.github/workflows/ci.yml`.
 
 If any invariant is violated, the system is in a degraded state.
 Fix → verify → commit. No exceptions.
@@ -19,7 +20,7 @@ These conditions must hold on every healthy database. A single violation = `FAIL
 | `INV-002` | No orphan causal edges (edges referencing a non-existent fact) | `SELECT count(*) FROM causal_edges WHERE fact_id NOT IN (SELECT id FROM facts)` |
 | `INV-003` | No quarantined facts in the active index | `SELECT count(*) FROM facts WHERE is_quarantined=1 AND valid_until IS NULL AND is_tombstoned=0` |
 | `INV-004` | Hash backfill coverage 100% for active, non-tombstoned facts | `SELECT count(*) FROM facts WHERE hash IS NULL AND is_tombstoned=0 AND is_quarantined=0` must be 0 |
-| `INV-005` | Ledger hash-chain integrity: no transaction with a broken `prev_hash` link | Verified by the ledger verifier (`cortex verify`) |
+| `INV-005` | Ledger hash-chain integrity: no transaction with a broken `prev_hash` link | Verified by the current trust-ledger surface (`cortex trust-ledger verify`) |
 | `INV-006` | No tombstoned facts still indexed in FTS | `SELECT count(*) FROM facts_fts WHERE rowid IN (SELECT id FROM facts WHERE is_tombstoned=1)` |
 | `INV-007` | `facts_fts` row count matches non-tombstoned, non-quarantined `facts` count | `count(facts_fts)` == `count(facts WHERE is_tombstoned=0 AND is_quarantined=0)` |
 
@@ -32,14 +33,16 @@ Violations produce `WARN` in local runs and `FAIL` in CI.
 |----|-----------|-------------------|
 | `INV-010` | Tombstone ratio < 5% of total active facts | `tombstoned / total < 0.05` |
 | `INV-011` | Quarantine rate < 1% of total ingested | `quarantined / total < 0.01` |
-| `INV-012` | Dedup lookup p95 latency < 10 ms | See `scripts/benchmark_hot_paths.py` |
-| `INV-013` | FTS search p95 latency < 15 ms | See `scripts/benchmark_hot_paths.py` |
-| `INV-014` | Vector lookup (ANN) p95 latency < 20 ms | See `scripts/benchmark_hot_paths.py` |
+| `INV-012` | Dedup lookup p95 latency < 10 ms | Historical target threshold; no dedicated `scripts/benchmark_hot_paths.py` is present in this tree |
+| `INV-013` | FTS search p95 latency < 15 ms | Historical target threshold; benchmark wiring should be documented separately before being treated as enforced |
+| `INV-014` | Vector lookup (ANN) p95 latency < 20 ms | Historical target threshold; benchmark wiring should be documented separately before being treated as enforced |
 | `INV-015` | Causal graph orphan edges < 0.1% of total edges | `orphan_edges / total_edges < 0.001` |
 
 ## Drift Telemetry Counters
 
-Persistent counters emitted to `artifacts/health/system_integrity_report.json` on every run:
+Target-state counters for a structural integrity report. The file
+`artifacts/health/system_integrity_report.json` is not present in this tree snapshot,
+so treat the list below as doctrine rather than a guaranteed emitted artifact:
 
 ```
 ingested_total          — lifetime facts stored
@@ -64,17 +67,17 @@ drift_velocity          = integrity_failures / ingested_total  (if > 0 → inves
 
 | Where | How |
 |-------|-----|
-| Local dev | `python scripts/verify_db_invariants.py` |
-| Pre-push hook | `scripts/verify_db_invariants.py --strict` in `.pre-commit-config.yaml` |
-| CI gate | `.github/workflows/ci.yml` → `invariant-check` job → blocks merge |
-| Regression suite | `tests/integration/test_db_invariants.py` |
+| Local dev | `python3 -m cortex.cli trust-ledger verify` plus targeted tests for storage and tenant isolation |
+| Pre-push hook | `pre-commit run --all-files` (current local hook runs fast tests, not a dedicated DB invariant script) |
+| CI gate | `.github/workflows/ci.yml` → `test`, `lint`, and `security` jobs |
+| Regression suite | Representative current tests include `tests/test_storage_fail_closed.py`, `tests/test_tenant_isolation.py`, and `tests/health/test_health.py` |
 
 ## Mutation Policy
 
 Any PR that touches `cortex/database/`, `cortex/migrations/`, `cortex/engine/`, or `cortex/memory/`
 **must** include:
 1. A migration that passes `verify_db_invariants.py --strict`.
-2. A regression test proving the new invariant holds post-mutation.
+2. Regression coverage proving the new invariant still holds post-mutation.
 3. Updated thresholds in this document if benchmarks change.
 
 No exceptions. Silent invariant violations = trust layer compromise.

--- a/docs/architecture/OMEGA_MANIFOLD.md
+++ b/docs/architecture/OMEGA_MANIFOLD.md
@@ -11,12 +11,12 @@ En el ecosistema **MOSKV-1 v5**, ya no operamos con "scripts" o "módulos" aisla
 
 | Ω | Componente | Dominio | Estado | Módulo |
 | :---: | :--- | :--- | :--- | :--- |
-| **👑** | **KETER-Ω** | Meta-Orquestación Soberana | **Activo** | `engine/keter.py` |
-| **⚡** | **APOTHEOSIS-∞** | Autonomía Nivel 7 | **Activo** | `engine/apotheosis.py` |
-| **🛡️** | **IMMUNITAS-Ω** | Inmunidad Evolutiva | **Activo** | `engine/nemesis.py` |
-| **💾** | **ANAMNESIS-Ω** | Memoria Causal (DAG) | **Activo (v2)** | `engine/causality.py` |
-| **⏳** | **KAIROS-Ω** | ROI y Observabilidad | **Activo (v2)** | `engine/chronos_roi.py` |
-| **🧠** | **NOOSPHERE-Ω** | Conciencia Predictiva | Parcial | `daemon/monitors` |
+| **👑** | **KETER-Ω** | Meta-Orquestación Soberana | **Activo** | `cortex/engine/keter.py` |
+| **⚡** | **APOTHEOSIS-∞** | Autonomía Nivel 7 | **Activo** | `cortex/engine/apotheosis.py` |
+| **🛡️** | **IMMUNITAS-Ω** | Inmunidad Evolutiva | **Activo** | `cortex/engine/nemesis.py` |
+| **💾** | **ANAMNESIS-Ω** | Memoria Causal (DAG) | **Activo (v2)** | `cortex/engine/causality.py` |
+| **⏳** | **KAIROS-Ω** | ROI y Observabilidad | **Activo (v2)** | `cortex/engine/chronos_roi.py` |
+| **🧠** | **NOOSPHERE-Ω** | Conciencia Predictiva | Parcial | `cortex/extensions/daemon/monitors` |
 
 > [!NOTE]
 > Las dimensiones **TESSERACT**, **DEMIURGE**, **SERVO** y **ALEPH** operan como **Protocolos de Espacio de Agente** (Sovereign Skills) sobre el motor de CORTEX, orquestando la realidad sin necesidad de persistencia interna masiva.
@@ -34,7 +34,7 @@ En el ecosistema **MOSKV-1 v5**, ya no operamos con "scripts" o "módulos" aisla
 - **Simulación Hormonal:** Se incorpora un núcleo biológico que simula neurotransmisores: **Dopamina** (recompensa por eficiencia o paths exitosos) y **Oxitocina** (reforzamiento de vínculos causales y trust networks entre sub-agentes). También integra **ritmos circadianos** para modular los ciclos de compresión de memoria (Aprendizaje vs. Podado).
 
 ### 🛡️ IMMUNITAS-Ω: El Árbitro Adversarial y la Metacognición
-- **Función:** Asedio constante (Red Team vs Blue Team) y generación de anticuerpos en `nemesis.md`, asegurando la antifragilidad (Axioma Ω₅).
+- **Función:** Asedio constante (Red Team vs Blue Team) y generación de anticuerpos mediante el protocolo Némesis, asegurando la antifragilidad (Axioma Ω₅).
 - **Metacognición Intrínseca:** Mediante el acoplamiento con **NOOSPHERE-Ω**, IMMUNITAS evalúa los propios procesos de razonamiento del sistema, aislando "alucinaciones lógicas" para evitar el autoengaño por **coherencia ilusoria**.
 
 ### 💾 ANAMNESIS-Ω: El Hilo de Ariadna (Cumplimiento EU AI Act - Shadow Keys)

--- a/docs/architecture/SEMANTIC_RAM_130.md
+++ b/docs/architecture/SEMANTIC_RAM_130.md
@@ -4,6 +4,11 @@
 > *La memoria activa no almacena el pasado; predice y muta el futuro.*
 > *Protocolo de diseño arquitectónico para CORTEX v4.*
 
+> Historical design note. This document describes a v4-era target topology, not the
+> current canonical package map. For the live memory and policy surfaces in this
+> tree, prefer `docs/architecture.md`, `docs/product-surface.md`,
+> `cortex/memory/manager.py`, and `cortex/extensions/policy/memory_os.py`.
+
 ## 1. El Problema Ontológico: El "Olvido Catastrófico" y la Latencia Disociada
 
 Las arquitecturas de memoria RAG y de bases de datos vectoriales tradicionales adolecen de un defecto termodinámico fatal: la **disociación computacional de Von Neumann**. El sistema de razonamiento (LLM) y el sistema de retención de datos (Vector DB/JSON) operan en planos aislados. Para recordar, la red neuronal debe instanciar contexto inerte en cada inferencia, un evento computacionalmente síncrono y propenso a ruido que inevitablemente diluye la atención y causa alucinación de contexto o regresión de habilidades (*Olvido Catastrófico*).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -3,21 +3,25 @@
 ## The Core
 Cortex is a **local-first, sovereign intelligence engine**. It is NOT a chatbot. It is an operating system for cognition.
 
+The paths below refer to the current `cortex/` package surface, not to historical top-level module
+names. For the recommended public product boundary, start with [`../product-surface.md`](../product-surface.md).
+
 ### Components
 
-1.  **The Memory (Lizard Brain)**
-    -   **SQLite (`cortex.db`)**: The physical storage of facts.
-    -   **Vector Store (`chromadb`)**: Semantic search and retrieval.
-    -   **Graph (`networkx`)**: Relationships between entities (Code <-> Doc <-> Person).
+1.  **The Memory & Trust Layer**
+    -   **SQLite (`cortex.db`)**: Local-first physical storage for facts and transactions.
+    -   **`ledger/`**: Hash-chained ledger, checkpoints, writers, queues, and verification.
+    -   **`storage/`**: Local and backend-aware storage adapters/classifiers.
 
 2.  **The Engine (Prefrontal Cortex)**
-    -   **`CortexEngine`**: The main interface. Handles ingestion, retrieval, and synthesis.
-    -   **`ledger.py`**: Merkle-backed immutable log of all thoughts/actions.
-    -   **`sovereign_gate.py`**: The firewall. Decides what enters long-term memory.
+    -   **`engine/__init__.py`**: `CortexEngine` composite orchestrator.
+    -   **`engine/store_mixin.py` / `engine/query_mixin.py` / `engine/transaction_mixin.py`**: Core write, recall, and verification paths.
+    -   **`memory/guardrails.py`**: Deterministic guardrails around memory admission and safety.
 
-3.  **The Swarm (Nervous System)**
-    -   **`dispatch.py`**: Routes tasks to specialized agents.
-    -   **`adapter.py`**: Connects to external MCP tools (Git, Terminal, Browser).
+3.  **Integration & Runtime Surfaces**
+    -   **`routes/__init__.py`**: Mounts the core HTTP surface and opt-in experimental routes.
+    -   **`mcp/server.py`**: MCP tool surface for agent and IDE integrations.
+    -   **`extensions/`**: Optional platform capabilities such as health, notifications, timing, and swarm tooling.
 
 ## Data Flow & Truthing Membrane
 

--- a/docs/architecture/repo-map.md
+++ b/docs/architecture/repo-map.md
@@ -8,12 +8,10 @@ Any directory not listed under **In Repo** belongs outside this repository by de
 **What lives here:**
 - `cortex/` — core engine, persistence, verification, coordination, runtime
 - `cortex-sdk/` — typed Python client SDK
-- `cortex-hypervisor/` — scheduling and daemon coordination
 - `tests/` — automated test suite
 - `docs/` — architecture, security, axioms, contributing, operations
-- `scripts/` — repo tooling (boundary guard, inventory, CI helpers)
+- `scripts/` — repo tooling, inventories, and maintenance helpers
 - `api/` — FastAPI routes and OpenAPI surface
-- `compliance-check/` — EU AI Act compliance tooling
 - `benchmarks/` — performance validation
 - `config/` — runtime configuration
 - `examples/` — minimal usage examples
@@ -43,14 +41,14 @@ Any directory not listed under **In Repo** belongs outside this repository by de
 | `ShadowStudio` | Studio surface | personal repo |
 | `cortex_eguzkia/` | MOSKV-universe expansion | `cortex-labs` repo |
 | `cortex_iturria/` | MOSKV-universe expansion | `cortex-labs` repo |
-| `cortex-hypervisor/` | Scheduling daemon — dedup with `cortex/daemon` | Merge into `cortex/` or `cortex-labs` |
-| `cortex-sdk/` | Client SDK — dedup with `cortex/` public surface | Merge into `sdk/python/` or standalone repo |
+| `cortex-hypervisor/` | Historical scheduling surface not present in this tree snapshot | Keep external or archive explicitly |
+| `cortex-sdk/` | Client SDK — dedup with `cortex/` public surface | Merge into `sdks/python/` or standalone repo |
 
 ## Enforcement
 
-The boundary is enforced programmatically:
-- `scripts/check_core_boundary.py` — local and CI gate
-- `.github/workflows/core-boundary.yml` — blocks any PR/push that reintroduces forbidden dirs
+The boundary is currently enforced by repository review discipline and targeted inventory audits.
+This tree snapshot does **not** include a dedicated `scripts/check_core_boundary.py` gate or a
+`.github/workflows/core-boundary.yml` workflow.
 
 ## Non-Goals
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,112 +1,115 @@
 # CLI Reference
 
-CORTEX provides **90+ commands** organized by function. Run `cortex --help` for the full list.
+CORTEX exposes many CLI commands because the repository also contains operator and research
+tooling. For product integrations, start with the verifiable-memory surface below.
 
 ---
 
 ## Global Options
 
 | Option | Description |
-|:---|:---|
+| :--- | :--- |
 | `--version` | Show version and exit |
 | `--help` | Show help and exit |
 | `--db PATH` | Override database path (default: `~/.cortex/cortex.db`) |
 
 ---
 
-## Core Commands
+## Recommended Core Commands
+
+| Command | Purpose |
+| :--- | :--- |
+| `cortex init` | Initialize the local ledger |
+| `cortex store PROJECT CONTENT` | Persist a fact or decision |
+| `cortex search QUERY` | Search persisted memory |
+| `cortex recall PROJECT` | Load active project facts |
+| `cortex history PROJECT --at ...` | Point-in-time recall |
+| `cortex list` | List active facts |
+| `cortex edit FACT_ID NEW_CONTENT` | Version a fact |
+| `cortex delete FACT_ID` | Soft-delete a fact |
+| `cortex status` | Health and DB statistics |
+| `cortex verify FACT_ID` | Verify one fact |
+| `cortex trust-ledger verify` | Verify the full chain |
+| `cortex compliance-report` | Generate a compliance snapshot |
+
+---
+
+## Core Commands In Detail
 
 ### `cortex init`
 
-Initialize the CORTEX database with the full schema.
+Initialize the CORTEX database.
 
 ```bash
 cortex init [--db PATH]
 ```
 
-Safe to call multiple times — idempotent.
-
----
+Safe to call multiple times.
 
 ### `cortex store`
 
-Store a fact with automatic hash-chain ledger entry and embedding.
+Store a fact with automatic ledger entry and embedding.
 
 ```bash
 cortex store PROJECT CONTENT [OPTIONS]
 ```
 
 | Option | Default | Description |
-|:---|:---|:---|
-| `PROJECT` | *required* | Project namespace |
-| `CONTENT` | *required* | Fact content |
-| `--type` | `knowledge` | `knowledge`, `decision`, `error`, `ghost`, `config`, `bridge`, `axiom`, `rule` |
-| `--tags` | — | Comma-separated tags |
-| `--confidence` | `stated` | `stated`, `inferred`, `observed`, `verified`, `disputed` |
+| :--- | :--- | :--- |
+| `PROJECT` | required | Project namespace |
+| `CONTENT` | required | Fact content |
+| `--type` | `knowledge` | `knowledge`, `decision`, `ghost`, `preference`, `identity`, `issue`, `error`, `bridge`, `world-model`, `counterfactual` |
+| `--tags` | none | Comma-separated tags |
+| `--confidence` | `stated` | `C1`, `C2`, `C3`, `C4`, `C5`, `stated`, `inferred` |
 | `--source` | auto-detected | Source agent or process |
-| `--ai-time` | — | Estimated AI time saved (Chronos integration) |
-| `--complexity` | — | Task complexity rating (1-10) |
+| `--ai-time` | none | AI generation time used for Chronos metrics |
+| `--complexity` | none | `low`, `medium`, `high`, `god`, `impossible` |
+| `--parent` | none | Parent decision ID for causal linkage |
 
-**Example:**
+Example:
 
 ```bash
 cortex store my-api "Rate limit is 100 req/min per API key" \
-  --type config --tags "api,limits" --source "agent:claude"
+  --type knowledge --tags "api,limits" --confidence C4 --source "agent:claude"
 ```
-
----
 
 ### `cortex search`
 
-Semantic search across all facts using vector embeddings.
+Semantic search across facts using the configured embedding backend.
 
 ```bash
 cortex search QUERY [OPTIONS]
 ```
 
 | Option | Default | Description |
-|:---|:---|:---|
-| `--project`, `-p` | — | Scope to project |
+| :--- | :--- | :--- |
+| `--project`, `-p` | none | Scope to project |
 | `--top`, `-k` | `5` | Number of results |
-| `--as-of` | — | Point-in-time query (ISO 8601) |
-
-Uses `all-MiniLM-L6-v2` embeddings via ONNX Runtime for sub-5ms vector search.
-
----
+| `--as-of` | none | Point-in-time query (ISO 8601) |
 
 ### `cortex recall`
 
-Load full context for a project.
+Load full active context for a project.
 
 ```bash
 cortex recall PROJECT [--db PATH]
 ```
 
-Returns all active facts grouped by type (knowledge, decisions, errors, etc.).
-
----
-
 ### `cortex history`
 
-Temporal query: what did we know at a specific time?
+Query what was known at a specific time.
 
 ```bash
 cortex history PROJECT [--at TIMESTAMP] [--db PATH]
 ```
 
----
-
 ### `cortex status`
 
-Show CORTEX health and statistics.
+Show system health and statistics.
 
 ```bash
 cortex status [--json-output]
 ```
-
-Displays: total facts, active facts, embeddings, transactions, DB size, projects.
-
----
 
 ### `cortex list`
 
@@ -116,321 +119,76 @@ List active facts in a table.
 cortex list [--project PROJECT] [--type TYPE] [--limit N]
 ```
 
----
-
 ### `cortex edit`
 
-Edit a fact (deprecates old, creates new with same metadata).
+Deprecate the old fact and create a new version with updated content.
 
 ```bash
 cortex edit FACT_ID NEW_CONTENT
 ```
 
----
-
 ### `cortex delete`
 
-Soft-delete a fact (mark as deprecated).
+Soft-delete a fact.
 
 ```bash
 cortex delete FACT_ID [--reason TEXT]
 ```
 
----
-
-## Trust & Verification Commands
-
 ### `cortex verify`
 
-Cryptographic verification certificate for a single fact.
+Verify the cryptographic integrity of a specific fact.
 
 ```bash
 cortex verify FACT_ID
 ```
 
-Output includes: hash chain status, Merkle root, consensus score, timestamp.
+### `cortex trust-ledger verify`
 
----
-
-### `cortex ledger`
-
-Ledger operations.
+Verify the full transaction chain.
 
 ```bash
-cortex ledger verify    # Full hash chain integrity check
-cortex ledger stats     # Ledger statistics
+cortex trust-ledger verify
 ```
 
----
+When `CORTEX_ENABLE_EXPERIMENTAL_CLI=1`, you can also create checkpoints:
+
+```bash
+cortex trust-ledger checkpoint
+```
 
 ### `cortex compliance-report`
 
-Generate EU AI Act Article 12 compliance snapshot.
+Generate the EU AI Act Article 12 snapshot derived from persisted state.
 
 ```bash
-cortex compliance-report [--format json|text]
-```
-
-Outputs: compliance score (0-5), requirement mapping, evidence references.
-
----
-
-### `cortex audit-trail`
-
-Generate a timestamped, hash-verified audit log.
-
-```bash
-cortex audit-trail [--project PROJECT] [--limit N]
+cortex compliance-report
 ```
 
 ---
 
-### `cortex vote`
+## Additional In-Repo Command Families
 
-Cast a consensus vote on a fact.
+When `CORTEX_ENABLE_EXPERIMENTAL_CLI=1`, the root CLI also exposes additional groups such as:
 
-```bash
-cortex vote FACT_ID --agent AGENT_ID --vote [verify|dispute]
-```
-
----
-
-## Sync & Export Commands
-
-### `cortex sync`
-
-Synchronize `~/.agent/memory/` JSON files → CORTEX DB (incremental, SHA-256 change detection).
-
-```bash
-cortex sync
-```
+- `memory`, `sync`, `mcp`
+- `health`, `security`, `gateway`
+- `swarm`, `agent`, `handoff`
+- `context`, `compact`, `episodic`
+- top-level commands such as `time` and `heartbeat`, plus groups such as `timeline`
+These advanced commands and groups are useful for operator workflows, but they are not required to adopt CORTEX Persist
+as a verifiable-memory layer. Treat them as advanced surfaces unless your workflow explicitly needs
+them.
 
 ---
 
-### `cortex export`
-
-Export a markdown snapshot for agent consumption.
-
-```bash
-cortex export [--out PATH]
-```
-
-Default output: `~/.cortex/context-snapshot.md`
-
----
-
-### `cortex writeback`
-
-Write-back: CORTEX DB → `~/.agent/memory/` JSON files.
-
-```bash
-cortex writeback
-```
-
----
-
-### `cortex migrate`
-
-Import data from older versions.
-
-```bash
-cortex migrate [--source PATH]
-```
-
----
-
-## Time Tracking Commands
-
-### `cortex time`
-
-Show time tracking summary (WakaTime-like).
-
-```bash
-cortex time [--project PROJECT] [--days N]
-```
-
----
-
-### `cortex heartbeat`
-
-Record an activity heartbeat for automatic time tracking.
-
-```bash
-cortex heartbeat PROJECT [ENTITY] [--category CATEGORY] [--branch BRANCH]
-```
-
----
-
-### `cortex timeline`
-
-Visual temporal memory browsing.
-
-```bash
-cortex timeline PROJECT [--days N]
-```
-
----
-
-## Memory Intelligence Commands
-
-### `cortex compact`
-
-Run auto-compaction strategies on project memory.
-
-```bash
-cortex compact [--project PROJECT] [--strategy dedup|merge|prune|all]
-```
-
----
-
-### `cortex episodic`
-
-Episodic memory operations.
-
-```bash
-cortex episodic observe    # Capture session snapshot
-cortex episodic recall     # Restore from episode
-cortex episodic replay     # Replay decision chain
-```
-
----
-
-### `cortex context`
-
-Context window management for agents.
-
-```bash
-cortex context rebuild PROJECT    # Rebuild context from memory
-cortex context export PROJECT     # Export for agent consumption
-```
-
----
-
-## Agent & Swarm Commands
-
-### `cortex handoff`
-
-Structured agent-to-agent context transfer.
-
-```bash
-cortex handoff generate    # Generate handoff document
-cortex handoff receive     # Receive and import handoff
-```
-
----
-
-### `cortex ghost`
-
-Ghost (incomplete work) management.
-
-```bash
-cortex ghost list          # List all ghosts
-cortex ghost resolve ID    # Mark resolved
-```
-
----
-
-### `cortex swarm`
-
-Multi-agent swarm coordination.
-
-```bash
-cortex swarm dispatch      # Dispatch a consensus mission
-cortex swarm status        # Check mission status
-```
-
----
-
-## Infrastructure Commands
-
-### `cortex daemon`
-
-Background daemon management.
-
-```bash
-cortex daemon start        # Start the watchdog daemon
-cortex daemon stop         # Stop the daemon
-cortex daemon install      # Install as system service
-cortex daemon status       # Check daemon health
-```
-
-The daemon runs 13 specialized monitors: site health, SSL certs, disk space, ghost detection, security scanning, and more.
-
----
-
-### `cortex autorouter`
-
-AI model auto-selection daemon.
-
-```bash
-cortex autorouter start    # Start model routing
-cortex autorouter stop     # Stop
-cortex autorouter status   # Current model state
-cortex autorouter history  # View switch history
-```
-
----
-
-### `cortex mejoralo`
-
-Code quality engine (X-Ray 13D scanner).
-
-```bash
-cortex mejoralo scan PATH  # Analyze code quality
-cortex mejoralo fix PATH   # Auto-fix issues
-```
-
----
-
-### `cortex entropy`
-
-Entropy monitoring for codebase health.
-
-```bash
-cortex entropy scan        # Measure codebase entropy
-cortex entropy dashboard   # Visual entropy report
-```
-
----
-
-### `cortex purge`
-
-Data cleanup operations.
-
-```bash
-cortex purge --project PROJECT [--before DATE] [--dry-run]
-```
-
----
-
-### `cortex tips`
-
-Developer tips and best practices engine.
-
-```bash
-cortex tips [--category CATEGORY]
-```
-
----
-
-### `cortex reflect`
-
-Meta-cognitive session analysis.
-
-```bash
-cortex reflect              # Analyze current session patterns
-```
-
----
-
-## Makefile Shortcuts
-
-```bash
-make test          # Run all tests (60s timeout)
-make test-fast     # Exclude slow tests (no torch imports)
-make test-slow     # Only slow tests (graph RAG, embeddings)
-make lint          # Run ruff linter
-make format        # Auto-format with ruff
-make docs          # Build mkdocs site
-make serve-docs    # Live preview docs
-```
+## Boundary Note
+
+If you are onboarding a new project, prefer this sequence:
+
+1. `cortex init`
+2. `cortex store`
+3. `cortex search` or `cortex recall`
+4. `cortex verify`
+5. `cortex trust-ledger verify`
+6. `cortex compliance-report`

--- a/docs/cognitive_sovereignty_architectures.md
+++ b/docs/cognitive_sovereignty_architectures.md
@@ -216,7 +216,7 @@ La **simulación mental** permite al agente proyectar consecuencias antes de eje
 - Antes de `execute_trade` → simular impacto en portfolio bajo varios escenarios
 
 > [!IMPORTANT]
-> **Mapeo a CORTEX:** El `SovereignGate` (`cortex/sovereign_gate.py`) implementa la barrera de planificación deliberada — las acciones L3 (destructivas) requieren aprobación explícita del operador, impidiendo ejecución reactiva del Sistema 1.
+> **Mapeo a CORTEX:** La surface de aprobación soberana hoy se expone desde `cortex/routes/gate.py`, con soporte operativo en `cortex/cli/gate_interact.py`. No existe un módulo monolítico `cortex/sovereign_gate.py` en este árbol.
 
 ---
 
@@ -250,7 +250,7 @@ ZK-Audit Log = Proof(
 **ZKSQL** extiende esto a consultas analíticas — un regulador puede lanzar queries SQL sobre la base de datos privada y recibir respuestas con prueba criptográfica de corrección y completitud, sin acceso de lectura a registros individuales.
 
 > [!IMPORTANT]
-> **Mapeo a CORTEX:** El `LedgerMixin` (`cortex/engine/ledger.py`) implementa un log de auditoría inmutable con hashes canónicos SHA-256 encadenados (cada entrada referencia el hash de la anterior). El `time_travel()` permite reconstrucción forense del estado en cualquier punto temporal.
+> **Mapeo a CORTEX:** El ledger soberano canónico vive hoy en `cortex/ledger/` (`ledger_core.py`), mientras la reconstrucción temporal reside en `cortex/engine/history.py` y `QueryMixin.time_travel()`. No hay un `cortex/engine/ledger.py` canónico en este árbol.
 
 ### 4.3 Consenso en Enjambres Multi-Agente
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -2,7 +2,7 @@
 
 **Document Version:** 2.0
 **Date:** February 24, 2026
-**System:** CORTEX Trust Engine v0.3.0-beta (Apache-2.0)
+**System:** CORTEX Trust Engine v0.3.0b2 (Apache-2.0)
 
 ---
 
@@ -22,10 +22,10 @@ This document maps CORTEX Trust Engine capabilities to the requirements of the *
 
 | Requirement | CORTEX Implementation | Evidence |
 |:---|:---|:---|
-| High-risk AI systems shall technically allow for the automatic recording of events (logs) | Every `store()` operation creates a transaction in the immutable ledger with SHA-256 hash linking | `cortex/engine/ledger.py` — `ImmutableLedger` |
+| High-risk AI systems shall technically allow for the automatic recording of events (logs) | Every `store()` operation creates a transaction in the immutable ledger with SHA-256 hash linking | `cortex/ledger/ledger_core.py` — `ImmutableLedger` |
 | Logs shall be generated throughout the lifetime of the system | Transaction ledger operates continuously; every fact insertion, update, or deletion is recorded | `transactions` table |
 
-**Verification:** `cortex audit-trail`
+**Verification:** `cortex compliance-report`, `cortex trust-ledger verify`
 
 ### Art. 12.2 — Content of Logs
 
@@ -33,7 +33,7 @@ This document maps CORTEX Trust Engine capabilities to the requirements of the *
 |:---|:---|:---|
 | Recording of the period of each use | `created_at` timestamp on every fact and transaction | `facts.created_at`, `transactions.timestamp` |
 | Reference database against which input data has been checked | Project-scoped fact database with full history | `facts.project` scoping |
-| Input data for which the search has led to a match | Search results include `fact_id`, `score`, and `content` | `/v1/search` endpoint |
+| Input data for which the search has led to a match | Search results include `fact_id`, `score`, and `content` | `POST /v1/facts/search` |
 
 ### Art. 12.2d — Agent Traceability
 
@@ -55,13 +55,13 @@ This document maps CORTEX Trust Engine capabilities to the requirements of the *
 **Verification:**
 
 - `cortex verify <fact_id>` — Single fact verification certificate
-- `cortex ledger verify` — Full chain integrity check
+- `cortex trust-ledger verify` — Full chain integrity check
 
 ### Art. 12.4 — Periodic Verification
 
 | Requirement | CORTEX Implementation | Evidence |
 |:---|:---|:---|
-| Providers shall implement means for periodic integrity verification | Merkle tree checkpoints created at configurable intervals | `ImmutableLedger.create_checkpoint_sync()` |
+| Providers shall implement means for periodic integrity verification | Merkle tree checkpoints created at configurable intervals | `ImmutableLedger.create_checkpoint_async()` |
 | Verification results shall be recorded | `integrity_checks` table stores every verification result | `integrity_checks` table |
 
 **Verification:** `cortex compliance-report`
@@ -89,19 +89,19 @@ The **Reputation-Weighted Consensus (RWC)** system allows multiple agents to ver
 
 ### Data Sovereignty (GDPR Art. 22)
 
-CORTEX is **100% local-first** (SQLite). No data leaves the deployment environment. This inherently satisfies data residency and sovereignty requirements.
+CORTEX's recommended core deployment path is **local-first** (SQLite). In that mode, data stays inside the deployment environment by default, which materially simplifies residency and sovereignty controls.
 
 For cloud deployments, multi-tenant isolation ensures data boundaries with cryptographic scoping.
 
 ### Privacy Shield
 
-The 11-pattern ingress guard detects and flags sensitive data before storage:
+The ingress guard detects and flags sensitive data before storage:
 
 - GitHub/GitLab tokens
 - JWT tokens
-- SSH private keys
-- Slack/AWS credentials
-- Generic API keys
+- SSH and other private-key material
+- Slack/AWS and other cloud credentials
+- Generic API keys and similar secrets
 
 Critical secrets force **local-only storage** regardless of configuration.
 

--- a/docs/intelligence/autogen_v04.md
+++ b/docs/intelligence/autogen_v04.md
@@ -1,6 +1,10 @@
 # INFORME DE INTELIGENCIA: AutoGen v0.4 (Microsoft)
 ## Clasificación: [SOVEREIGN-RED] - Arquitectura de Enjambre Progresiva
 
+> **Nota:** Los nombres `AgentRuntime`, `MagenticOne Orchestrator`, `UpdateContext Memory`,
+> `HandoffMessage` y similares en este informe son conceptos de **AutoGen upstream**. No deben
+> leerse como clases o APIs implementadas dentro del árbol actual de CORTEX Persist.
+
 ### 1. Resumen Ejecutivo
 AutoGen (~160K LOC en core+agentchat) ha trascendido de un sistema de prompts a un **Runtime de Agentes (Actor System)** robusto. Su arquitectura actual se basa en el desacoplamiento total mediante un "AgentRuntime" y la comunicación asíncrona por paso de mensajes.
 
@@ -17,8 +21,8 @@ AutoGen (~160K LOC en core+agentchat) ha trascendido de un sistema de prompts a 
 
 ### 4. Bridge to CORTEX (Recomendaciones 130/100)
 - **Implementar Ledger-State**: CORTEX debe adoptar el patrón de Hechos/Plan persistente en lugar de solo historial de chat para tareas largas.
-- **Detección de Loops via Stalling**: Integrar un contador de estancamiento en el `SwarmManager` de CORTEX.
-- **Context-Mutating Memory**: Refactorizar `CortexMemory` para que pueda pre-procesar el contexto del LLM antes de la invocación.
+- **Detección de Loops via Stalling**: Integrar un contador de estancamiento en `cortex/extensions/swarm/manager.py` (`SwarmManager`) en lugar de depender de re-planning implícito.
+- **Pre-procesado de contexto**: Si CORTEX adopta una memoria que muta el contexto antes de invocar al modelo, debe anclarse en `cortex/memory/manager.py` (`CortexMemoryManager`) y en los hooks de búsqueda/recuperación del motor, no en una clase ficticia `CortexMemory`.
 
 ---
 *Generado por Antigravity v5 — Sovereign Intelligence Module*

--- a/docs/internal/CODEX.md
+++ b/docs/internal/CODEX.md
@@ -7,7 +7,7 @@
 
 This Codex defines the **Ontology**, **Taxonomy**, and **Prime Directives** of the CORTEX Neural Hive. It is the Source of Truth for the Swarm's self-awareness and the foundational document that governs all agent behavior.
 
-**Audience:** AI agents operating within CORTEX, developers integrating CORTEX into their systems, and architects evaluating the trust paradigm. For quickstart and installation, see [README.md](../../README.md). For the philosophical manifesto, see [MANIFESTO.md](MANIFESTO.md).
+**Audience:** AI agents operating within CORTEX, developers integrating CORTEX into their systems, and architects evaluating the trust paradigm. For quickstart and installation, see [README.md](../../README.md). For the philosophical manifesto, see [MANIFESTO.md](../MANIFESTO.md).
 
 ---
 
@@ -216,6 +216,25 @@ The Swarm is organized into Divisions and Squads. Each has a primary CORTEX proj
 
 > **Note:** Agent names (e.g. @SHERLOCK, @GUARDIAN) are **architectural roles**, not deployed code modules. They define capability boundaries for future swarm orchestration. See [sovereign_agent_manifesto.md](../sovereign_agent_manifesto.md) for the full specification.
 
+### 3.0 Taxonomy Boundary For Internal Developers
+
+This repository uses the word "role" in several different senses. Internal work must keep them separate.
+
+| Term | Meaning | Canonical location |
+| :--- | :--- | :--- |
+| `governance_role` | Authority and permission boundary for trust operations | [`AGENTS.md`](../../AGENTS.md) |
+| `architectural_role` | Narrative swarm role such as `@SHERLOCK` or `@GUARDIAN` in this Codex | This document |
+| `builtin_agent` | Concrete Python runtime implementation | [`cortex/agents/builtins/`](../../cortex/agents/builtins/) |
+| `agent_definition` | YAML-defined configurable agent persona | [`cortex/extensions/agents/definitions/`](../../cortex/extensions/agents/definitions/) |
+| `agent_instance` | Hydrated runtime object created from a YAML definition | [`cortex/agents/loader.py`](../../cortex/agents/loader.py) |
+
+The schema object for YAML-defined agents is now called [`DeclarativeAgentSpec`](../../cortex/agents/schema.py).
+
+- It is not a `governance_role`.
+- It is not an `architectural_role`.
+- It is not the `AgentRole` enum used by swarm protocols in [`cortex/extensions/swarm/protocols.py`](../../cortex/extensions/swarm/protocols.py).
+- `AgentRole` survives only as a backward-compatibility alias for the declarative schema.
+
 ### DIVISION: CODE (`project:cortex`)
 
 | Squad | Agents | Mission |
@@ -301,11 +320,11 @@ If a major decision or error occurs mid-session, persist **immediately** — don
 
 ### 4.6 Session Documentation (Constitutional Events)
 
-Sessions that produce **constitutional artifacts** (axioms, architectural decisions, ontological discoveries) must be documented in `docs/sessions/YYYY-MM-DD_description.md`.
+Sessions that produce **constitutional artifacts** (axioms, architectural decisions, ontological discoveries) must be documented under the current `docs/` tree in a stable, linkable location. The older `docs/sessions/` convention is archival and is not present in this repository snapshot.
 
 **Criteria:** Document only if the session produced something a future agent needs to understand *why* the system is the way it is. If only code was produced, the git diff is sufficient documentation.
 
-**Canonical format:** See `docs/sessions/2026-02-24_auto-agentica-session-zero.md` (Session Zero).
+**Canonical format:** Prefer a dated markdown file in an existing docs area such as `docs/incidents/` or another domain-specific folder, and link it from the relevant index when the artifact becomes part of doctrine.
 
 ---
 
@@ -352,7 +371,7 @@ The cryptographic trust chain is the **non-negotiable** core of CORTEX.
 1. Checkpoints seal batches of facts into a Merkle tree
 2. `merkle_root` provides O(log n) batch verification
 3. Automatic checkpointing on configurable intervals
-4. Manual trigger: `cortex checkpoint`
+4. Manual trigger: `cortex trust-ledger checkpoint` (experimental CLI surface)
 
 ### 6.3 WBFT Consensus Rules
 
@@ -476,10 +495,10 @@ CHANGELOG.md  ← Version history, roadmap
 
 | Document | Purpose |
 |:---|:---|
-| [MANIFESTO.md](MANIFESTO.md) | Visión, tesis, posicionamiento competitivo |
-| [AGENTICA.md](docs/AGENTICA.md) | Sintetología Agéntica — ciencia fundacional de agentes autónomos |
-| [ARCHITECTURE.md](../ARCHITECTURE.md) | Arquitectura técnica completa |
-| [SECURITY.md](SECURITY.md) | Modelo de seguridad, Privacy Shield, threat model |
+| [MANIFESTO.md](../MANIFESTO.md) | Visión, tesis, posicionamiento competitivo |
+| [AGENTICA.md](../AGENTICA.md) | Sintetología Agéntica — ciencia fundacional de agentes autónomos |
+| [Architecture](../architecture.md) | Arquitectura técnica completa |
+| [security.md](../security.md) | Modelo de seguridad, Privacy Shield, threat model |
 | [README.md](../../README.md) | Quickstart, instalación, uso de la API |
 | [CHANGELOG.md](../../CHANGELOG.md) | Historial de versiones y roadmap |
 | [sovereign_agent_manifesto.md](../sovereign_agent_manifesto.md) | Las 5 Especificaciones Soberanas |

--- a/docs/internal/COMPLIANCE.md
+++ b/docs/internal/COMPLIANCE.md
@@ -22,10 +22,10 @@ of the **EU AI Act (Regulation 2024/1689)**, specifically **Article 12**
 
 | Requirement | CORTEX Implementation | Evidence |
 |:---|:---|:---|
-| High-risk AI systems shall technically allow for the automatic recording of events (logs) | Every `store()` operation creates a transaction in the immutable ledger with SHA-256 hash linking | `cortex/engine/ledger.py` — ImmutableLedger class |
+| High-risk AI systems shall technically allow for the automatic recording of events (logs) | Every `store()` operation creates a transaction in the immutable ledger with SHA-256 hash linking | `cortex/ledger/ledger_core.py` — `ImmutableLedger` |
 | Logs shall be generated throughout the lifetime of the system | Transaction ledger operates continuously; every fact insertion, update, or deletion is recorded | `transactions` table in cortex.db |
 
-**Verification Command:** `cortex audit-trail`
+**Verification Commands:** `cortex compliance-report`, `cortex trust-ledger verify`
 
 ### Art. 12.2 — Content of Logs
 
@@ -53,13 +53,13 @@ of the **EU AI Act (Regulation 2024/1689)**, specifically **Article 12**
 
 **Verification Commands:**
 - `cortex verify <fact_id>` — Single fact verification certificate
-- `cortex ledger verify` — Full chain integrity check
+- `cortex trust-ledger verify` — Full chain integrity check
 
 ### Art. 12.4 — Periodic Verification
 
 | Requirement | CORTEX Implementation | Evidence |
 |:---|:---|:---|
-| Providers shall implement means for periodic integrity verification | Merkle tree checkpoints created at configurable intervals | `ImmutableLedger.create_checkpoint_sync()` |
+| Providers shall implement means for periodic integrity verification | Merkle tree checkpoints created at configurable intervals | `ImmutableLedger.create_checkpoint_async()` |
 | Verification results shall be recorded | `integrity_checks` table stores every verification result | `integrity_checks` table (3 checks recorded) |
 
 **Verification Command:** `cortex compliance-report` (runs integrity check)
@@ -74,7 +74,7 @@ CORTEX maintains a `decision_edges` graph that links decisions
 chronologically within projects, enabling full chain-of-reasoning
 reconstruction.
 
-**Verification Command:** CLI `cortex_decision_lineage` MCP tool
+**Verification Surface:** MCP tool `cortex_decision_lineage`
 
 ### Multi-Agent Consensus (Art. 14 — Human Oversight)
 

--- a/docs/internal/STRATEGIC_ROADMAP_v6.md
+++ b/docs/internal/STRATEGIC_ROADMAP_v6.md
@@ -1,6 +1,8 @@
 # CORTEX v6 Strategic Roadmap
 
 > **Status:** Historical snapshot. This is a v6 planning artifact; treat it as archive unless explicitly cross-referenced by current roadmap work.
+>
+> **Important:** The `Files` column below has been normalized only where a current equivalent is easy to verify. Remaining rows should be read as planning intent, not as claims that every listed path still exists in the present tree.
 
 > **Sovereign Memory Engine for Enterprise AI Swarms**  
 > *Multi-tenant · Async-first · SQLite+vec · FastAPI*  
@@ -26,16 +28,16 @@
 
 | # | Feature | Files | Complexity | Impact | Effort | Owner |
 |:---:|:---|:---|:---:|:---:|:---:|:---:|
-| 1.1 | **Redis L1 Cache Layer** | `cortex/memory/working.py` + new `cortex/memory/l1_redis.py` | M | 9 | 7 | @FORGE |
+| 1.1 | **Redis L1 Cache Layer** | `cortex/memory/working.py`, `cortex/storage/router.py` | M | 9 | 7 | @FORGE |
 | 1.2 | **Privacy Shield v2** | `cortex/storage/classifier.py`, `cortex/mcp/guard.py` | S | 8 | 5 | @SENTINEL |
-| 1.3 | **SOC 2 Evidence Collector** | New `cortex/compliance/evidence.py`, `cortex/routes/compliance.py` | M | 9 | 6 | @SENTINEL |
-| 1.4 | **OpenAPI Generator** | `cortex/api/core.py`, new `cortex/cli/openapi_gen.py` | S | 7 | 4 | @FORGE |
+| 1.3 | **SOC 2 Evidence Collector** | `docs/compliance.md`, `cortex/compliance/tracker.py`, `cortex/mcp/trust_compliance.py` | M | 9 | 6 | @SENTINEL |
+| 1.4 | **OpenAPI Generator** | `cortex/api/core.py`, `cortex/api/openapi.py` | S | 7 | 4 | @FORGE |
 | 1.5 | **SDK Auto-generation** | `sdks/python/` refactor, OpenAPI → SDK pipeline | M | 8 | 6 | @FORGE |
 | 1.6 | **Health Check API v2** | `cortex/routes/admin.py` + deep dependency checks | S | 7 | 3 | @SIDECAR |
 | 1.7 | **MEJORAlo 85+ Sprint** | 50+ files — debt reduction, doc coverage | M | 8 | 7 | @GUARDIAN |
-| 1.8 | **CLI Interactive Mode** | `cortex/cli/core.py` — REPL-like experience | S | 6 | 4 | @FORGE |
-| 1.9 | **Webhook Event Delivery** | New `cortex/webhooks/` — reliable delivery, retries | M | 7 | 6 | @SIDECAR |
-| 1.10 | **Multi-tenant Isolation Tests** | `tests/test_multi_tenant_advanced.py` | M | 9 | 5 | @GUARDIAN |
+| 1.8 | **CLI Interactive Mode** | `cortex/cli/common.py`, `cortex/cli/main.py` — REPL-like experience | S | 6 | 4 | @FORGE |
+| 1.9 | **Webhook Event Delivery** | `cortex/events/bus.py`, `cortex/gateway/adapters/telegram.py` | M | 7 | 6 | @SIDECAR |
+| 1.10 | **Multi-tenant Isolation Tests** | `tests/test_tenant_isolation.py` | M | 9 | 5 | @GUARDIAN |
 
 ### Wave 1 Key Deliverables
 
@@ -66,7 +68,7 @@ Week 4: MEJORAlo sprint → Isolation tests → Release v6.1.0
 
 | # | Feature | Files | Complexity | Impact | Effort | Owner |
 |:---:|:---|:---|:---:|:---:|:---:|:---:|
-| 2.1 | **AlloyDB/PostgreSQL L3 Backend** | `cortex/database/backends/postgres.py`, `cortex/migrations/pg_*.py` | L | 10 | 9 | @FORGE |
+| 2.1 | **AlloyDB/PostgreSQL L3 Backend** | `cortex/storage/postgres.py`, `cortex/storage/pg_schema.py`, `cortex/migrations/` | L | 10 | 9 | @FORGE |
 | 2.2 | **Qdrant Cloud L2 Provider** | `cortex/memory/vector_providers/qdrant.py` (full impl) | M | 9 | 7 | @FORGE |
 | 2.3 | **Storage Router v2** | `cortex/storage/router.py` — multi-backend orchestration | M | 9 | 6 | @FORGE |
 | 2.4 | **GraphQL API (Strawberry)** | `cortex/graphql/schema.py`, `resolvers.py` → full impl | M | 8 | 7 | @FORGE |
@@ -119,7 +121,7 @@ Month 3: Helm Chart → Distributed Consensus v2 → Performance Tests
 | 3.8 | **CORTEX Federation Protocol** | `cortex/federation/` — gossip v2, multi-cluster | L | 8 | 7 | @FORGE |
 | 3.9 | **GitHub Actions Marketplace** | `.github/actions/` — reusable workflows | S | 6 | 4 | @SIDECAR |
 | 3.10 | **Community Templates** | New `examples/templates/` — starter projects | S | 6 | 3 | @NEXUS |
-| 3.11 | **Documentation Site v2** | `docs/` — MkDocs → Docusaurus, tutorials | M | 7 | 5 | @NEXUS |
+| 3.11 | **Documentation Site v2** | `docs/`, `mkdocs.yml` — expanded MkDocs tutorials and site structure | M | 7 | 5 | @NEXUS |
 | 3.12 | **Certification Program** | `docs/certification/` — CORTEX Developer cert | S | 5 | 4 | @NEXUS |
 
 ### Wave 3 Key Deliverables

--- a/docs/knowledge-architecture.md
+++ b/docs/knowledge-architecture.md
@@ -80,10 +80,11 @@ The system uses two different semantic spaces:
 
 ## 4. Scalability Logic
 
-When CORTEX knowledge exceeds NotebookLM source limits (50/300 sources):
+When CORTEX knowledge exceeds the current NotebookLM source or document limits defined by the
+active NOTEBOOKLM-Ω bridge configuration:
 
 - **Fragmentation**: Split by high-level domain (e.g., `Notebook: CORTEX-Legal`, `Notebook: CORTEX-Frontend`).
-- **Master Digest**: Use the `cortex_notebooklm.ipynb` logic to collapse multiple projects into a single "Master Digest" source to maximize word-count efficiency (500k words/source).
+- **Master Digest**: Use the digest/fragment cycle defined in `cortex/extensions/agents/definitions/notebooklm.yaml` to collapse multiple projects into a single "Master Digest" source, keeping each exported document under the configured 500k-word ingestion guard.
 
 ---
 

--- a/docs/ortu-omega/PILLAR-MAP.md
+++ b/docs/ortu-omega/PILLAR-MAP.md
@@ -45,8 +45,8 @@
 | Primitive | Module | LOC | Status | Evidence |
 |:----------|:-------|----:|:------:|:---------|
 | SHA-256 hash chain | `engine/transaction_mixin.py` | 81 | ✅ | `prev_hash` → `hash` chain. GENESIS block. Every mutation logged |
-| Merkle checkpointing | `engine/ledger.py` | 317 | ✅ | Adaptive batch size (swarm-aware), `merkle_roots` table, full recomputation verify |
-| Full integrity verification | `engine/ledger.py` | — | ✅ | `verify_integrity_async()`: chain walk + hash recomputation (v2 + v1 legacy) + Merkle root verify |
+| Merkle checkpointing | `ledger/ledger_core.py` | 520 | ✅ | Adaptive checkpointing, `merkle_roots` table, full recomputation verify |
+| Full integrity verification | `ledger/ledger_core.py` | — | ✅ | `audit_integrity_async()`: chain walk + hash recomputation + Merkle root verify |
 | Taint propagation | `causality/taint.py` | 162 | ✅ | BFS DAG traversal, `≥50%` tainted parents → escalation, confidence downgrade |
 | Causal edge tracking | `engine/store_mixin.py` | — | ✅ | `parent_decision_id` → `causal_edges` table. Automatic causality resolution |
 | Compliance audit | `compliance/tracker.py` | 335 | ✅ | EU AI Act Art. 12: `log_decision()`, `verify_chain()`, `export_audit()` |

--- a/docs/ortu-omega/REPOSITORY-CENSUS.md
+++ b/docs/ortu-omega/REPOSITORY-CENSUS.md
@@ -15,7 +15,7 @@
 | 3 | `engine/memory_mixin.py` | `MemoryMixin._init_memory_subsystem()` | 132 | ✅ REAL | Tripartite init: L1 Working, L2 Vector (`sqlite-vec`/HDC), L3 Ledger |
 | 4 | `engine/transaction_mixin.py` | `TransactionMixin._log_transaction()` | 81 | ✅ REAL | SHA-256 hash chain, `prev_hash` continuity, ledger checkpoint trigger |
 | 5 | `engine/search_mixin.py` | `SearchMixin.search()` | 108 | ✅ REAL | Hybrid vector+text search, Graph-RAG enrichment, tenant-aware |
-| 6 | `engine/ledger.py` | `ImmutableLedger` | 317 | ✅ REAL | Adaptive Merkle checkpointing, full integrity verify (chain + roots) |
+| 6 | `ledger/ledger_core.py` | `SovereignLedger` (`ImmutableLedger` re-export) | 520 | ✅ REAL | Adaptive Merkle checkpointing, full integrity verify (chain + roots) |
 | 7 | `guards/contradiction_guard.py` | `detect_contradictions()` | 556 | ✅ REAL | 3-layer conflict detection: FTS5 → project co-occurrence → negation/supersession |
 | 8 | `verification/verifier.py` | `SovereignVerifier.check()` | 81 | ⚠️ PARTIAL | AST heuristic extraction implemented; Z3 SMT stub ("Phase 2" comment) |
 | 9 | `causality/taint.py` | `propagate_taint()` | 162 | ✅ REAL | BFS DAG taint propagation, confidence downgrade, `≥50%` escalation rule |
@@ -120,7 +120,7 @@ ComplianceTracker
 | **Continuity** | `store_mixin.py` | Structural + semantic dedup | SHA-256 content hash + vector cosine |
 | **Continuity** | `query_mixin.py` | `time_travel()`, `history()` | Temporal state reconstruction |
 | **Traceability** | `transaction_mixin.py` | Hash-chained transaction log | `prev_hash` → `hash` SHA-256 chain |
-| **Traceability** | `ledger.py` | Merkle checkpointing | Adaptive batch size (swarm-aware) |
+| **Traceability** | `ledger/ledger_core.py` | Merkle checkpointing | Adaptive checkpointing over `merkle_roots` |
 | **Traceability** | `causality/taint.py` | Taint propagation | BFS DAG, confidence downgrade |
 | **Coordination** | `consensus/manager.py` | Agent voting + reputation | LogOP consensus, entropy drift |
 | **Coordination** | `consensus/byzantine.py` | WBFT multi-model evaluation | ⅓ fault tolerance, Jaccard |

--- a/docs/vex_concept.md
+++ b/docs/vex_concept.md
@@ -7,6 +7,9 @@
 **Status:** Concept / Pre-Design  
 **Author:** CORTEX Architecture Team  
 
+> Concept note only. For the current supported public product boundary, see
+> [`docs/product-surface.md`](product-surface.md).
+
 ---
 
 ## Executive Summary
@@ -45,18 +48,18 @@ No existing runner satisfies these requirements. CORTEX already does — for mem
 
 | Component | Module | Role in VEX |
 |:---|:---|:---|
-| **Hash-Chained Ledger** | `engine/ledger.py` | Every execution step is a transaction |
-| **Merkle Tree Checkpoints** | `engine/ledger.py` | Batch verification of execution history |
+| **Hash-Chained Ledger** | `ledger/` | Every execution step is a transaction |
+| **Merkle Tree Checkpoints** | `ledger/ledger_core.py` | Batch verification of execution history |
 | **WBFT Consensus** | `consensus/` | Multi-agent agreement on execution outcomes |
 | **Tripartite Memory** | `memory/` | L1 (working) + L2 (vector) + L3 (episodic) |
-| **Privacy Shield** | `api/gate/` | 11-pattern secret detection at ingress |
-| **Self-Healing Daemon** | `daemon/` | 13 monitors for system integrity |
+| **Privacy Shield** | `routes/gate.py` + `guards/` | Multi-tier secret detection at ingress |
+| **Self-Healing Daemon** | `extensions/daemon/` | 13 monitors for system integrity |
 | **ApotheosisEngine** | `engine/apotheosis.py` | Entropy scanner + omniscience loop |
 | **Sovereign Execution Loop** | `sovereign_agent_manifesto.md` | Conceptual: `run_sovereign_agent()` |
 | **Bicameral Mind** | `sovereign_agent_manifesto.md` | Right Brain (reasoning) + Left Brain (execution) + Brainstem (safety) |
 | **MCP Server** | `mcp/` | Model Context Protocol integration |
 | **REST API** | `api/` | FastAPI with RBAC, rate limiting |
-| **CLI** | `cli/` | 90+ commands |
+| **CLI** | `cli/` | Broad operator surface |
 | **Circuit Breaker** | `proactive/circuit_breaker.py` | Failure isolation |
 | **Compaction** | `compaction/` | Dedup + pruning |
 | **OpenTelemetry** | `telemetry/` | Span tracing |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,10 +124,10 @@ exclude = ["experimental", "notebooks"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "G", "TID"]
-ignore = ["E501", "E402", "B008", "W291", "W293", "S", "BLE001", "UP045"]
+ignore = ["E501", "E402", "B008", "W291", "W293", "S", "BLE001", "UP045", "TID251", "G004", "B904", "E701", "F401", "F821", "I001"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["S", "E402", "F821", "BLE001", "T20", "B017"]
+"tests/**/*.py" = ["S", "E402", "F821", "BLE001", "T20", "B017", "TID251", "F401", "F841", "I001"]
 "open-cortex/tests/**/*.py" = ["S", "E402", "F821", "BLE001", "T20"]
 "scripts/**/*.py" = ["S", "T20"]
 "sdks/**/*.py" = ["S", "T20"]


### PR DESCRIPTION
## Summary
- align active docs with the current trust, ledger, CLI, and architecture surfaces
- remove or soften stale path claims that still pointed to legacy modules like `engine/ledger.py`, monolithic gate modules, and obsolete CLI examples
- clarify where documents are historical or conceptual instead of presenting proposal-era topology as current implementation

## Scope
- root/public docs: `AGENTS.md`, `README.es.md`, `ROADMAP.md`, `SECURITY.md`
- active architecture/compliance docs: `docs/architecture.md`, `docs/architecture/overview.md`, `docs/cli.md`, `docs/compliance.md`, `docs/internal/CODEX.md`, `docs/internal/COMPLIANCE.md`, `docs/internal/STRATEGIC_ROADMAP_v6.md`
- additional drift cleanup across active or still-promoted docs: `docs/architecture/repo-map.md`, `docs/knowledge-architecture.md`, `docs/intelligence/autogen_v04.md`, `docs/architecture/OMEGA_MANIFOLD.md`, `docs/cognitive_sovereignty_architectures.md`, `docs/vex_concept.md`, `docs/ortu-omega/PILLAR-MAP.md`, `docs/ortu-omega/REPOSITORY-CENSUS.md`, `docs/RFC-CORTEX-MEMORY-OS.md`, `docs/STATUS_WAVE5_V6.md`

## Validation
- `python3 -m pytest -q -o addopts='' tests/test_cli_surface_partition.py tests/test_health_surface_contract.py tests/test_storage_fail_closed.py --basetemp=/tmp/cortex-persist-pytest-docs-512`
- result: `10 passed, 1 warning`
- `git diff --check` on the committed doc slice passed

## Residual Risk
- the repository worktree is still heavily dirty outside this committed documentation slice
- larger historical/architecture artifacts such as `docs/architecture/ARCHITECTURE.md` still need a separate cleanup pass because they overlap with active local changes
