### PR TITLE
feat: add offline ledger export verifier

### DIFF
--- a/cortex/cli/public_verifier_cmds.py
+++ b/cortex/cli/public_verifier_cmds.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import json
+
+import click
+
+from cortex.cli.common import cli
+from cortex.ledger.public_verifier import verify_export
+
+
+@cli.command("verify-ledger-export")
+@click.argument("export_dir", type=click.Path(exists=True, file_okay=False, dir_okay=True))
+def verify_ledger_export(export_dir: str) -> None:
+    """Verify a public ledger export from files only."""
+    report = verify_export(export_dir)
+    click.echo(json.dumps(report, indent=2, sort_keys=True))
+
+    if report["result"] == "INVALID":
+        raise click.exceptions.Exit(1)
+    if report["result"] == "VALID_WITH_LIMITATIONS":
+        raise click.exceptions.Exit(2)

--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -8,6 +8,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from cortex.ledger.ledger_core import SovereignLedger
     from cortex.ledger.models import LedgerEvent, SemanticStatus
+    from cortex.ledger.public_export import (
+        ExportAuthority,
+        LedgerExportResult,
+        public_key_record,
+        write_public_ledger_export,
+    )
     from cortex.ledger.public_verifier import verify_export
     from cortex.ledger.queue import EnrichmentQueue
     from cortex.ledger.store import LedgerStore
@@ -23,6 +29,10 @@ __all__ = [
     "LedgerWriter",
     "LedgerVerifier",
     "EnrichmentQueue",
+    "ExportAuthority",
+    "LedgerExportResult",
+    "public_key_record",
+    "write_public_ledger_export",
     "verify_export",
 ]
 
@@ -33,6 +43,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LedgerWriter": ("cortex.ledger.writer", "LedgerWriter"),
     "LedgerVerifier": ("cortex.ledger.verifier", "LedgerVerifier"),
     "EnrichmentQueue": ("cortex.ledger.queue", "EnrichmentQueue"),
+    "ExportAuthority": ("cortex.ledger.public_export", "ExportAuthority"),
+    "LedgerExportResult": ("cortex.ledger.public_export", "LedgerExportResult"),
+    "public_key_record": ("cortex.ledger.public_export", "public_key_record"),
+    "write_public_ledger_export": ("cortex.ledger.public_export", "write_public_ledger_export"),
     "verify_export": ("cortex.ledger.public_verifier", "verify_export"),
 }
 

--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -7,7 +7,15 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cortex.ledger.ledger_core import SovereignLedger
-    from cortex.ledger.models import LedgerEvent, SemanticStatus
+    from cortex.ledger.models import LedgerEvent, LedgerOriginSignature, SemanticStatus
+    from cortex.ledger.origin import (
+        OriginKeyRecord,
+        OriginKeyRegistry,
+        OriginSignatureError,
+        OriginSignaturePolicy,
+        sign_event_origin,
+        verify_event_origin,
+    )
     from cortex.ledger.public_export import (
         ExportAuthority,
         LedgerExportResult,
@@ -22,6 +30,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "LedgerEvent",
+    "LedgerOriginSignature",
     "SemanticStatus",
     "SovereignLedger",
     "ImmutableLedger",
@@ -31,18 +40,31 @@ __all__ = [
     "EnrichmentQueue",
     "ExportAuthority",
     "LedgerExportResult",
+    "OriginKeyRecord",
+    "OriginKeyRegistry",
+    "OriginSignatureError",
+    "OriginSignaturePolicy",
     "public_key_record",
+    "sign_event_origin",
     "write_public_ledger_export",
+    "verify_event_origin",
     "verify_export",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LedgerEvent": ("cortex.ledger.models", "LedgerEvent"),
+    "LedgerOriginSignature": ("cortex.ledger.models", "LedgerOriginSignature"),
     "SemanticStatus": ("cortex.ledger.models", "SemanticStatus"),
     "LedgerStore": ("cortex.ledger.store", "LedgerStore"),
     "LedgerWriter": ("cortex.ledger.writer", "LedgerWriter"),
     "LedgerVerifier": ("cortex.ledger.verifier", "LedgerVerifier"),
     "EnrichmentQueue": ("cortex.ledger.queue", "EnrichmentQueue"),
+    "OriginKeyRecord": ("cortex.ledger.origin", "OriginKeyRecord"),
+    "OriginKeyRegistry": ("cortex.ledger.origin", "OriginKeyRegistry"),
+    "OriginSignatureError": ("cortex.ledger.origin", "OriginSignatureError"),
+    "OriginSignaturePolicy": ("cortex.ledger.origin", "OriginSignaturePolicy"),
+    "sign_event_origin": ("cortex.ledger.origin", "sign_event_origin"),
+    "verify_event_origin": ("cortex.ledger.origin", "verify_event_origin"),
     "ExportAuthority": ("cortex.ledger.public_export", "ExportAuthority"),
     "LedgerExportResult": ("cortex.ledger.public_export", "LedgerExportResult"),
     "public_key_record": ("cortex.ledger.public_export", "public_key_record"),

--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from cortex.ledger.ledger_core import SovereignLedger
     from cortex.ledger.models import LedgerEvent, SemanticStatus
+    from cortex.ledger.public_verifier import verify_export
     from cortex.ledger.queue import EnrichmentQueue
     from cortex.ledger.store import LedgerStore
     from cortex.ledger.verifier import LedgerVerifier
@@ -22,6 +23,7 @@ __all__ = [
     "LedgerWriter",
     "LedgerVerifier",
     "EnrichmentQueue",
+    "verify_export",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
@@ -31,6 +33,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LedgerWriter": ("cortex.ledger.writer", "LedgerWriter"),
     "LedgerVerifier": ("cortex.ledger.verifier", "LedgerVerifier"),
     "EnrichmentQueue": ("cortex.ledger.queue", "EnrichmentQueue"),
+    "verify_export": ("cortex.ledger.public_verifier", "verify_export"),
 }
 
 

--- a/cortex/ledger/models.py
+++ b/cortex/ledger/models.py
@@ -51,6 +51,19 @@ class ActionResult:
 
 
 @dataclass(frozen=True)
+class LedgerOriginSignature:
+    actor_id: str
+    key_id: str
+    signature_alg: str
+    signed_at: str
+    nonce: str
+    signature: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class LedgerEvent:
     event_id: str
     ts: str
@@ -62,6 +75,7 @@ class LedgerEvent:
     intent: IntentPayload | None = None
     correlation_id: str | None = None
     trace_id: str | None = None
+    origin: LedgerOriginSignature | None = None
     prev_hash: str | None = None
     hash: str | None = None
     semantic_status: SemanticStatus = "pending"
@@ -126,6 +140,7 @@ class LedgerEvent:
             "intent": self.intent.to_dict() if self.intent else None,
             "correlation_id": self.correlation_id,
             "trace_id": self.trace_id,
+            "origin": self.origin.to_dict() if self.origin else None,
             "prev_hash": self.prev_hash,
             "hash": self.hash,
             "semantic_status": self.semantic_status,

--- a/cortex/ledger/origin.py
+++ b/cortex/ledger/origin.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import dataclasses
+import secrets
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from cortex.ledger.models import LedgerEvent, LedgerOriginSignature
+from cortex.utils.canonical import canonical_json
+
+
+class OriginSignatureError(ValueError):
+    """Raised when a ledger event fails origin-authenticity validation."""
+
+
+@dataclass(frozen=True)
+class OriginKeyRecord:
+    key_id: str
+    actor_id: str
+    public_key: Ed25519PublicKey
+    permissions: frozenset[str]
+    actor_type: str = "agent"
+    status: str = "active"
+    environment: str = "test"
+    valid_from: str | None = None
+    valid_until: str | None = None
+    hardware_backed: bool = False
+
+    @staticmethod
+    def from_public_key(
+        *,
+        key_id: str,
+        actor_id: str,
+        public_key: Ed25519PublicKey,
+        permissions: Sequence[str],
+        actor_type: str = "agent",
+        status: str = "active",
+        environment: str = "test",
+        valid_from: str | None = None,
+        valid_until: str | None = None,
+        hardware_backed: bool = False,
+    ) -> OriginKeyRecord:
+        return OriginKeyRecord(
+            key_id=key_id,
+            actor_id=actor_id,
+            public_key=public_key,
+            permissions=frozenset(permissions),
+            actor_type=actor_type,
+            status=status,
+            environment=environment,
+            valid_from=valid_from,
+            valid_until=valid_until,
+            hardware_backed=hardware_backed,
+        )
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "actor_id": self.actor_id,
+            "actor_type": self.actor_type,
+            "algorithm": "ed25519",
+            "environment": self.environment,
+            "hardware_backed": self.hardware_backed,
+            "key_id": self.key_id,
+            "permissions": sorted(self.permissions),
+            "public_key": _public_key_b64url(self.public_key),
+            "status": self.status,
+            "valid_from": self.valid_from,
+            "valid_until": self.valid_until,
+        }
+
+
+class OriginKeyRegistry:
+    def __init__(self, records: Sequence[OriginKeyRecord] = ()) -> None:
+        self._records: dict[str, OriginKeyRecord] = {}
+        for record in records:
+            self.add(record)
+
+    def add(self, record: OriginKeyRecord) -> None:
+        if record.key_id in self._records:
+            raise ValueError(f"duplicate origin key id: {record.key_id}")
+        self._records[record.key_id] = record
+
+    def get(self, key_id: str) -> OriginKeyRecord | None:
+        return self._records.get(key_id)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "keys": [
+                record.to_public_dict()
+                for record in sorted(self._records.values(), key=lambda item: item.key_id)
+            ],
+            "schema_version": "cortex-origin-key-registry-v1",
+        }
+
+
+@dataclass(frozen=True)
+class OriginSignaturePolicy:
+    registry: OriginKeyRegistry
+    strict: bool = True
+
+    @staticmethod
+    def strict_mode(registry: OriginKeyRegistry) -> OriginSignaturePolicy:
+        return OriginSignaturePolicy(registry=registry, strict=True)
+
+    def validate_event(self, event: LedgerEvent) -> None:
+        if not self.strict:
+            return
+        verify_event_origin(event, self.registry)
+
+
+def sign_event_origin(
+    event: LedgerEvent,
+    *,
+    key_id: str,
+    private_key: Ed25519PrivateKey,
+    signed_at: str | None = None,
+    nonce: str | None = None,
+) -> LedgerEvent:
+    """Attach an Ed25519 origin envelope to an event before ledger persistence."""
+    unsigned_origin = LedgerOriginSignature(
+        actor_id=event.actor,
+        key_id=key_id,
+        signature_alg="ed25519",
+        signed_at=signed_at or _utc_now(),
+        nonce=nonce or secrets.token_urlsafe(24),
+        signature=None,
+    )
+    unsigned_event = dataclasses.replace(event, origin=unsigned_origin)
+    signature = _b64url_encode(private_key.sign(origin_signature_scope(unsigned_event)))
+    signed_origin = dataclasses.replace(unsigned_origin, signature=signature)
+    return dataclasses.replace(unsigned_event, origin=signed_origin)
+
+
+def verify_event_origin(event: LedgerEvent, registry: OriginKeyRegistry) -> None:
+    origin = event.origin
+    if origin is None or not origin.signature:
+        raise OriginSignatureError("origin_signature_missing")
+    if origin.signature_alg != "ed25519":
+        raise OriginSignatureError(f"origin_signature_alg_unsupported:{origin.signature_alg}")
+    if origin.actor_id != event.actor:
+        raise OriginSignatureError("origin_actor_mismatch")
+
+    key = registry.get(origin.key_id)
+    if key is None:
+        raise OriginSignatureError(f"origin_key_missing:{origin.key_id}")
+    if key.status != "active":
+        raise OriginSignatureError(f"origin_key_not_active:{origin.key_id}")
+    if key.actor_id != origin.actor_id:
+        raise OriginSignatureError("origin_key_actor_mismatch")
+    if event.action not in key.permissions:
+        raise OriginSignatureError(f"origin_key_permission_denied:{event.action}")
+    _validate_key_time(key, origin.signed_at)
+
+    try:
+        key.public_key.verify(_b64url_decode(origin.signature), origin_signature_scope(event))
+    except (InvalidSignature, ValueError) as exc:
+        raise OriginSignatureError("origin_signature_invalid") from exc
+
+
+def origin_signature_scope(event: LedgerEvent) -> bytes:
+    payload = event.to_payload()
+    payload.pop("hash", None)
+    payload.pop("prev_hash", None)
+    origin = payload.get("origin")
+    if not isinstance(origin, dict):
+        raise OriginSignatureError("origin_signature_missing")
+    signature_scope = dict(origin)
+    signature_scope.pop("signature", None)
+    payload["origin"] = signature_scope
+    return canonical_json(payload).encode("utf-8")
+
+
+def _validate_key_time(key: OriginKeyRecord, signed_at: str) -> None:
+    signed = _parse_utc(signed_at)
+    if key.valid_from is not None and signed < _parse_utc(key.valid_from):
+        raise OriginSignatureError(f"origin_key_not_yet_valid:{key.key_id}")
+    if key.valid_until is not None and signed > _parse_utc(key.valid_until):
+        raise OriginSignatureError(f"origin_key_expired:{key.key_id}")
+
+
+def _parse_utc(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise OriginSignatureError("origin_timestamp_invalid") from exc
+    if parsed.tzinfo is None:
+        raise OriginSignatureError("origin_timestamp_missing_timezone")
+    return parsed
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(value: str) -> bytes:
+    if not value:
+        raise ValueError("empty_base64url")
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.b64decode((value + padding).encode("ascii"), altchars=b"-_", validate=True)
+    except (binascii.Error, UnicodeEncodeError) as exc:
+        raise ValueError("invalid_base64url") from exc
+
+
+def _public_key_b64url(public_key: Ed25519PublicKey) -> str:
+    return _b64url_encode(public_key.public_bytes(Encoding.Raw, PublicFormat.Raw))

--- a/cortex/ledger/public_export.py
+++ b/cortex/ledger/public_export.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from cortex.ledger.public_verifier import verify_export
+
+
+@dataclass(frozen=True)
+class ExportAuthority:
+    key_id: str
+    actor_id: str
+    private_key: Ed25519PrivateKey
+    environment: str = "test"
+
+
+@dataclass(frozen=True)
+class LedgerExportResult:
+    export_dir: Path
+    manifest_path: Path
+    events_path: Path
+    public_keys_path: Path
+    verification_report_path: Path | None
+    manifest_hash: str
+    verification_result: str | None
+
+
+def write_public_ledger_export(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    export_dir: str | Path,
+    public_keys: Sequence[Mapping[str, Any]],
+    export_authority: ExportAuthority,
+    export_id: str,
+    tenant_id: str,
+    stream_id: str,
+    purpose: str = "forensic_ledger_export",
+    environment: str = "test",
+    created_at: str | None = None,
+    include_verification_report: bool = False,
+) -> LedgerExportResult:
+    """Write a signed public ledger export package without exporting fact payloads."""
+    if not events:
+        raise ValueError("at least one ledger event is required")
+    root = Path(export_dir)
+    root.mkdir(parents=True, exist_ok=True)
+
+    event_objects = [dict(event) for event in events]
+    _validate_event_package_scope(event_objects, tenant_id=tenant_id, stream_id=stream_id)
+
+    events_path = root / "events.jsonl"
+    public_keys_path = root / "public-keys.json"
+    key_events_path = root / "key-events.jsonl"
+    schema_path = root / "schema.json"
+    verification_profile_path = root / "verification-profile.json"
+    manifest_path = root / "manifest.json"
+    verification_report_path = root / "verification-report.json"
+
+    _write_text_atomic(
+        events_path,
+        "".join(_canonical_json(event) + "\n" for event in event_objects),
+    )
+    _write_text_atomic(key_events_path, "")
+    _write_json_atomic(schema_path, _schema_document())
+    _write_json_atomic(verification_profile_path, _verification_profile_document())
+    _write_json_atomic(
+        public_keys_path,
+        _key_registry_document(
+            tenant_id=tenant_id,
+            public_keys=public_keys,
+            export_authority=export_authority,
+            generated_at=created_at or _utc_now(),
+        ),
+    )
+
+    manifest_without_signature = _manifest_document(
+        events=event_objects,
+        export_id=export_id,
+        tenant_id=tenant_id,
+        stream_id=stream_id,
+        created_by=export_authority.actor_id,
+        created_at=created_at or _utc_now(),
+        purpose=purpose,
+        environment=environment,
+        root=root,
+    )
+    manifest = dict(manifest_without_signature)
+    manifest["signature"] = {
+        "key_id": export_authority.key_id,
+        "signature_scope": "canonical_manifest_without_signature",
+        "value": _b64url_encode(
+            export_authority.private_key.sign(
+                _canonical_json(manifest_without_signature).encode("utf-8")
+            )
+        ),
+    }
+    _write_json_atomic(manifest_path, manifest)
+
+    verification_result: str | None = None
+    if include_verification_report:
+        report = verify_export(root)
+        verification_result = str(report["result"])
+        _write_json_atomic(verification_report_path, report)
+    else:
+        verification_report_path = None
+
+    return LedgerExportResult(
+        export_dir=root,
+        manifest_path=manifest_path,
+        events_path=events_path,
+        public_keys_path=public_keys_path,
+        verification_report_path=verification_report_path,
+        manifest_hash=_sha256_file(manifest_path),
+        verification_result=verification_result,
+    )
+
+
+def public_key_record(
+    *,
+    key_id: str,
+    actor_id: str,
+    public_key: Ed25519PublicKey,
+    permissions: Sequence[str],
+    actor_type: str = "agent",
+    environment: str = "test",
+    valid_from: str = "2026-01-01T00:00:00Z",
+    valid_until: str = "2027-01-01T00:00:00Z",
+    hardware_backed: bool = False,
+) -> dict[str, Any]:
+    """Build a public key registry record for exported ledger verification."""
+    return {
+        "actor_id": actor_id,
+        "actor_type": actor_type,
+        "algorithm": "ed25519",
+        "environment": environment,
+        "hardware_backed": hardware_backed,
+        "key_id": key_id,
+        "permissions": list(permissions),
+        "public_key": _public_key_b64url(public_key),
+        "status": "active",
+        "valid_from": valid_from,
+        "valid_until": valid_until,
+    }
+
+
+def _manifest_document(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    export_id: str,
+    tenant_id: str,
+    stream_id: str,
+    created_by: str,
+    created_at: str,
+    purpose: str,
+    environment: str,
+    root: Path,
+) -> dict[str, Any]:
+    hashes = [str(event["hash"]) for event in events]
+    first = events[0]
+    last = events[-1]
+    return {
+        "algorithms": {
+            "event_hash": "sha256",
+            "manifest_hash": "sha256",
+            "merkle": "merkle-profile-v1",
+            "signature": "ed25519",
+        },
+        "counts": {
+            "erasure_tombstone_count": 0,
+            "event_count": len(events),
+            "redacted_event_count": 0,
+        },
+        "created_at": created_at,
+        "created_by": created_by,
+        "environment": environment,
+        "export_id": export_id,
+        "hashes": {
+            "events_file_sha256": _sha256_file(root / "events.jsonl"),
+            "first_event_hash": hashes[0],
+            "key_events_file_sha256": _sha256_file(root / "key-events.jsonl"),
+            "last_event_hash": hashes[-1],
+            "merkle_root": _merkle_root_v1(hashes),
+            "public_keys_file_sha256": _sha256_file(root / "public-keys.json"),
+            "schema_file_sha256": _sha256_file(root / "schema.json"),
+            "verification_profile_sha256": _sha256_file(root / "verification-profile.json"),
+        },
+        "limitations": [],
+        "purpose": purpose,
+        "range": {
+            "first_recorded_at": first["recorded_at"],
+            "first_sequence": first["sequence"],
+            "last_recorded_at": last["recorded_at"],
+            "last_sequence": last["sequence"],
+        },
+        "schema_version": "cortex-forensic-export-manifest-v1",
+        "stream_id": stream_id,
+        "tenant_id": tenant_id,
+    }
+
+
+def _key_registry_document(
+    *,
+    tenant_id: str,
+    public_keys: Sequence[Mapping[str, Any]],
+    export_authority: ExportAuthority,
+    generated_at: str,
+) -> dict[str, Any]:
+    keys = [dict(key) for key in public_keys]
+    if not any(key.get("key_id") == export_authority.key_id for key in keys):
+        keys.append(
+            public_key_record(
+                key_id=export_authority.key_id,
+                actor_id=export_authority.actor_id,
+                actor_type="export_authority",
+                environment=export_authority.environment,
+                public_key=export_authority.private_key.public_key(),
+                permissions=["ledger.export"],
+            )
+        )
+    return {
+        "generated_at": generated_at,
+        "keys": sorted(keys, key=lambda key: str(key["key_id"])),
+        "schema_version": "cortex-key-registry-v1",
+        "tenant_id": tenant_id,
+    }
+
+
+def _schema_document() -> dict[str, str]:
+    return {"profile": "public-v1-strict", "schema_version": "cortex-ledger-event-schema-v1"}
+
+
+def _verification_profile_document() -> dict[str, str]:
+    return {
+        "canonicalization": "canonical-json-v1",
+        "merkle": "merkle-profile-v1",
+        "profile": "public-v1-strict",
+        "schema_version": "cortex-verification-profile-v1",
+    }
+
+
+def _validate_event_package_scope(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    tenant_id: str,
+    stream_id: str,
+) -> None:
+    previous_sequence: int | None = None
+    previous_hash = "GENESIS"
+    for event in events:
+        if event.get("tenant_id") != tenant_id:
+            raise ValueError(f"event tenant mismatch: {event.get('event_id')}")
+        if event.get("stream_id") != stream_id:
+            raise ValueError(f"event stream mismatch: {event.get('event_id')}")
+        detail = event.get("detail")
+        if isinstance(detail, Mapping) and any(
+            field in detail for field in ("content", "payload", "plaintext", "fact_content")
+        ):
+            raise ValueError(f"event contains inline fact payload: {event.get('event_id')}")
+        if event.get("prev_hash") != previous_hash:
+            raise ValueError(f"event chain break before export: {event.get('event_id')}")
+        sequence = event.get("sequence")
+        if not isinstance(sequence, int):
+            raise ValueError(f"event sequence invalid: {event.get('event_id')}")
+        if previous_sequence is not None and sequence != previous_sequence + 1:
+            raise ValueError(f"event sequence gap: {event.get('event_id')}")
+        previous_sequence = sequence
+        previous_hash = str(event.get("hash"))
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _write_json_atomic(path: Path, value: Mapping[str, Any]) -> None:
+    _write_text_atomic(path, _canonical_json(value))
+
+
+def _write_text_atomic(path: Path, value: str) -> None:
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(value, encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _public_key_b64url(public_key: Ed25519PublicKey) -> str:
+    return _b64url_encode(public_key.public_bytes(Encoding.Raw, PublicFormat.Raw))
+
+
+def _merkle_root_v1(event_hashes: Sequence[str]) -> str:
+    nodes = [
+        _sha256_bytes(("CORTEX-MERKLE-LEAF-v1:" + event_hash).encode("utf-8"))
+        for event_hash in event_hashes
+    ]
+    if not nodes:
+        return _sha256_bytes(b"CORTEX-MERKLE-EMPTY-v1")
+
+    while len(nodes) > 1:
+        next_nodes: list[str] = []
+        for index in range(0, len(nodes), 2):
+            left = nodes[index]
+            right = nodes[index + 1] if index + 1 < len(nodes) else None
+            if right is None:
+                next_nodes.append(left)
+            else:
+                next_nodes.append(
+                    _sha256_bytes(("CORTEX-MERKLE-NODE-v1:" + left + right).encode("utf-8"))
+                )
+        nodes = next_nodes
+    return nodes[0]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/cortex/ledger/public_verifier.py
+++ b/cortex/ledger/public_verifier.py
@@ -1,0 +1,683 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+PUBLIC_V1_STRICT = "public-v1-strict"
+REPORT_GUARANTEES = (
+    "integrity_verified",
+    "origin_authenticity_verified",
+    "authority_verified",
+    "replay_consistency_verified",
+    "temporal_consistency_verified",
+    "online_freshness_verified",
+    "completeness_verified",
+    "truth_verified",
+)
+STRICT_REQUIRED_EVENT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "stream_id",
+        "tenant_id",
+        "sequence",
+        "event_id",
+        "nonce",
+        "issued_at",
+        "recorded_at",
+        "actor_id",
+        "actor_key_id",
+        "action",
+        "project",
+        "target",
+        "detail",
+        "prev_hash",
+        "hash_alg",
+        "hash",
+        "signature_alg",
+        "origin_signature",
+    }
+)
+
+ResultCode = Literal["VALID_FULL_STRICT", "VALID_WITH_LIMITATIONS", "INVALID"]
+
+
+class PublicVerifierError(ValueError):
+    """Input cannot be parsed as a public ledger export."""
+
+
+@dataclass(frozen=True)
+class VerificationInput:
+    export_dir: Path
+    events_path: Path
+    manifest_path: Path
+    public_keys_path: Path
+    key_events_path: Path
+    schema_path: Path
+    verification_profile_path: Path
+
+    @staticmethod
+    def from_export_dir(export_dir: str | Path) -> VerificationInput:
+        root = Path(export_dir)
+        return VerificationInput(
+            export_dir=root,
+            events_path=root / "events.jsonl",
+            manifest_path=root / "manifest.json",
+            public_keys_path=root / "public-keys.json",
+            key_events_path=root / "key-events.jsonl",
+            schema_path=root / "schema.json",
+            verification_profile_path=root / "verification-profile.json",
+        )
+
+
+def verify_export(export_dir: str | Path) -> dict[str, Any]:
+    """Verify an exported public ledger package without SQLite, network, or runtime trust."""
+    verifier = _PublicLedgerVerifier(VerificationInput.from_export_dir(export_dir))
+    return verifier.verify()
+
+
+class _PublicLedgerVerifier:
+    def __init__(self, paths: VerificationInput) -> None:
+        self.paths = paths
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+        self.events: list[dict[str, Any]] = []
+        self.key_registry: dict[str, Any] | None = None
+        self.key_index: dict[str, dict[str, Any]] = {}
+        self.manifest: dict[str, Any] | None = None
+        self.event_hashes: list[str] = []
+        self.guarantees: dict[str, bool] = {name: False for name in REPORT_GUARANTEES}
+
+    def verify(self) -> dict[str, Any]:
+        self.events = self._load_events()
+        self.key_registry = self._load_optional_object(
+            self.paths.public_keys_path,
+            missing_warning="public_keys_missing",
+        )
+        if self.key_registry is not None:
+            self.key_index = self._build_key_index(self.key_registry)
+        self.manifest = self._load_optional_object(
+            self.paths.manifest_path,
+            missing_warning="manifest_missing",
+        )
+
+        self._verify_events()
+        self._verify_manifest()
+        self._finalize_guarantees()
+        return self._report()
+
+    def _load_events(self) -> list[dict[str, Any]]:
+        if not self.paths.events_path.exists():
+            self.errors.append("events_jsonl_missing")
+            return []
+
+        events: list[dict[str, Any]] = []
+        try:
+            lines = self.paths.events_path.read_text(encoding="utf-8").splitlines()
+        except OSError as exc:
+            self.errors.append(f"events_jsonl_unreadable:{exc.__class__.__name__}")
+            return []
+
+        for line_number, line in enumerate(lines, start=1):
+            if not line:
+                self.errors.append(f"events_jsonl_blank_line:{line_number}")
+                continue
+            try:
+                value = json.loads(line, object_pairs_hook=_reject_duplicate_keys)
+            except json.JSONDecodeError as exc:
+                self.errors.append(f"events_jsonl_invalid_json:{line_number}:{exc.msg}")
+                continue
+            except ValueError as exc:
+                self.errors.append(f"events_jsonl_invalid_json:{line_number}:{exc}")
+                continue
+            if not isinstance(value, dict):
+                self.errors.append(f"events_jsonl_non_object:{line_number}")
+                continue
+            if _contains_float(value):
+                self.errors.append(f"events_jsonl_float_not_allowed:{line_number}")
+                continue
+            events.append(value)
+
+        if not events and not self.errors:
+            self.errors.append("events_jsonl_empty")
+        return events
+
+    def _load_optional_object(self, path: Path, *, missing_warning: str) -> dict[str, Any] | None:
+        if not path.exists():
+            self.warnings.append(missing_warning)
+            return None
+        try:
+            value = json.loads(
+                path.read_text(encoding="utf-8"), object_pairs_hook=_reject_duplicate_keys
+            )
+        except json.JSONDecodeError as exc:
+            self.errors.append(f"{path.name}_invalid_json:{exc.msg}")
+            return None
+        except (OSError, ValueError) as exc:
+            self.errors.append(f"{path.name}_unreadable:{exc.__class__.__name__}:{exc}")
+            return None
+        if not isinstance(value, dict):
+            self.errors.append(f"{path.name}_non_object")
+            return None
+        if _contains_float(value):
+            self.errors.append(f"{path.name}_float_not_allowed")
+            return None
+        return value
+
+    def _build_key_index(self, registry: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+        keys = registry.get("keys")
+        if not isinstance(keys, list):
+            self.errors.append("public_keys_missing_keys_array")
+            return {}
+
+        index: dict[str, dict[str, Any]] = {}
+        for key in keys:
+            if not isinstance(key, dict):
+                self.errors.append("public_keys_non_object_key")
+                continue
+            key_id = key.get("key_id")
+            if not isinstance(key_id, str) or not key_id:
+                self.errors.append("public_keys_missing_key_id")
+                continue
+            if key_id in index:
+                self.errors.append(f"public_keys_duplicate_key_id:{key_id}")
+                continue
+            index[key_id] = key
+        return index
+
+    def _verify_events(self) -> None:
+        seen_event_ids: set[str] = set()
+        seen_nonces: set[str] = set()
+        previous_hash = "GENESIS"
+        previous_sequence: int | None = None
+        integrity_ok = bool(self.events)
+        origin_ok = bool(self.events) and bool(self.key_index)
+        authority_ok = bool(self.events) and bool(self.key_index)
+        replay_ok = bool(self.events)
+        temporal_ok = bool(self.events)
+
+        for index, event in enumerate(self.events, start=1):
+            missing = sorted(STRICT_REQUIRED_EVENT_FIELDS - event.keys())
+            if missing:
+                self.errors.append(f"event_missing_required_fields:{index}:{','.join(missing)}")
+                integrity_ok = False
+                origin_ok = False
+                authority_ok = False
+                replay_ok = False
+                temporal_ok = False
+                continue
+
+            if event.get("hash_alg") != "sha256":
+                self.errors.append(f"event_unsupported_hash_alg:{index}:{event.get('hash_alg')}")
+                integrity_ok = False
+            if event.get("signature_alg") != "ed25519":
+                self.errors.append(
+                    f"event_unsupported_signature_alg:{index}:{event.get('signature_alg')}"
+                )
+                origin_ok = False
+
+            event_id = _require_str(event, "event_id", index, self.errors)
+            nonce = _require_str(event, "nonce", index, self.errors)
+            sequence = _require_int(event, "sequence", index, self.errors)
+            if event_id in seen_event_ids:
+                self.errors.append(f"event_replay_duplicate_event_id:{event_id}")
+                replay_ok = False
+            seen_event_ids.add(event_id)
+            if nonce in seen_nonces:
+                self.errors.append(f"event_replay_duplicate_nonce:{nonce}")
+                replay_ok = False
+            seen_nonces.add(nonce)
+
+            if previous_sequence is not None and sequence != previous_sequence + 1:
+                self.errors.append(f"event_sequence_gap:{index}:expected:{previous_sequence + 1}")
+                replay_ok = False
+            previous_sequence = sequence
+
+            prev_hash = _require_str(event, "prev_hash", index, self.errors)
+            if prev_hash != previous_hash:
+                self.errors.append(f"event_chain_break:{index}:expected:{previous_hash}")
+                integrity_ok = False
+
+            computed_hash = _event_hash(event)
+            expected_hash = _require_str(event, "hash", index, self.errors)
+            self.event_hashes.append(expected_hash)
+            if computed_hash != expected_hash:
+                self.errors.append(f"event_hash_mismatch:{event_id}")
+                integrity_ok = False
+            previous_hash = expected_hash
+
+            event_temporal_ok = self._verify_event_time(event, index)
+            temporal_ok = temporal_ok and event_temporal_ok
+
+            key = self.key_index.get(str(event.get("actor_key_id")))
+            if key is None:
+                self.warnings.append(f"event_actor_key_missing:{event_id}")
+                origin_ok = False
+                authority_ok = False
+                temporal_ok = False
+                continue
+
+            if key.get("actor_id") != event.get("actor_id"):
+                self.errors.append(f"event_actor_key_actor_mismatch:{event_id}")
+                authority_ok = False
+            if key.get("algorithm") != "ed25519":
+                self.errors.append(f"event_actor_key_unsupported_algorithm:{event_id}")
+                origin_ok = False
+            if event.get("action") not in _string_list(key.get("permissions")):
+                self.errors.append(f"event_actor_key_permission_denied:{event_id}")
+                authority_ok = False
+            if not self._key_valid_for_event(key, event, index):
+                temporal_ok = False
+                authority_ok = False
+
+            try:
+                _verify_ed25519(
+                    _event_signature_scope(event),
+                    str(event["origin_signature"]),
+                    str(key["public_key"]),
+                )
+            except (InvalidSignature, PublicVerifierError, KeyError, TypeError, ValueError) as exc:
+                self.errors.append(
+                    f"event_origin_signature_invalid:{event_id}:{exc.__class__.__name__}"
+                )
+                origin_ok = False
+
+        self.guarantees["integrity_verified"] = integrity_ok and not _has_error_prefix(
+            self.errors, ("event_hash_", "event_chain_", "event_missing_", "event_unsupported_hash")
+        )
+        self.guarantees["origin_authenticity_verified"] = origin_ok
+        self.guarantees["authority_verified"] = authority_ok
+        self.guarantees["replay_consistency_verified"] = replay_ok
+        self.guarantees["temporal_consistency_verified"] = temporal_ok
+
+    def _verify_event_time(self, event: Mapping[str, Any], index: int) -> bool:
+        try:
+            issued_at = _parse_utc(str(event["issued_at"]))
+            recorded_at = _parse_utc(str(event["recorded_at"]))
+        except (KeyError, PublicVerifierError) as exc:
+            self.errors.append(f"event_timestamp_invalid:{index}:{exc.__class__.__name__}")
+            return False
+        if recorded_at < issued_at:
+            self.errors.append(f"event_recorded_before_issued:{index}")
+            return False
+        return True
+
+    def _key_valid_for_event(
+        self,
+        key: Mapping[str, Any],
+        event: Mapping[str, Any],
+        index: int,
+    ) -> bool:
+        try:
+            issued_at = _parse_utc(str(event["issued_at"]))
+            valid_from = _parse_utc(str(key["valid_from"]))
+            valid_until = _parse_utc(str(key["valid_until"]))
+        except (KeyError, PublicVerifierError) as exc:
+            self.errors.append(f"event_key_validity_invalid:{index}:{exc.__class__.__name__}")
+            return False
+        if key.get("status") != "active":
+            self.errors.append(f"event_key_not_active:{index}")
+            return False
+        if not valid_from <= issued_at <= valid_until:
+            self.errors.append(f"event_key_outside_validity:{index}")
+            return False
+        return True
+
+    def _verify_manifest(self) -> None:
+        if self.manifest is None:
+            return
+
+        manifest_signature_ok = self._verify_manifest_signature()
+        file_hashes_ok = self._verify_manifest_file_hashes()
+        range_ok = self._verify_manifest_range()
+        merkle_ok = self._verify_manifest_merkle()
+        counts_ok = self._verify_manifest_counts()
+        manifest_scope_ok = self._verify_manifest_scope()
+
+        self.guarantees["completeness_verified"] = (
+            manifest_signature_ok
+            and file_hashes_ok
+            and range_ok
+            and merkle_ok
+            and counts_ok
+            and manifest_scope_ok
+            and self.guarantees["integrity_verified"]
+        )
+
+    def _verify_manifest_signature(self) -> bool:
+        assert self.manifest is not None
+        signature = self.manifest.get("signature")
+        if not isinstance(signature, dict):
+            self.errors.append("manifest_signature_missing")
+            return False
+        key_id = signature.get("key_id")
+        value = signature.get("value")
+        key = self.key_index.get(str(key_id))
+        if key is None:
+            self.warnings.append(f"manifest_signature_key_missing:{key_id}")
+            return False
+        if "ledger.export" not in _string_list(key.get("permissions")):
+            self.errors.append(f"manifest_signature_permission_denied:{key_id}")
+            return False
+        try:
+            _verify_ed25519(
+                _manifest_signature_scope(self.manifest), str(value), str(key["public_key"])
+            )
+        except (InvalidSignature, PublicVerifierError, KeyError, TypeError, ValueError) as exc:
+            self.errors.append(f"manifest_signature_invalid:{exc.__class__.__name__}")
+            return False
+        return True
+
+    def _verify_manifest_file_hashes(self) -> bool:
+        assert self.manifest is not None
+        hashes = self.manifest.get("hashes")
+        if not isinstance(hashes, dict):
+            self.errors.append("manifest_hashes_missing")
+            return False
+        expected = {
+            "events_file_sha256": self.paths.events_path,
+            "schema_file_sha256": self.paths.schema_path,
+            "public_keys_file_sha256": self.paths.public_keys_path,
+            "key_events_file_sha256": self.paths.key_events_path,
+            "verification_profile_sha256": self.paths.verification_profile_path,
+        }
+        ok = True
+        for field, path in expected.items():
+            expected_hash = hashes.get(field)
+            if not isinstance(expected_hash, str):
+                self.errors.append(f"manifest_hash_missing:{field}")
+                ok = False
+                continue
+            if not path.exists():
+                self.errors.append(f"manifest_file_missing:{path.name}")
+                ok = False
+                continue
+            actual_hash = _sha256_file(path)
+            if actual_hash != expected_hash:
+                self.errors.append(f"manifest_file_hash_mismatch:{field}")
+                ok = False
+        return ok
+
+    def _verify_manifest_range(self) -> bool:
+        assert self.manifest is not None
+        if not self.events:
+            self.errors.append("manifest_range_without_events")
+            return False
+        event_range = self.manifest.get("range")
+        if not isinstance(event_range, dict):
+            self.errors.append("manifest_range_missing")
+            return False
+        first = self.events[0]
+        last = self.events[-1]
+        expected = {
+            "first_sequence": first.get("sequence"),
+            "last_sequence": last.get("sequence"),
+            "first_recorded_at": first.get("recorded_at"),
+            "last_recorded_at": last.get("recorded_at"),
+        }
+        ok = True
+        for field, expected_value in expected.items():
+            if event_range.get(field) != expected_value:
+                self.errors.append(f"manifest_range_mismatch:{field}")
+                ok = False
+        return ok
+
+    def _verify_manifest_merkle(self) -> bool:
+        assert self.manifest is not None
+        hashes = self.manifest.get("hashes")
+        if not isinstance(hashes, dict):
+            return False
+        expected_root = hashes.get("merkle_root")
+        if not isinstance(expected_root, str):
+            self.errors.append("manifest_merkle_root_missing")
+            return False
+        actual_root = _merkle_root_v1(self.event_hashes)
+        if actual_root != expected_root:
+            self.errors.append("manifest_merkle_root_mismatch")
+            return False
+        return True
+
+    def _verify_manifest_counts(self) -> bool:
+        assert self.manifest is not None
+        counts = self.manifest.get("counts")
+        if not isinstance(counts, dict):
+            self.errors.append("manifest_counts_missing")
+            return False
+        if counts.get("event_count") != len(self.events):
+            self.errors.append("manifest_event_count_mismatch")
+            return False
+        return True
+
+    def _verify_manifest_scope(self) -> bool:
+        assert self.manifest is not None
+        stream_id = self.manifest.get("stream_id")
+        tenant_id = self.manifest.get("tenant_id")
+        ok = True
+        for event in self.events:
+            if event.get("stream_id") != stream_id:
+                self.errors.append(f"manifest_stream_mismatch:{event.get('event_id')}")
+                ok = False
+            if event.get("tenant_id") != tenant_id:
+                self.errors.append(f"manifest_tenant_mismatch:{event.get('event_id')}")
+                ok = False
+        return ok
+
+    def _finalize_guarantees(self) -> None:
+        self.guarantees["online_freshness_verified"] = False
+        self.guarantees["truth_verified"] = False
+
+        if self.manifest is not None and self.guarantees["completeness_verified"]:
+            self.guarantees["authority_verified"] = (
+                self.guarantees["authority_verified"] and self._manifest_export_authority_ok()
+            )
+
+    def _manifest_export_authority_ok(self) -> bool:
+        assert self.manifest is not None
+        signature = self.manifest.get("signature")
+        if not isinstance(signature, dict):
+            return False
+        key = self.key_index.get(str(signature.get("key_id")))
+        return key is not None and "ledger.export" in _string_list(key.get("permissions"))
+
+    def _report(self) -> dict[str, Any]:
+        errors = sorted(set(self.errors))
+        warnings = sorted(set(self.warnings))
+        result = _result_code(self.guarantees, errors)
+        return {
+            "profile": PUBLIC_V1_STRICT,
+            "result": result,
+            "guarantees": {name: bool(self.guarantees[name]) for name in REPORT_GUARANTEES},
+            "counts": {
+                "events": len(self.events),
+                "errors": len(errors),
+                "warnings": len(warnings),
+            },
+            "artifacts": self._artifact_hashes(),
+            "event_hashes": list(self.event_hashes),
+            "errors": errors,
+            "warnings": warnings,
+        }
+
+    def _artifact_hashes(self) -> dict[str, str | None]:
+        artifacts = {
+            "events.jsonl": self.paths.events_path,
+            "manifest.json": self.paths.manifest_path,
+            "public-keys.json": self.paths.public_keys_path,
+            "key-events.jsonl": self.paths.key_events_path,
+            "schema.json": self.paths.schema_path,
+            "verification-profile.json": self.paths.verification_profile_path,
+        }
+        return {
+            artifact_name: _sha256_file(path) if path.exists() else None
+            for artifact_name, path in artifacts.items()
+        }
+
+
+def _result_code(guarantees: Mapping[str, bool], errors: Sequence[str]) -> ResultCode:
+    if errors:
+        return "INVALID"
+    required_offline_guarantees = (
+        "integrity_verified",
+        "origin_authenticity_verified",
+        "authority_verified",
+        "replay_consistency_verified",
+        "temporal_consistency_verified",
+        "completeness_verified",
+    )
+    if all(guarantees[name] for name in required_offline_guarantees):
+        return "VALID_FULL_STRICT"
+    return "VALID_WITH_LIMITATIONS"
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    seen: set[str] = set()
+    out: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate JSON key: {key}")
+        seen.add(key)
+        out[key] = value
+    return out
+
+
+def _contains_float(value: Any) -> bool:
+    if isinstance(value, float):
+        return True
+    if isinstance(value, Mapping):
+        return any(_contains_float(child) for child in value.values())
+    if isinstance(value, list):
+        return any(_contains_float(child) for child in value)
+    return False
+
+
+def _canonical_json(value: Any) -> str:
+    if _contains_float(value):
+        raise PublicVerifierError("float_not_allowed")
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _b64url_decode(value: str) -> bytes:
+    if not value:
+        raise PublicVerifierError("empty_base64url")
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.b64decode((value + padding).encode("ascii"), altchars=b"-_", validate=True)
+    except (binascii.Error, UnicodeEncodeError) as exc:
+        raise PublicVerifierError("invalid_base64url") from exc
+
+
+def _verify_ed25519(payload: bytes, signature_b64url: str, public_key_b64url: str) -> None:
+    public_key = Ed25519PublicKey.from_public_bytes(_b64url_decode(public_key_b64url))
+    public_key.verify(_b64url_decode(signature_b64url), payload)
+
+
+def _event_hash(event: Mapping[str, Any]) -> str:
+    scope = dict(event)
+    scope.pop("hash", None)
+    scope.pop("origin_signature", None)
+    return _sha256_bytes(_canonical_json(scope).encode("utf-8"))
+
+
+def _event_signature_scope(event: Mapping[str, Any]) -> bytes:
+    scope = dict(event)
+    scope.pop("origin_signature", None)
+    return _canonical_json(scope).encode("utf-8")
+
+
+def _manifest_signature_scope(manifest: Mapping[str, Any]) -> bytes:
+    scope = dict(manifest)
+    scope.pop("signature", None)
+    return _canonical_json(scope).encode("utf-8")
+
+
+def _merkle_root_v1(event_hashes: Sequence[str]) -> str:
+    nodes = [
+        _sha256_bytes(("CORTEX-MERKLE-LEAF-v1:" + event_hash).encode("utf-8"))
+        for event_hash in event_hashes
+    ]
+    if not nodes:
+        return _sha256_bytes(b"CORTEX-MERKLE-EMPTY-v1")
+
+    while len(nodes) > 1:
+        next_nodes: list[str] = []
+        for index in range(0, len(nodes), 2):
+            left = nodes[index]
+            right = nodes[index + 1] if index + 1 < len(nodes) else None
+            if right is None:
+                next_nodes.append(left)
+            else:
+                next_nodes.append(
+                    _sha256_bytes(("CORTEX-MERKLE-NODE-v1:" + left + right).encode("utf-8"))
+                )
+        nodes = next_nodes
+    return nodes[0]
+
+
+def _parse_utc(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise PublicVerifierError("invalid_timestamp") from exc
+    if parsed.tzinfo is None:
+        raise PublicVerifierError("timestamp_missing_timezone")
+    return parsed
+
+
+def _require_str(
+    event: Mapping[str, Any],
+    field: str,
+    index: int,
+    errors: list[str],
+) -> str:
+    value = event.get(field)
+    if not isinstance(value, str) or not value:
+        errors.append(f"event_field_invalid:{index}:{field}")
+        return ""
+    return value
+
+
+def _require_int(
+    event: Mapping[str, Any],
+    field: str,
+    index: int,
+    errors: list[str],
+) -> int:
+    value = event.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        errors.append(f"event_field_invalid:{index}:{field}")
+        return 0
+    return value
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _has_error_prefix(errors: Sequence[str], prefixes: Sequence[str]) -> bool:
+    return any(error.startswith(tuple(prefixes)) for error in errors)

--- a/cortex/ledger/verifier.py
+++ b/cortex/ledger/verifier.py
@@ -4,7 +4,13 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from cortex.ledger.models import ActionResult, ActionTarget, IntentPayload, LedgerEvent
+from cortex.ledger.models import (
+    ActionResult,
+    ActionTarget,
+    IntentPayload,
+    LedgerEvent,
+    LedgerOriginSignature,
+)
 from cortex.ledger.store import LedgerStore
 
 if TYPE_CHECKING:
@@ -139,6 +145,11 @@ class LedgerVerifier:
         target = ActionTarget(**payload["target"])
         result = ActionResult(**payload["result"])
         intent = IntentPayload(**payload["intent"]) if payload.get("intent") else None
+        origin = (
+            LedgerOriginSignature(**payload["origin"])
+            if isinstance(payload.get("origin"), dict)
+            else None
+        )
 
         return LedgerEvent(
             event_id=payload["event_id"],
@@ -151,6 +162,7 @@ class LedgerVerifier:
             intent=intent,
             correlation_id=payload.get("correlation_id"),
             trace_id=payload.get("trace_id"),
+            origin=origin,
             prev_hash=payload.get("prev_hash"),
             hash=payload.get("hash"),
             semantic_status=payload.get("semantic_status", "pending"),

--- a/cortex/ledger/writer.py
+++ b/cortex/ledger/writer.py
@@ -1,16 +1,26 @@
 import dataclasses
 
 from cortex.ledger.models import LedgerEvent
+from cortex.ledger.origin import OriginSignaturePolicy
 from cortex.ledger.queue import EnrichmentQueue
 from cortex.ledger.store import LedgerStore
 
 
 class LedgerWriter:
-    def __init__(self, store: LedgerStore, queue: EnrichmentQueue) -> None:
+    def __init__(
+        self,
+        store: LedgerStore,
+        queue: EnrichmentQueue,
+        origin_policy: OriginSignaturePolicy | None = None,
+    ) -> None:
         self.store = store
         self.queue = queue
+        self.origin_policy = origin_policy
 
     def append(self, event: LedgerEvent) -> str:
+        if self.origin_policy is not None:
+            self.origin_policy.validate_event(event)
+
         with self.store.tx() as conn:
             # 1. Get last hash
             cursor = conn.execute("SELECT hash FROM ledger_events ORDER BY rowid DESC LIMIT 1")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -161,6 +161,28 @@ cortex ledger verify    # Full hash chain integrity check
 cortex ledger stats     # Ledger statistics
 ```
 
+### `cortex verify-ledger-export`
+
+Offline verification for a public ledger export package.
+
+```bash
+cortex verify-ledger-export ./export-dir
+```
+
+The command reads exported files only. It does not open SQLite, call network
+services, or trust a running CORTEX process. Output is deterministic JSON with
+split guarantees for integrity, origin authenticity, authority, replay
+consistency, temporal consistency, online freshness, completeness, and factual
+truth.
+
+Exit codes:
+
+| Code | Meaning |
+|:---|:---|
+| `0` | `VALID_FULL_STRICT` |
+| `1` | `INVALID` |
+| `2` | `VALID_WITH_LIMITATIONS` |
+
 ---
 
 ### `cortex compliance-report`

--- a/docs/compliance/ORIGIN_SIGNATURE_STRICT_MODE.md
+++ b/docs/compliance/ORIGIN_SIGNATURE_STRICT_MODE.md
@@ -1,0 +1,66 @@
+# Origin Signature Strict Mode
+
+Status: draft
+
+M4 adds a runtime origin-authenticity gate for ledger events. The gate is
+opt-in at `LedgerWriter` construction so existing legacy ledger writes continue
+to run until a deployer explicitly enables strict mode for an agent write path.
+
+## Runtime Contract
+
+Strict mode validates a `LedgerEvent` before opening the SQLite transaction.
+If validation fails, no `ledger_events` row is inserted and no enrichment job is
+created.
+
+The event must carry an `origin` envelope:
+
+- `actor_id`: actor that produced the event.
+- `key_id`: registry key used to verify the event.
+- `signature_alg`: currently `ed25519`.
+- `signed_at`: timezone-aware timestamp.
+- `nonce`: origin-generated uniqueness token.
+- `signature`: base64url Ed25519 signature.
+
+## Signature Scope
+
+The signed payload is:
+
+```text
+canonical_json(event payload without hash and prev_hash, and with origin.signature removed)
+```
+
+The runtime hash-chain still commits the complete event payload after the
+origin signature is attached. This means the ledger hash commits the signature,
+and the origin signature commits the pre-persistence event intent.
+
+## Key Registry
+
+`OriginKeyRegistry` is an in-process registry of `OriginKeyRecord` entries.
+Each record binds:
+
+- `key_id`
+- `actor_id`
+- Ed25519 public key
+- allowed actions
+- key status
+- optional validity window
+- optional hardware-backed flag
+
+Strict mode rejects:
+
+- missing origin envelope;
+- unsupported signature algorithm;
+- actor/key mismatch;
+- missing, inactive, not-yet-valid, or expired key;
+- action not present in key permissions;
+- invalid signature over the canonical scope.
+
+## Current Limitations
+
+M4 does not add durable key-registry storage, replay tables, freshness windows,
+or nonce reservation. Those are M5 responsibilities.
+
+M4 also does not assert that event content is true. It distinguishes origin
+authenticity from content truth: a valid key can still sign false content, and
+that must be handled by guard validation, review workflows, and downstream
+forensic analysis.

--- a/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
+++ b/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
@@ -1,0 +1,98 @@
+# Public Ledger Export Package
+
+Status: draft
+
+This document defines the forensic ledger export package produced for
+independent offline verification. The package is evidence packaging only: it
+does not enforce runtime origin signing, authorize agent actions, or export fact
+payloads. Runtime rejection of unsigned or badly signed origin events belongs to
+M4.
+
+## Required Artifacts
+
+An export directory contains:
+
+- `events.jsonl`: canonical JSON Lines ledger events.
+- `manifest.json`: signed export manifest over package artifacts and event
+  range.
+- `public-keys.json`: actor and export-authority public key registry.
+- `key-events.jsonl`: reserved key lifecycle event stream.
+- `schema.json`: event schema/profile descriptor.
+- `verification-profile.json`: canonicalization, hash, signature, and Merkle
+  profile descriptor.
+
+When requested, the exporter also writes:
+
+- `verification-report.json`: deterministic output from the offline verifier.
+
+The package must not contain `facts.jsonl` or plaintext fact payload files.
+Fact export is a separate product surface with separate retention, redaction,
+and erasure controls.
+
+## Manifest Scope
+
+`manifest.json` includes:
+
+- export identity, tenant, stream, purpose, environment, creator, and creation
+  time;
+- event count and sequence/time range;
+- SHA-256 hashes of `events.jsonl`, `public-keys.json`, `key-events.jsonl`,
+  `schema.json`, and `verification-profile.json`;
+- first and last event hash;
+- `merkle-profile-v1` root over event hashes;
+- Ed25519 signature by an export authority key.
+
+The manifest signature scope is:
+
+```text
+Ed25519.sign(export_authority_private_key, canonical_json(manifest without signature))
+```
+
+## Event Payload Boundary
+
+The public ledger export may include references to encrypted or externally
+controlled fact material, for example `payload_ref` or `subject_ref`.
+
+The export builder rejects common inline fact payload keys inside event
+`detail`:
+
+- `content`
+- `payload`
+- `plaintext`
+- `fact_content`
+
+This is a guardrail for forensic packaging, not a complete PII detector. M6 is
+the enforcement milestone for immutable-ledger no-PII policy.
+
+## Guarantee Split
+
+If the optional verifier report is generated, it must preserve the offline
+guarantee split:
+
+- `integrity_verified`
+- `origin_authenticity_verified`
+- `authority_verified`
+- `replay_consistency_verified`
+- `temporal_consistency_verified`
+- `online_freshness_verified`
+- `completeness_verified`
+- `truth_verified`
+
+For offline exports, `online_freshness_verified` remains false. The verifier
+does not assert that event contents are true; `truth_verified` remains false by
+default.
+
+## Current Limitations
+
+M3 assumes events already carry `public-v1-strict` fields, including
+`origin_signature`, `actor_key_id`, `nonce`, and hash-chain continuity.
+
+M3 does not:
+
+- sign ledger events on behalf of actors;
+- reject unsigned runtime writes before persistence;
+- create actor-key authorization policy;
+- prove that a source database contains no omitted events;
+- export plaintext facts or reconstruct fact contents.
+
+Those controls belong to later milestones, especially M4 and M5.

--- a/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
+++ b/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
@@ -6,7 +6,8 @@ This document defines the forensic ledger export package produced for
 independent offline verification. The package is evidence packaging only: it
 does not enforce runtime origin signing, authorize agent actions, or export fact
 payloads. Runtime rejection of unsigned or badly signed origin events belongs to
-M4.
+M4. The runtime strict-mode contract is documented in
+[`ORIGIN_SIGNATURE_STRICT_MODE.md`](ORIGIN_SIGNATURE_STRICT_MODE.md).
 
 ## Required Artifacts
 
@@ -86,6 +87,11 @@ default.
 
 M3 assumes events already carry `public-v1-strict` fields, including
 `origin_signature`, `actor_key_id`, `nonce`, and hash-chain continuity.
+
+M4 adds a separate runtime `LedgerEvent.origin` envelope for pre-persistence
+origin-authenticity validation. A later adapter may map that runtime envelope
+into the public export event fields, but this package specification does not
+claim that bridge as automatic.
 
 M3 does not:
 

--- a/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
+++ b/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
@@ -6,6 +6,9 @@ This document defines the minimum contract for an offline public verifier for
 CORTEX ledger exports. The verifier must validate exported bytes without
 accessing SQLite, network services, or a running CORTEX process.
 
+The matching package layout is documented in
+[`PUBLIC_LEDGER_EXPORT_PACKAGE.md`](PUBLIC_LEDGER_EXPORT_PACKAGE.md).
+
 ## Profiles
 
 - `legacy-v0`: verifies the current transaction hash shape for legacy data. It

--- a/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
+++ b/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
@@ -97,3 +97,21 @@ Reports must split guarantees:
 
 For offline historical exports, `online_freshness_verified` is false. By
 default, `truth_verified` is false.
+
+## CLI Contract
+
+The read-only verifier CLI accepts an exported package directory:
+
+```bash
+cortex verify-ledger-export ./export-dir
+```
+
+The command must:
+
+- read exported files only;
+- avoid SQLite, network calls, and a running CORTEX process;
+- emit deterministic JSON with `profile`, `result`, `guarantees`, `counts`,
+  `artifacts`, `event_hashes`, `errors`, and `warnings`;
+- exit `0` for `VALID_FULL_STRICT`;
+- exit `1` for `INVALID`;
+- exit `2` for `VALID_WITH_LIMITATIONS`.

--- a/tests/test_ledger_origin_signatures.py
+++ b/tests/test_ledger_origin_signatures.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.ledger.models import ActionResult, ActionTarget, LedgerEvent
+from cortex.ledger.origin import (
+    OriginKeyRecord,
+    OriginKeyRegistry,
+    OriginSignatureError,
+    OriginSignaturePolicy,
+    sign_event_origin,
+    verify_event_origin,
+)
+from cortex.ledger.queue import EnrichmentQueue
+from cortex.ledger.store import LedgerStore
+from cortex.ledger.verifier import LedgerVerifier
+from cortex.ledger.writer import LedgerWriter
+
+ACTOR_ID = "agent-risk-01"
+KEY_ID = "ed25519:agent-risk-01:runtime-001"
+SIGNED_AT = "2026-02-03T10:15:30Z"
+NONCE = "nonce_01HXORIGIN000000000000001"
+
+
+def test_strict_origin_policy_accepts_signed_authorized_event(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+
+    event_id = writer.append(event)
+
+    with store.tx() as conn:
+        row = conn.execute(
+            "SELECT payload_json FROM ledger_events WHERE event_id = ?",
+            (event_id,),
+        ).fetchone()
+    assert row is not None
+    payload = json.loads(row["payload_json"])
+    assert payload["origin"]["key_id"] == KEY_ID
+    assert payload["origin"]["signature_alg"] == "ed25519"
+    assert payload["origin"]["nonce"] == NONCE
+    assert LedgerVerifier(store).verify_chain()["valid"] is True
+
+
+def test_strict_origin_policy_rejects_unsigned_event_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+
+    with pytest.raises(OriginSignatureError, match="origin_signature_missing"):
+        writer.append(_event())
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_tampered_event_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+    signed = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+    tampered = dataclasses.replace(signed, target=ActionTarget(app="Tampered"))
+
+    with pytest.raises(OriginSignatureError, match="origin_signature_invalid"):
+        writer.append(tampered)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_permission_denied_before_persistence(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.read"],
+            )
+        ]
+    )
+    store = LedgerStore(tmp_path / "ledger.db")
+    writer = LedgerWriter(
+        store,
+        EnrichmentQueue(store),
+        origin_policy=OriginSignaturePolicy.strict_mode(registry),
+    )
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+
+    with pytest.raises(OriginSignatureError, match="origin_key_permission_denied"):
+        writer.append(event)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_origin_signature_scope_verifies_independently() -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ]
+    )
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+
+    verify_event_origin(event, registry)
+
+
+def _strict_writer(
+    tmp_path: Path,
+    private_key: Ed25519PrivateKey,
+) -> tuple[LedgerStore, LedgerWriter]:
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ]
+    )
+    store = LedgerStore(tmp_path / "ledger.db")
+    return (
+        store,
+        LedgerWriter(
+            store,
+            EnrichmentQueue(store),
+            origin_policy=OriginSignaturePolicy.strict_mode(registry),
+        ),
+    )
+
+
+def _event() -> LedgerEvent:
+    return LedgerEvent.new(
+        tool="agent-runtime",
+        actor=ACTOR_ID,
+        action="fact.store",
+        target=ActionTarget(app="CORTEX", identifier="fact:001"),
+        result=ActionResult(ok=True, latency_ms=12, verified=True),
+        metadata={"project": "cortex-persist", "tenant_id": "tenant-acme"},
+    )
+
+
+def _row_count(store: LedgerStore, table_name: str) -> int:
+    if table_name not in {"ledger_events", "enrichment_jobs"}:
+        raise ValueError(f"unsupported table: {table_name}")
+    with store.tx() as conn:
+        row = conn.execute(f"SELECT COUNT(*) AS count FROM {table_name}").fetchone()
+    return int(row["count"])

--- a/tests/test_public_ledger_export.py
+++ b/tests/test_public_ledger_export.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.ledger.public_export import (
+    ExportAuthority,
+    public_key_record,
+    write_public_ledger_export,
+)
+from cortex.ledger.public_verifier import verify_export
+
+TENANT_ID = "tenant-acme"
+STREAM_ID = "tenant:acme:ledger:primary"
+ACTOR_ID = "agent-risk-01"
+ACTOR_KEY_ID = "ed25519:agent-risk-01:test-export-001"
+EXPORT_KEY_ID = "ed25519:export-authority:test-export-001"
+CREATED_AT = "2026-02-03T10:15:30Z"
+
+
+def test_write_public_ledger_export_package_with_verification_report(tmp_path: Path) -> None:
+    actor_private_key = Ed25519PrivateKey.generate()
+    export_private_key = Ed25519PrivateKey.generate()
+    event = _signed_event(actor_private_key)
+    export_dir = tmp_path / "forensic-export"
+
+    result = write_public_ledger_export(
+        events=[event],
+        export_dir=export_dir,
+        public_keys=[
+            public_key_record(
+                key_id=ACTOR_KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=actor_private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ],
+        export_authority=ExportAuthority(
+            key_id=EXPORT_KEY_ID,
+            actor_id="export-authority-01",
+            private_key=export_private_key,
+        ),
+        export_id="export-2026-02-03-001",
+        tenant_id=TENANT_ID,
+        stream_id=STREAM_ID,
+        created_at=CREATED_AT,
+        include_verification_report=True,
+    )
+
+    expected_files = {
+        "events.jsonl",
+        "key-events.jsonl",
+        "manifest.json",
+        "public-keys.json",
+        "schema.json",
+        "verification-profile.json",
+        "verification-report.json",
+    }
+    assert expected_files <= {path.name for path in export_dir.iterdir()}
+    assert not (export_dir / "facts.jsonl").exists()
+    assert result.verification_report_path == export_dir / "verification-report.json"
+    assert result.verification_result == "VALID_FULL_STRICT"
+    assert result.manifest_hash == _sha256_file(export_dir / "manifest.json")
+
+    report = verify_export(export_dir)
+    assert report["result"] == "VALID_FULL_STRICT"
+    assert report["guarantees"]["integrity_verified"] is True
+    assert report["guarantees"]["origin_authenticity_verified"] is True
+    assert report["guarantees"]["authority_verified"] is True
+    assert report["guarantees"]["completeness_verified"] is True
+    assert report["guarantees"]["truth_verified"] is False
+    assert report == _load_json(export_dir / "verification-report.json")
+
+    manifest = _load_json(export_dir / "manifest.json")
+    public_keys = _load_json(export_dir / "public-keys.json")
+    assert manifest["signature"]["key_id"] == EXPORT_KEY_ID
+    assert manifest["hashes"]["events_file_sha256"] == _sha256_file(export_dir / "events.jsonl")
+    assert manifest["hashes"]["public_keys_file_sha256"] == _sha256_file(
+        export_dir / "public-keys.json"
+    )
+    assert {key["key_id"] for key in public_keys["keys"]} == {ACTOR_KEY_ID, EXPORT_KEY_ID}
+    assert manifest["counts"]["event_count"] == 1
+    assert manifest["range"]["first_sequence"] == 1
+    assert manifest["range"]["last_sequence"] == 1
+
+
+def test_write_public_ledger_export_rejects_inline_fact_payload(tmp_path: Path) -> None:
+    actor_private_key = Ed25519PrivateKey.generate()
+    export_private_key = Ed25519PrivateKey.generate()
+    event = _signed_event(actor_private_key)
+    event["detail"] = dict(event["detail"])
+    event["detail"]["payload"] = "plaintext fact body"
+
+    with pytest.raises(ValueError, match="inline fact payload"):
+        write_public_ledger_export(
+            events=[event],
+            export_dir=tmp_path / "forensic-export",
+            public_keys=[
+                public_key_record(
+                    key_id=ACTOR_KEY_ID,
+                    actor_id=ACTOR_ID,
+                    public_key=actor_private_key.public_key(),
+                    permissions=["fact.store"],
+                )
+            ],
+            export_authority=ExportAuthority(
+                key_id=EXPORT_KEY_ID,
+                actor_id="export-authority-01",
+                private_key=export_private_key,
+            ),
+            export_id="export-2026-02-03-001",
+            tenant_id=TENANT_ID,
+            stream_id=STREAM_ID,
+            created_at=CREATED_AT,
+        )
+
+
+def _signed_event(private_key: Ed25519PrivateKey) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "action": "fact.store",
+        "actor_id": ACTOR_ID,
+        "actor_key_id": ACTOR_KEY_ID,
+        "detail": {
+            "fact_type": "risk_signal",
+            "payload_ref": "facts/tenant-acme/fact-001.enc.json",
+            "subject_ref": "subject:hmac-sha256:01HX",
+        },
+        "event_id": "evt_01HXEXPORT0000000000000001",
+        "hash_alg": "sha256",
+        "issued_at": CREATED_AT,
+        "nonce": "nonce_01HXEXPORT0000000000000001",
+        "prev_hash": "GENESIS",
+        "project": "cortex-persist",
+        "recorded_at": CREATED_AT,
+        "schema_version": "cortex-ledger-event-v1",
+        "sequence": 1,
+        "signature_alg": "ed25519",
+        "stream_id": STREAM_ID,
+        "target": "fact:001",
+        "tenant_id": TENANT_ID,
+    }
+    event["hash"] = _event_hash(event)
+    event["origin_signature"] = _b64url_encode(
+        private_key.sign(_canonical_json(event).encode("utf-8"))
+    )
+    return event
+
+
+def _event_hash(event: dict[str, Any]) -> str:
+    scope = dict(event)
+    scope.pop("hash", None)
+    scope.pop("origin_signature", None)
+    return hashlib.sha256(_canonical_json(scope).encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value

--- a/tests/test_public_ledger_verifier.py
+++ b/tests/test_public_ledger_verifier.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cortex.cli import cli
+from cortex.ledger.public_verifier import verify_export
+
+FIXTURES = Path(__file__).parent / "fixtures" / "ledger_verifier"
+STRICT = FIXTURES / "public_v1_strict"
+MUTATIONS = FIXTURES / "public_v1_strict_mutations"
+
+
+def test_verify_export_returns_full_strict_report_for_public_v1_fixture() -> None:
+    report = verify_export(STRICT)
+    expected = json.loads((STRICT / "expected-report.json").read_text(encoding="utf-8"))
+
+    assert report["profile"] == "public-v1-strict"
+    assert report["result"] == expected["result"]
+    assert report["guarantees"] == expected["guarantees"]
+    assert report["counts"] == {"events": 1, "errors": 0, "warnings": 0}
+    assert report["event_hashes"] == [
+        "518375b3ebdb916e0a779eb2baa6c9fcfbe4ae246a18eda9b4dfad0f32d2d59b"
+    ]
+
+
+def test_verify_export_without_manifest_is_valid_with_limitations(tmp_path: Path) -> None:
+    export_dir = tmp_path / "export"
+    shutil.copytree(STRICT, export_dir)
+    (export_dir / "manifest.json").unlink()
+
+    report = verify_export(export_dir)
+
+    assert report["result"] == "VALID_WITH_LIMITATIONS"
+    assert report["guarantees"]["integrity_verified"] is True
+    assert report["guarantees"]["origin_authenticity_verified"] is True
+    assert report["guarantees"]["authority_verified"] is True
+    assert report["guarantees"]["completeness_verified"] is False
+    assert report["warnings"] == ["manifest_missing"]
+    assert report["errors"] == []
+
+
+def test_verify_export_rejects_missing_nonce_strict_event() -> None:
+    report = verify_export(MUTATIONS / "missing_nonce")
+
+    assert report["result"] == "INVALID"
+    assert report["guarantees"]["integrity_verified"] is False
+    assert any(
+        error.startswith("event_missing_required_fields:1:nonce") for error in report["errors"]
+    )
+
+
+def test_verify_export_rejects_tampered_detail_hash() -> None:
+    report = verify_export(MUTATIONS / "tampered_detail")
+
+    assert report["result"] == "INVALID"
+    assert "event_hash_mismatch:evt_01HX0000000000000000000000" in report["errors"]
+
+
+def test_verify_export_rejects_bad_manifest_signature(tmp_path: Path) -> None:
+    export_dir = tmp_path / "export"
+    shutil.copytree(STRICT, export_dir)
+    shutil.copyfile(
+        MUTATIONS / "bad_manifest_signature" / "manifest.json",
+        export_dir / "manifest.json",
+    )
+
+    report = verify_export(export_dir)
+
+    assert report["result"] == "INVALID"
+    assert "manifest_signature_invalid:InvalidSignature" in report["errors"]
+
+
+def test_verify_ledger_export_cli_emits_report_and_exit_zero_for_full_strict() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["verify-ledger-export", str(STRICT)])
+
+    assert result.exit_code == 0
+    report = json.loads(result.output)
+    assert report["result"] == "VALID_FULL_STRICT"
+    assert report["guarantees"]["truth_verified"] is False
+
+
+def test_verify_ledger_export_cli_exits_two_for_limitations(tmp_path: Path) -> None:
+    export_dir = tmp_path / "export"
+    shutil.copytree(STRICT, export_dir)
+    (export_dir / "manifest.json").unlink()
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["verify-ledger-export", str(export_dir)])
+
+    assert result.exit_code == 2
+    report = json.loads(result.output)
+    assert report["result"] == "VALID_WITH_LIMITATIONS"
+
+
+def test_verify_ledger_export_cli_exits_one_for_invalid_export() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["verify-ledger-export", str(MUTATIONS / "tampered_detail")])
+
+    assert result.exit_code == 1
+    report = json.loads(result.output)
+    assert report["result"] == "INVALID"


### PR DESCRIPTION
## Summary
- Add a read-only public ledger verifier that validates exported files without SQLite, network calls, or trusting a running CORTEX process.
- Verify event canonicalization, SHA-256 hashes, hash-chain continuity, Ed25519 origin signatures, actor permissions, replay consistency, temporal consistency, signed manifest file hashes, range, counts, scope, and Merkle root.
- Add `cortex verify-ledger-export` JSON CLI output with deterministic guarantee-split report and explicit exit codes.

## Scope
This PR is intentionally stacked on PR #289 / branch `codex/public-verifier-vectors` so the M2 diff contains verifier runtime only. It does not modify write paths, migrations, ledger persistence, SQLite schemas, or export generation.

## Validation
- `pytest tests/test_ledger_integrity_verification.py tests/test_cli_init.py tests/test_public_ledger_verifier.py tests/test_public_ledger_verifier_vectors.py -v` -> 25 passed, 11 dependency warnings
- `ruff check cortex/ledger/public_verifier.py cortex/cli/public_verifier_cmds.py tests/test_public_ledger_verifier.py` -> passed
- `pyright cortex/ledger/public_verifier.py cortex/cli/public_verifier_cmds.py tests/test_public_ledger_verifier.py` -> 0 errors
- `git diff --cached --check` -> passed before commit
- `python3 -m py_compile cortex/ledger/public_verifier.py cortex/cli/public_verifier_cmds.py tests/test_public_ledger_verifier.py` -> passed
- CLI smoke: valid fixture exit `0`, invalid tampered fixture exit `1`, repeated stdout reports byte-identical

## Residual Notes
- `python3 -m cortex.cli ...` emits unrelated dependency warnings on stderr from the global CLI bootstrap; verifier stdout remains deterministic JSON.

Closes #280