### PR TITLE
feat: commit forensic evidence manifests to ledger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,12 @@ RUN apt-get update && \
 
 # Copy virtual environment from builder
 COPY --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/cortex /app/cortex
 COPY --from=builder /root/.cache/huggingface /root/.cache/huggingface
 
 # Run as non-root user
 RUN useradd -m -u 1000 cortex
+RUN mkdir -p /data && chown -R cortex:cortex /data
 USER cortex
 
 ENV PATH="/app/.venv/bin:$PATH"

--- a/cortex/cli/forensics_cmds.py
+++ b/cortex/cli/forensics_cmds.py
@@ -106,7 +106,9 @@ def build_manifest_cmd(
 )
 def verify_manifest_cmd(manifest: str, base_dir: str) -> None:
     """Verify a canonical evidence manifest against local artifact bytes."""
-    manifest_payload, artifacts, manifest_path, base = _load_manifest_and_artifacts(manifest, base_dir)
+    manifest_payload, artifacts, manifest_path, base = _load_manifest_and_artifacts(
+        manifest, base_dir
+    )
     report = verify_evidence_manifest(manifest_payload, artifacts)
     _emit_status_json(
         {
@@ -130,7 +132,9 @@ def verify_manifest_cmd(manifest: str, base_dir: str) -> None:
 @click.option("--db", default=DEFAULT_DB, show_default=True, help="Database path.")
 def commit_manifest_cmd(manifest: str, base_dir: str, db: str) -> None:
     """Verify and commit a forensic evidence manifest to the transaction ledger."""
-    manifest_payload, artifacts, manifest_path, base = _load_manifest_and_artifacts(manifest, base_dir)
+    manifest_payload, artifacts, manifest_path, base = _load_manifest_and_artifacts(
+        manifest, base_dir
+    )
     result = commit_evidence_manifest(db, manifest_payload, artifacts)
     _emit_status_json(
         {
@@ -155,7 +159,9 @@ def commit_manifest_cmd(manifest: str, base_dir: str, db: str) -> None:
 @click.option("--db", default=DEFAULT_DB, show_default=True, help="Database path.")
 def verify_commit_cmd(manifest: str, base_dir: str, db: str) -> None:
     """Verify a forensic manifest and its matching transaction-ledger commitment."""
-    manifest_payload, artifacts, manifest_path, base = _load_manifest_and_artifacts(manifest, base_dir)
+    manifest_payload, artifacts, manifest_path, base = _load_manifest_and_artifacts(
+        manifest, base_dir
+    )
     report = verify_evidence_commit(db, manifest_payload, artifacts)
     _emit_status_json(
         {

--- a/cortex/cli/forensics_cmds.py
+++ b/cortex/cli/forensics_cmds.py
@@ -1,0 +1,264 @@
+"""CLI commands for local forensic evidence manifests."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import click
+
+from cortex.cli.common import DEFAULT_DB, cli
+from cortex.forensics.evidence_bundle import (
+    build_evidence_manifest,
+    commit_evidence_manifest,
+    dump_evidence_manifest,
+    load_evidence_manifest_bytes,
+    verify_evidence_commit,
+    verify_evidence_manifest,
+)
+
+
+@click.group("forensics")
+def forensics_cmds() -> None:
+    """Local forensic evidence utilities."""
+
+
+@forensics_cmds.command("build-manifest")
+@click.argument(
+    "artifacts",
+    nargs=-1,
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+)
+@click.option(
+    "--base-dir",
+    default=".",
+    show_default=True,
+    type=click.Path(exists=True, file_okay=False, path_type=str),
+    help="Directory used to derive manifest-relative artifact paths.",
+)
+@click.option("--bundle-id", required=True, help="Stable identifier for this evidence bundle.")
+@click.option("--tenant-id", default="default", show_default=True, help="Tenant scope.")
+@click.option("--project", default=None, help="Optional project scope.")
+@click.option(
+    "--profile",
+    default="customer-confidential",
+    show_default=True,
+    help="Delivery profile recorded in the manifest.",
+)
+@click.option(
+    "--generated-at",
+    default=None,
+    help="Optional ISO timestamp. Defaults to current UTC time.",
+)
+@click.option(
+    "--output",
+    required=True,
+    type=click.Path(dir_okay=False, path_type=str),
+    help="Manifest JSON output path.",
+)
+def build_manifest_cmd(
+    artifacts: tuple[str, ...],
+    base_dir: str,
+    bundle_id: str,
+    tenant_id: str,
+    project: str | None,
+    profile: str,
+    generated_at: str | None,
+    output: str,
+) -> None:
+    """Build a canonical SHA-256 manifest for local evidence artifacts."""
+    base = _resolve_base_dir(base_dir)
+    output_path = Path(output)
+    _ensure_output_does_not_overwrite_artifact(output_path, artifacts)
+    artifact_bytes = _read_explicit_artifacts(base, artifacts)
+    manifest = build_evidence_manifest(
+        artifact_bytes,
+        bundle_id=bundle_id,
+        tenant_id=tenant_id,
+        project=project,
+        generated_at=generated_at,
+        profile=profile,
+    )
+    _atomic_write_bytes(output_path, dump_evidence_manifest(manifest))
+    _emit_status_json(
+        {
+            "valid": True,
+            "manifest": str(output_path),
+            "manifest_sha256": manifest["manifest_sha256"],
+            "artifact_count": manifest["artifact_count"],
+            "total_bytes": manifest["total_bytes"],
+        },
+        status_code=0,
+    )
+
+
+@forensics_cmds.command("verify-manifest")
+@click.argument("manifest", type=click.Path(exists=True, dir_okay=False, path_type=str))
+@click.option(
+    "--base-dir",
+    default=".",
+    show_default=True,
+    type=click.Path(exists=True, file_okay=False, path_type=str),
+    help="Directory containing the manifest-listed artifact paths.",
+)
+def verify_manifest_cmd(manifest: str, base_dir: str) -> None:
+    """Verify a canonical evidence manifest against local artifact bytes."""
+    manifest_payload, artifacts, manifest_path, base = _load_manifest_and_artifacts(manifest, base_dir)
+    report = verify_evidence_manifest(manifest_payload, artifacts)
+    _emit_status_json(
+        {
+            "manifest": str(manifest_path),
+            "base_dir": str(base),
+            **report,
+        },
+        status_code=0 if report["valid"] is True else 1,
+    )
+
+
+@forensics_cmds.command("commit-manifest")
+@click.argument("manifest", type=click.Path(exists=True, dir_okay=False, path_type=str))
+@click.option(
+    "--base-dir",
+    default=".",
+    show_default=True,
+    type=click.Path(exists=True, file_okay=False, path_type=str),
+    help="Directory containing the manifest-listed artifact paths.",
+)
+@click.option("--db", default=DEFAULT_DB, show_default=True, help="Database path.")
+def commit_manifest_cmd(manifest: str, base_dir: str, db: str) -> None:
+    """Verify and commit a forensic evidence manifest to the transaction ledger."""
+    manifest_payload, artifacts, manifest_path, base = _load_manifest_and_artifacts(manifest, base_dir)
+    result = commit_evidence_manifest(db, manifest_payload, artifacts)
+    _emit_status_json(
+        {
+            "manifest": str(manifest_path),
+            "base_dir": str(base),
+            "db": db,
+            **result,
+        },
+        status_code=0 if result["valid"] is True and result["committed"] is True else 1,
+    )
+
+
+@forensics_cmds.command("verify-commit")
+@click.argument("manifest", type=click.Path(exists=True, dir_okay=False, path_type=str))
+@click.option(
+    "--base-dir",
+    default=".",
+    show_default=True,
+    type=click.Path(exists=True, file_okay=False, path_type=str),
+    help="Directory containing the manifest-listed artifact paths.",
+)
+@click.option("--db", default=DEFAULT_DB, show_default=True, help="Database path.")
+def verify_commit_cmd(manifest: str, base_dir: str, db: str) -> None:
+    """Verify a forensic manifest and its matching transaction-ledger commitment."""
+    manifest_payload, artifacts, manifest_path, base = _load_manifest_and_artifacts(manifest, base_dir)
+    report = verify_evidence_commit(db, manifest_payload, artifacts)
+    _emit_status_json(
+        {
+            "manifest": str(manifest_path),
+            "base_dir": str(base),
+            "db": db,
+            **report,
+        },
+        status_code=0 if report["valid"] is True else 1,
+    )
+
+
+def _read_explicit_artifacts(base: Path, artifacts: tuple[str, ...]) -> dict[str, bytes]:
+    artifact_bytes: dict[str, bytes] = {}
+    for artifact in artifacts:
+        artifact_path = _resolve_under_base(Path(artifact), base, label="artifact")
+        relative_path = artifact_path.relative_to(base).as_posix()
+        artifact_bytes[relative_path] = artifact_path.read_bytes()
+    return artifact_bytes
+
+
+def _ensure_output_does_not_overwrite_artifact(output: Path, artifacts: tuple[str, ...]) -> None:
+    resolved_output = output.resolve(strict=False)
+    for artifact in artifacts:
+        artifact_path = Path(artifact)
+        if not artifact_path.exists():
+            continue
+        if artifact_path.resolve(strict=True) == resolved_output:
+            raise click.ClickException("--output must not overwrite an evidence artifact")
+
+
+def _load_manifest_and_artifacts(
+    manifest: str,
+    base_dir: str,
+) -> tuple[dict[str, Any], dict[str, bytes], Path, Path]:
+    base = _resolve_base_dir(base_dir)
+    manifest_path = Path(manifest).resolve(strict=True)
+    try:
+        manifest_payload = load_evidence_manifest_bytes(manifest_path.read_bytes())
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    artifacts: dict[str, bytes] = {}
+    for relative_path in _manifest_artifact_paths(manifest_payload):
+        artifact_path = _resolve_manifest_entry(base, relative_path)
+        if not artifact_path.exists() or not artifact_path.is_file():
+            continue
+        artifacts[relative_path] = artifact_path.read_bytes()
+    return manifest_payload, artifacts, manifest_path, base
+
+
+def _resolve_base_dir(base_dir: str) -> Path:
+    return Path(base_dir).resolve(strict=True)
+
+
+def _resolve_under_base(path: Path, base: Path, *, label: str) -> Path:
+    resolved = path.resolve(strict=True)
+    try:
+        resolved.relative_to(base)
+    except ValueError as exc:
+        raise click.ClickException(f"{label} is outside --base-dir: {path}") from exc
+    return resolved
+
+
+def _resolve_manifest_entry(base: Path, relative_path: str) -> Path:
+    pure_path = PurePosixPath(relative_path)
+    if pure_path.is_absolute() or any(part in {"", ".", ".."} for part in pure_path.parts):
+        raise click.ClickException(f"manifest contains unsafe artifact path: {relative_path}")
+    candidate = base.joinpath(*pure_path.parts)
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(base)
+    except ValueError as exc:
+        raise click.ClickException(
+            f"manifest artifact is outside --base-dir: {relative_path}"
+        ) from exc
+    return resolved
+
+
+def _manifest_artifact_paths(manifest: dict[str, Any]) -> list[str]:
+    entries = manifest.get("artifacts")
+    if not isinstance(entries, list):
+        raise click.ClickException("manifest artifacts must be a list")
+    paths: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get("path"), str):
+            raise click.ClickException("manifest artifact entries must contain string paths")
+        paths.append(entry["path"])
+    return paths
+
+
+def _atomic_write_bytes(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp_path.write_bytes(data)
+    tmp_path.replace(path)
+
+
+def _emit_status_json(payload: dict[str, Any], *, status_code: int) -> None:
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+    if status_code:
+        raise click.exceptions.Exit(status_code)
+
+
+if os.environ.get("CORTEX_ENABLE_EXPERIMENTAL_CLI") == "1":
+    cli.add_command(forensics_cmds)

--- a/cortex/database/schema.py
+++ b/cortex/database/schema.py
@@ -84,7 +84,7 @@ __all__ = [
     "get_init_meta",
 ]
 
-SCHEMA_VERSION = "5.4.0"
+SCHEMA_VERSION = "5.4.2"
 
 # ─── Core Facts Table ────────────────────────────────────────────────
 CREATE_FACTS = """

--- a/cortex/database/schema_extensions.py
+++ b/cortex/database/schema_extensions.py
@@ -294,6 +294,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(
 CREATE_MERKLE_ROOTS = """
 CREATE TABLE IF NOT EXISTS merkle_roots (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id       TEXT NOT NULL DEFAULT '__global__',
     root_hash       TEXT NOT NULL,
     tx_start_id     INTEGER NOT NULL,
     tx_end_id       INTEGER NOT NULL,

--- a/cortex/engine/transaction_mixin.py
+++ b/cortex/engine/transaction_mixin.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from typing import Any
+from typing import Any, cast
 
 import aiosqlite
 
@@ -46,7 +46,7 @@ class TransactionMixin(EngineMixinBase):
         prev = await cursor.fetchone()
         await cursor.close()
         ph = prev[0] if prev else "GENESIS"
-        th = compute_tx_hash(ph, project, action, dj, ts)
+        th = compute_tx_hash(ph, project, action, dj, ts, tenant_id=tenant_id)
 
         c = await conn.execute(
             "INSERT INTO transactions "
@@ -62,7 +62,7 @@ class TransactionMixin(EngineMixinBase):
             row = await cur.fetchone()
             actual_ph = row[0] if row else ph
             if actual_ph != ph:
-                th = compute_tx_hash(actual_ph, project, action, dj, ts)
+                th = compute_tx_hash(actual_ph, project, action, dj, ts, tenant_id=tenant_id)
                 await conn.execute("UPDATE transactions SET hash = ? WHERE id = ?", (th, tx_id))
 
         if getattr(self, "_ledger", None):
@@ -86,5 +86,5 @@ class TransactionMixin(EngineMixinBase):
             from cortex.ledger import ImmutableLedger
 
             # Pass the pool directly instead of a raw connection
-            self._ledger = ImmutableLedger(self.pool)
+            self._ledger = ImmutableLedger(cast(Any, self).pool)
         return await self._ledger.audit_integrity_async()

--- a/cortex/forensics/__init__.py
+++ b/cortex/forensics/__init__.py
@@ -1,0 +1,1 @@
+"""Forensic export and audit utilities."""

--- a/cortex/forensics/evidence_bundle.py
+++ b/cortex/forensics/evidence_bundle.py
@@ -359,7 +359,9 @@ def verify_evidence_commit(
     tenant_id = detail["tenant_id"]
     conn = connect(db_path, row_factory=sqlite3.Row)
     try:
-        existing = _find_existing_commit(conn, tenant_id, detail["bundle_id"], detail["manifest_sha256"])
+        existing = _find_existing_commit(
+            conn, tenant_id, detail["bundle_id"], detail["manifest_sha256"]
+        )
         if existing is None:
             violations.append(
                 {
@@ -426,7 +428,9 @@ def _commit_detail(manifest: Mapping[str, Any]) -> dict[str, Any]:
         "total_bytes": manifest.get("total_bytes"),
         "artifacts": [
             {
-                "path": _normalize_artifact_path(entry.get("path") if isinstance(entry, Mapping) else None),
+                "path": _normalize_artifact_path(
+                    entry.get("path") if isinstance(entry, Mapping) else None
+                ),
                 "bytes": entry.get("bytes") if isinstance(entry, Mapping) else None,
                 "sha256": entry.get("sha256") if isinstance(entry, Mapping) else None,
             }

--- a/cortex/forensics/evidence_bundle.py
+++ b/cortex/forensics/evidence_bundle.py
@@ -1,0 +1,605 @@
+"""Canonical forensic evidence manifests and ledger commitments.
+
+The manifest functions verify local artifact bytes. The commitment functions
+append a raw-free digest record to the canonical transaction ledger only after
+manifest verification succeeds.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from collections.abc import Mapping
+from pathlib import PurePosixPath
+from typing import Any
+
+from cortex.database.core import connect
+from cortex.ledger.ledger_core import MerkleTree, SovereignLedger
+from cortex.utils.canonical import canonical_json, compute_tx_hash, compute_tx_hash_v1, now_iso
+
+EVIDENCE_MANIFEST_SCHEMA = "cortex.forensics.evidence_manifest.v1"
+EVIDENCE_COMMIT_ACTION = "forensic_evidence_commit"
+
+__all__ = [
+    "EVIDENCE_COMMIT_ACTION",
+    "EVIDENCE_MANIFEST_SCHEMA",
+    "build_evidence_manifest",
+    "canonical_json_bytes",
+    "commit_evidence_manifest",
+    "dump_evidence_manifest",
+    "load_evidence_manifest_bytes",
+    "sha256_hex",
+    "verify_evidence_commit",
+    "verify_evidence_manifest",
+]
+
+
+def canonical_json_bytes(payload: Any) -> bytes:
+    """Return the exact UTF-8 bytes used for canonical JSON hashing."""
+    return canonical_json(payload).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    """Return a SHA-256 hex digest for already-canonicalized bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def build_evidence_manifest(
+    artifacts: Mapping[str, bytes | bytearray | memoryview],
+    *,
+    bundle_id: str,
+    tenant_id: str,
+    project: str | None = None,
+    generated_at: str | None = None,
+    profile: str = "customer-confidential",
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic manifest for a set of evidence artifacts."""
+    if not artifacts:
+        raise ValueError("evidence manifest requires at least one artifact")
+
+    entries: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    total_bytes = 0
+    for raw_path, raw_bytes in artifacts.items():
+        path = _normalize_artifact_path(raw_path)
+        if path in seen_paths:
+            raise ValueError(f"duplicate evidence artifact path: {path}")
+        seen_paths.add(path)
+        artifact_bytes = _coerce_bytes(raw_bytes, path)
+        total_bytes += len(artifact_bytes)
+        entries.append(
+            {
+                "path": path,
+                "bytes": len(artifact_bytes),
+                "sha256": sha256_hex(artifact_bytes),
+            }
+        )
+
+    manifest: dict[str, Any] = {
+        "schema": EVIDENCE_MANIFEST_SCHEMA,
+        "bundle_id": _require_nonempty(bundle_id, "bundle_id"),
+        "tenant_id": _require_nonempty(tenant_id, "tenant_id"),
+        "project": project,
+        "generated_at": generated_at or now_iso(),
+        "profile": _require_nonempty(profile, "profile"),
+        "algorithms": {
+            "artifact_hash": "sha256(raw artifact bytes)",
+            "manifest_hash": "sha256(canonical_json(manifest without manifest_sha256))",
+            "ledger_hash": "sha256(v3 tenant-bound; v2/v1 legacy verification accepted)",
+            "canonical_json": "json.dumps(sort_keys=True,separators=(',',':'),ensure_ascii=True)",
+        },
+        "artifact_count": len(entries),
+        "total_bytes": total_bytes,
+        "artifacts": sorted(entries, key=lambda entry: str(entry["path"])),
+    }
+    if metadata is not None:
+        manifest["metadata"] = dict(metadata)
+    manifest["manifest_sha256"] = _manifest_sha256(manifest)
+    return manifest
+
+
+def verify_evidence_manifest(
+    manifest: Mapping[str, Any],
+    artifacts: Mapping[str, bytes | bytearray | memoryview],
+) -> dict[str, Any]:
+    """Verify a manifest against supplied artifact bytes without source access."""
+    violations: list[dict[str, Any]] = []
+    if manifest.get("schema") != EVIDENCE_MANIFEST_SCHEMA:
+        violations.append(
+            {
+                "type": "MANIFEST_SCHEMA_UNSUPPORTED",
+                "schema": manifest.get("schema"),
+            }
+        )
+
+    expected_manifest_hash = manifest.get("manifest_sha256")
+    actual_manifest_hash = _manifest_sha256(manifest)
+    if expected_manifest_hash != actual_manifest_hash:
+        violations.append(
+            {
+                "type": "MANIFEST_HASH_MISMATCH",
+                "expected": expected_manifest_hash,
+                "actual": actual_manifest_hash,
+            }
+        )
+
+    manifest_entries = manifest.get("artifacts")
+    if not isinstance(manifest_entries, list):
+        return {
+            "valid": False,
+            "violations": violations + [{"type": "MANIFEST_ARTIFACTS_INVALID"}],
+            "checked": {"artifacts": 0, "bytes": 0},
+        }
+
+    expected_by_path: dict[str, Mapping[str, Any]] = {}
+    checked_bytes = 0
+    for entry in manifest_entries:
+        if not isinstance(entry, Mapping):
+            violations.append({"type": "MANIFEST_ARTIFACT_INVALID", "path": None})
+            continue
+        raw_path = entry.get("path")
+        try:
+            path = _normalize_artifact_path(raw_path)
+        except ValueError as exc:
+            violations.append(
+                {
+                    "type": "MANIFEST_ARTIFACT_PATH_INVALID",
+                    "path": raw_path,
+                    "error": str(exc),
+                }
+            )
+            continue
+        if path in expected_by_path:
+            violations.append({"type": "MANIFEST_ARTIFACT_DUPLICATE", "path": path})
+            continue
+        expected_by_path[path] = entry
+
+    actual_by_path: dict[str, bytes] = {}
+    for raw_path, raw_bytes in artifacts.items():
+        try:
+            path = _normalize_artifact_path(raw_path)
+            actual_by_path[path] = _coerce_bytes(raw_bytes, path)
+        except ValueError as exc:
+            violations.append(
+                {
+                    "type": "ARTIFACT_INPUT_INVALID",
+                    "path": raw_path,
+                    "error": str(exc),
+                }
+            )
+
+    for path in sorted(expected_by_path):
+        entry = expected_by_path[path]
+        artifact_bytes = actual_by_path.get(path)
+        if artifact_bytes is None:
+            violations.append({"type": "ARTIFACT_MISSING", "path": path})
+            continue
+        checked_bytes += len(artifact_bytes)
+
+        expected_bytes = entry.get("bytes")
+        if expected_bytes != len(artifact_bytes):
+            violations.append(
+                {
+                    "type": "ARTIFACT_BYTES_MISMATCH",
+                    "path": path,
+                    "expected": expected_bytes,
+                    "actual": len(artifact_bytes),
+                }
+            )
+
+        expected_sha256 = entry.get("sha256")
+        actual_sha256 = sha256_hex(artifact_bytes)
+        if expected_sha256 != actual_sha256:
+            violations.append(
+                {
+                    "type": "ARTIFACT_HASH_MISMATCH",
+                    "path": path,
+                    "expected": expected_sha256,
+                    "actual": actual_sha256,
+                }
+            )
+
+    for path in sorted(set(actual_by_path) - set(expected_by_path)):
+        violations.append({"type": "ARTIFACT_UNEXPECTED", "path": path})
+
+    expected_count = manifest.get("artifact_count")
+    if expected_count != len(expected_by_path):
+        violations.append(
+            {
+                "type": "MANIFEST_ARTIFACT_COUNT_MISMATCH",
+                "expected": expected_count,
+                "actual": len(expected_by_path),
+            }
+        )
+
+    expected_total = manifest.get("total_bytes")
+    if expected_total != checked_bytes:
+        violations.append(
+            {
+                "type": "MANIFEST_TOTAL_BYTES_MISMATCH",
+                "expected": expected_total,
+                "actual": checked_bytes,
+            }
+        )
+
+    return {
+        "valid": not violations,
+        "violations": violations,
+        "checked": {
+            "artifacts": len(expected_by_path),
+            "bytes": checked_bytes,
+            "input_artifacts": len(actual_by_path),
+            "input_bytes": sum(len(data) for data in actual_by_path.values()),
+        },
+    }
+
+
+def commit_evidence_manifest(
+    db_path: str,
+    manifest: Mapping[str, Any],
+    artifacts: Mapping[str, bytes | bytearray | memoryview],
+) -> dict[str, Any]:
+    """Verify a manifest and commit its digest metadata to the transaction ledger."""
+    verification = verify_evidence_manifest(manifest, artifacts)
+    if verification["valid"] is not True:
+        return {
+            "valid": False,
+            "committed": False,
+            "already_committed": False,
+            "verification": verification,
+        }
+
+    try:
+        detail = _commit_detail(manifest)
+    except ValueError as exc:
+        return {
+            "valid": False,
+            "committed": False,
+            "already_committed": False,
+            "violations": [{"type": "COMMIT_DETAIL_INVALID", "error": str(exc)}],
+            "tx_id": None,
+            "tx_hash": None,
+            "tenant_id": None,
+            "manifest_sha256": manifest.get("manifest_sha256"),
+            "verification": verification,
+        }
+    tenant_id = detail["tenant_id"]
+    conn = connect(db_path, row_factory=sqlite3.Row)
+    try:
+        ledger = SovereignLedger(conn)
+        conn.execute("BEGIN EXCLUSIVE")
+        existing = _find_existing_commit(
+            conn,
+            tenant_id,
+            detail["bundle_id"],
+            detail["manifest_sha256"],
+        )
+        if existing is not None:
+            violations = _verify_existing_commit(conn, tenant_id, existing, detail)
+            if violations:
+                conn.rollback()
+                return {
+                    "valid": False,
+                    "committed": False,
+                    "already_committed": True,
+                    "violations": violations,
+                    "tx_id": existing["id"],
+                    "tx_hash": existing["hash"],
+                    "tenant_id": tenant_id,
+                    "manifest_sha256": detail["manifest_sha256"],
+                    "verification": verification,
+                }
+            conn.commit()
+            return {
+                "valid": True,
+                "committed": True,
+                "already_committed": True,
+                "tx_id": existing["id"],
+                "tx_hash": existing["hash"],
+                "tenant_id": tenant_id,
+                "manifest_sha256": detail["manifest_sha256"],
+                "verification": verification,
+            }
+
+        tx_hash = ledger.record_transaction_in_current_transaction(
+            _commit_project(detail),
+            EVIDENCE_COMMIT_ACTION,
+            detail,
+            tenant_id=tenant_id,
+        )
+        row = conn.execute(
+            "SELECT id, hash FROM transactions WHERE tenant_id = ? AND hash = ?",
+            (tenant_id, tx_hash),
+        ).fetchone()
+        result = {
+            "valid": True,
+            "committed": True,
+            "already_committed": False,
+            "tx_id": row["id"] if row else None,
+            "tx_hash": tx_hash,
+            "tenant_id": tenant_id,
+            "manifest_sha256": detail["manifest_sha256"],
+            "verification": verification,
+        }
+        conn.commit()
+        return result
+    except sqlite3.Error:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def verify_evidence_commit(
+    db_path: str,
+    manifest: Mapping[str, Any],
+    artifacts: Mapping[str, bytes | bytearray | memoryview],
+) -> dict[str, Any]:
+    """Verify local evidence and its matching ledger commitment."""
+    verification = verify_evidence_manifest(manifest, artifacts)
+    violations: list[dict[str, Any]] = []
+    if verification["valid"] is not True:
+        violations.append({"type": "MANIFEST_INVALID", "violations": verification["violations"]})
+
+    try:
+        detail = _commit_detail(manifest)
+    except ValueError as exc:
+        violations.append({"type": "COMMIT_DETAIL_INVALID", "error": str(exc)})
+        return {
+            "valid": False,
+            "violations": violations,
+            "tx_id": None,
+            "tx_hash": None,
+            "tenant_id": None,
+            "manifest_sha256": manifest.get("manifest_sha256"),
+            "verification": verification,
+        }
+    tenant_id = detail["tenant_id"]
+    conn = connect(db_path, row_factory=sqlite3.Row)
+    try:
+        existing = _find_existing_commit(conn, tenant_id, detail["bundle_id"], detail["manifest_sha256"])
+        if existing is None:
+            violations.append(
+                {
+                    "type": "COMMIT_MISSING",
+                    "tenant_id": tenant_id,
+                    "bundle_id": detail["bundle_id"],
+                    "manifest_sha256": detail["manifest_sha256"],
+                }
+            )
+            tx_id = None
+            tx_hash = None
+        else:
+            tx_id = existing["id"]
+            tx_hash = existing["hash"]
+            violations.extend(_verify_existing_commit(conn, tenant_id, existing, detail))
+
+        return {
+            "valid": not violations,
+            "violations": violations,
+            "tx_id": tx_id,
+            "tx_hash": tx_hash,
+            "tenant_id": tenant_id,
+            "manifest_sha256": detail["manifest_sha256"],
+            "verification": verification,
+        }
+    finally:
+        conn.close()
+
+
+def dump_evidence_manifest(manifest: Mapping[str, Any]) -> bytes:
+    """Serialize a manifest as canonical JSON bytes."""
+    return canonical_json_bytes(manifest)
+
+
+def load_evidence_manifest_bytes(data: bytes | str) -> dict[str, Any]:
+    """Parse a manifest from bytes or text and reject non-object JSON."""
+    raw = data.decode("utf-8") if isinstance(data, bytes) else data
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("invalid evidence manifest JSON") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("invalid evidence manifest schema")
+    return parsed
+
+
+def _commit_detail(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    bundle_id = _require_nonempty(str(manifest.get("bundle_id") or ""), "bundle_id")
+    tenant_id = _require_nonempty(str(manifest.get("tenant_id") or ""), "tenant_id")
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ValueError("manifest artifacts must be a list")
+    return {
+        "schema": "cortex.forensics.evidence_commit.v1",
+        "bundle_id": bundle_id,
+        "tenant_id": tenant_id,
+        "project": manifest.get("project"),
+        "profile": manifest.get("profile"),
+        "manifest_sha256": _require_nonempty(
+            str(manifest.get("manifest_sha256") or ""),
+            "manifest_sha256",
+        ),
+        "artifact_count": manifest.get("artifact_count"),
+        "total_bytes": manifest.get("total_bytes"),
+        "artifacts": [
+            {
+                "path": _normalize_artifact_path(entry.get("path") if isinstance(entry, Mapping) else None),
+                "bytes": entry.get("bytes") if isinstance(entry, Mapping) else None,
+                "sha256": entry.get("sha256") if isinstance(entry, Mapping) else None,
+            }
+            for entry in artifacts
+        ],
+    }
+
+
+def _commit_project(detail: Mapping[str, Any]) -> str:
+    project = detail.get("project")
+    return str(project) if project else "forensics"
+
+
+def _find_existing_commit(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    bundle_id: str,
+    manifest_sha256: str,
+) -> sqlite3.Row | None:
+    try:
+        rows = conn.execute(
+            "SELECT id, hash, detail FROM transactions "
+            "WHERE tenant_id = ? AND action = ? ORDER BY id",
+            (tenant_id, EVIDENCE_COMMIT_ACTION),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return None
+    for row in rows:
+        try:
+            detail = json.loads(row["detail"] or "{}")
+        except json.JSONDecodeError:
+            continue
+        if (
+            detail.get("bundle_id") == bundle_id
+            and detail.get("manifest_sha256") == manifest_sha256
+        ):
+            return row
+    return None
+
+
+def _verify_existing_commit(
+    conn: sqlite3.Connection,
+    tenant_id: str,
+    existing: sqlite3.Row,
+    detail: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    try:
+        stored_detail = json.loads(existing["detail"] or "{}")
+    except json.JSONDecodeError:
+        stored_detail = None
+        violations.append({"type": "COMMIT_DETAIL_INVALID_JSON", "tx_id": existing["id"]})
+    if stored_detail != detail:
+        violations.append({"type": "COMMIT_DETAIL_MISMATCH", "tx_id": existing["id"]})
+    violations.extend(_verify_tenant_chain(conn, tenant_id))
+    violations.extend(_verify_merkle_roots(conn))
+    return violations
+
+
+def _verify_tenant_chain(conn: sqlite3.Connection, tenant_id: str) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    rows = conn.execute(
+        "SELECT id, project, action, detail, prev_hash, hash, timestamp "
+        "FROM transactions WHERE tenant_id = ? ORDER BY id",
+        (tenant_id,),
+    ).fetchall()
+    expected_prev = "GENESIS"
+    for row in rows:
+        if row["prev_hash"] != expected_prev:
+            violations.append(
+                {
+                    "type": "CHAIN_BREAK",
+                    "tx_id": row["id"],
+                    "expected": expected_prev,
+                    "actual": row["prev_hash"],
+                }
+            )
+        computed_v3 = compute_tx_hash(
+            row["prev_hash"],
+            row["project"],
+            row["action"],
+            row["detail"],
+            row["timestamp"],
+            tenant_id=tenant_id,
+        )
+        computed_v2 = compute_tx_hash(
+            row["prev_hash"],
+            row["project"],
+            row["action"],
+            row["detail"],
+            row["timestamp"],
+        )
+        computed_v1 = compute_tx_hash_v1(
+            row["prev_hash"],
+            row["project"],
+            row["action"],
+            row["detail"],
+            row["timestamp"],
+        )
+        if row["hash"] not in {computed_v3, computed_v2, computed_v1}:
+            violations.append({"type": "TAMPER_DETECTED", "tx_id": row["id"]})
+        expected_prev = row["hash"]
+    return violations
+
+
+def _verify_merkle_roots(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    violations: list[dict[str, Any]] = []
+    try:
+        roots = conn.execute(
+            "SELECT COALESCE(tenant_id, '__global__') AS tenant_id, root_hash, "
+            "tx_start_id, tx_end_id FROM merkle_roots ORDER BY id"
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return violations
+
+    for root in roots:
+        root_tenant_id = root["tenant_id"]
+        if root_tenant_id == "__global__":
+            rows = conn.execute(
+                "SELECT hash FROM transactions WHERE id >= ? AND id <= ? ORDER BY id",
+                (root["tx_start_id"], root["tx_end_id"]),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT hash FROM transactions "
+                "WHERE tenant_id = ? AND id >= ? AND id <= ? ORDER BY id",
+                (root_tenant_id, root["tx_start_id"], root["tx_end_id"]),
+            ).fetchall()
+        computed_root = MerkleTree([row["hash"] for row in rows]).root_hash
+        if computed_root != root["root_hash"]:
+            violations.append(
+                {
+                    "type": "MERKLE_MISMATCH",
+                    "tenant_id": root_tenant_id,
+                    "range": f"{root['tx_start_id']}-{root['tx_end_id']}",
+                }
+            )
+    return violations
+
+
+def _manifest_sha256(manifest: Mapping[str, Any]) -> str:
+    body = dict(manifest)
+    body.pop("manifest_sha256", None)
+    return sha256_hex(canonical_json_bytes(body))
+
+
+def _normalize_artifact_path(raw_path: object) -> str:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise ValueError("artifact path must be a non-empty relative POSIX path")
+    if "\\" in raw_path:
+        raise ValueError("artifact path must use POSIX '/' separators")
+    path = PurePosixPath(raw_path)
+    if path.is_absolute() or path.name == "" or str(path) in {"", "."}:
+        raise ValueError("artifact path must be relative")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError("artifact path must not contain traversal or empty segments")
+    canonical_path = str(path)
+    if canonical_path != raw_path:
+        raise ValueError("artifact path must already be canonical")
+    return canonical_path
+
+
+def _coerce_bytes(data: bytes | bytearray | memoryview, path: str) -> bytes:
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, bytearray):
+        return bytes(data)
+    if isinstance(data, memoryview):
+        return data.tobytes()
+    raise ValueError(f"artifact {path} must be bytes")
+
+
+def _require_nonempty(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field_name} must be a non-empty string")
+    return value

--- a/cortex/ledger/ledger_core.py
+++ b/cortex/ledger/ledger_core.py
@@ -303,9 +303,7 @@ class SovereignLedger:
             "tenant_id",
             "TEXT NOT NULL DEFAULT '__global__'",
         )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_tx_tenant_id ON transactions(tenant_id, id)"
-        )
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_tx_tenant_id ON transactions(tenant_id, id)")
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_merkle_tenant_range "
             "ON merkle_roots(tenant_id, tx_start_id, tx_end_id)"

--- a/cortex/ledger/ledger_core.py
+++ b/cortex/ledger/ledger_core.py
@@ -237,8 +237,26 @@ class SovereignLedger:
         self._config = config
 
         # Schema is created synchronously on init if possible
-        if isinstance(db, sqlite3.Connection):
-            self._ensure_schema_sync(db)
+        if self._is_sync_connection(db):
+            self._ensure_schema_sync(cast(sqlite3.Connection, db))
+
+    @staticmethod
+    def _is_sync_connection(db: object) -> bool:
+        """Return true for sqlite-compatible synchronous connections.
+
+        Some test/runtime wrappers expose the sqlite3 connection protocol
+        without preserving a strict ``sqlite3.Connection`` identity.
+        """
+        if isinstance(db, aiosqlite.Connection):
+            return False
+        return isinstance(db, sqlite3.Connection) or all(
+            hasattr(db, attr) for attr in ("execute", "commit", "rollback")
+        )
+
+    def _sync_db(self) -> sqlite3.Connection:
+        if not self._is_sync_connection(self.db):
+            raise RuntimeError("operation requires a sync sqlite3.Connection")
+        return cast(sqlite3.Connection, self.db)
 
     def _ensure_schema_sync(self, conn: sqlite3.Connection):
         conn.executescript("""
@@ -249,11 +267,12 @@ class SovereignLedger:
                 detail      TEXT,
                 prev_hash   TEXT NOT NULL,
                 hash        TEXT NOT NULL UNIQUE,
-                tenant_id   TEXT DEFAULT 'default',
+                tenant_id   TEXT NOT NULL DEFAULT 'default',
                 timestamp   TEXT NOT NULL
             );
             CREATE TABLE IF NOT EXISTS merkle_roots (
                 id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                tenant_id       TEXT NOT NULL DEFAULT '__global__',
                 root_hash       TEXT NOT NULL,
                 tx_start_id     INTEGER NOT NULL,
                 tx_end_id       INTEGER NOT NULL,
@@ -272,6 +291,36 @@ class SovereignLedger:
             CREATE INDEX IF NOT EXISTS idx_tx_prev ON transactions(prev_hash);
             CREATE INDEX IF NOT EXISTS idx_merkle_range ON merkle_roots(tx_start_id, tx_end_id);
         """)
+        self._ensure_ledger_column(
+            conn,
+            "transactions",
+            "tenant_id",
+            "TEXT NOT NULL DEFAULT 'default'",
+        )
+        self._ensure_ledger_column(
+            conn,
+            "merkle_roots",
+            "tenant_id",
+            "TEXT NOT NULL DEFAULT '__global__'",
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_tx_tenant_id ON transactions(tenant_id, id)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_merkle_tenant_range "
+            "ON merkle_roots(tenant_id, tx_start_id, tx_end_id)"
+        )
+
+    @staticmethod
+    def _ensure_ledger_column(
+        conn: sqlite3.Connection,
+        table: str,
+        column: str,
+        definition: str,
+    ) -> None:
+        columns = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+        if column not in columns:
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
 
     def record_write(self) -> None:
         """Track write rate for adaptive checkpointing."""
@@ -288,71 +337,142 @@ class SovereignLedger:
             return getattr(self._config, "CHECKPOINT_MIN", 10)
         return getattr(self._config, "CHECKPOINT_MAX", 100)
 
-    def record_transaction(self, project: str, action: str, detail: Any = None) -> str:
+    @staticmethod
+    def _effective_tenant_id(tenant_id: str | None) -> str:
+        return tenant_id or "default"
+
+    def record_transaction(
+        self,
+        project: str,
+        action: str,
+        detail: Any = None,
+        tenant_id: str | None = None,
+    ) -> str:
         """Record a transaction synchronously."""
-        if not isinstance(self.db, sqlite3.Connection):
-            raise RuntimeError("record_transaction requires a sync sqlite3.Connection")
+        conn = self._sync_db()
 
         self.record_write()
         detail_json = canonical_json(detail) if detail else "{}"
         ts = now_iso()
+        effective_tenant_id = self._effective_tenant_id(tenant_id)
 
         try:
-            self.db.execute("BEGIN EXCLUSIVE")
-            cursor = self.db.execute("SELECT hash FROM transactions ORDER BY id DESC LIMIT 1")
-            row = cursor.fetchone()
-            prev_hash = row[0] if row else "GENESIS"
-            new_hash = compute_tx_hash(prev_hash, project, action, detail_json, ts)
-
-            self.db.execute(
-                "INSERT INTO transactions (project, action, detail, prev_hash, hash, timestamp)"
-                " VALUES (?, ?, ?, ?, ?, ?)",
-                (project, action, detail_json, prev_hash, new_hash, ts),
+            conn.execute("BEGIN EXCLUSIVE")
+            new_hash = self._record_transaction_sync_unlocked(
+                conn,
+                project,
+                action,
+                detail_json,
+                ts,
+                effective_tenant_id,
             )
-            self.db.commit()
+            conn.commit()
             return new_hash
         except sqlite3.Error:
-            self.db.rollback()
+            conn.rollback()
             raise
 
-    async def record_transaction_async(self, project: str, action: str, detail: Any = None) -> str:
+    def record_transaction_in_current_transaction(
+        self,
+        project: str,
+        action: str,
+        detail: Any = None,
+        tenant_id: str | None = None,
+    ) -> str:
+        """Record a transaction inside the caller's active SQLite transaction."""
+        conn = self._sync_db()
+
+        self.record_write()
+        return self._record_transaction_sync_unlocked(
+            conn,
+            project,
+            action,
+            canonical_json(detail) if detail else "{}",
+            now_iso(),
+            self._effective_tenant_id(tenant_id),
+        )
+
+    def _record_transaction_sync_unlocked(
+        self,
+        conn: sqlite3.Connection,
+        project: str,
+        action: str,
+        detail_json: str,
+        timestamp: str,
+        tenant_id: str,
+    ) -> str:
+        cursor = conn.execute(
+            "SELECT hash FROM transactions WHERE tenant_id = ? ORDER BY id DESC LIMIT 1",
+            (tenant_id,),
+        )
+        row = cursor.fetchone()
+        prev_hash = row[0] if row else "GENESIS"
+        new_hash = compute_tx_hash(prev_hash, project, action, detail_json, timestamp, tenant_id)
+        conn.execute(
+            "INSERT INTO transactions "
+            "(project, action, detail, prev_hash, hash, tenant_id, timestamp)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (project, action, detail_json, prev_hash, new_hash, tenant_id, timestamp),
+        )
+        return new_hash
+
+    async def record_transaction_async(
+        self,
+        project: str,
+        action: str,
+        detail: Any = None,
+        tenant_id: str | None = None,
+    ) -> str:
         """Record a transaction asynchronously (requires a connection pool)."""
         self.record_write()
         detail_json = canonical_json(detail) if detail else "{}"
         ts = now_iso()
+        effective_tenant_id = self._effective_tenant_id(tenant_id)
 
         async with self._get_conn_proxy() as conn:  # type: ignore[reportAttributeAccessIssue]
             await conn.execute("BEGIN EXCLUSIVE")
             try:
                 cursor = await conn.execute(
-                    "SELECT hash FROM transactions ORDER BY id DESC LIMIT 1"
+                    "SELECT hash FROM transactions WHERE tenant_id = ? ORDER BY id DESC LIMIT 1",
+                    (effective_tenant_id,),
                 )
                 row = await cursor.fetchone()
                 prev_hash = row[0] if row else "GENESIS"
-                new_hash = compute_tx_hash(prev_hash, project, action, detail_json, ts)
+                new_hash = compute_tx_hash(
+                    prev_hash,
+                    project,
+                    action,
+                    detail_json,
+                    ts,
+                    effective_tenant_id,
+                )
 
                 await conn.execute(
-                    "INSERT INTO transactions (project, action, detail, prev_hash, hash, timestamp)"
-                    " VALUES (?, ?, ?, ?, ?, ?)",
-                    (project, action, detail_json, prev_hash, new_hash, ts),
+                    "INSERT INTO transactions "
+                    "(project, action, detail, prev_hash, hash, tenant_id, timestamp)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (project, action, detail_json, prev_hash, new_hash, effective_tenant_id, ts),
                 )
                 await conn.commit()
                 return new_hash
-            except Exception:
+            except (aiosqlite.Error, sqlite3.Error, TypeError, ValueError):
                 await conn.rollback()
                 raise
 
     def create_checkpoint(self) -> str | None:
         """Create a Merkle checkpoint synchronously."""
-        if not isinstance(self.db, sqlite3.Connection):
+        if not self._is_sync_connection(self.db):
             return None
+        conn = self._sync_db()
 
         batch_size = self.adaptive_batch_size
-        cursor = self.db.execute("SELECT MAX(tx_end_id) FROM merkle_roots")
+        cursor = conn.execute(
+            "SELECT MAX(tx_end_id) FROM merkle_roots WHERE tenant_id = '__global__'"
+        )
         row = cursor.fetchone()
         last_covered = row[0] or 0 if row else 0
 
-        cursor = self.db.execute(
+        cursor = conn.execute(
             "SELECT id, hash FROM transactions WHERE id > ? ORDER BY id LIMIT ?",
             (last_covered, batch_size),
         )
@@ -366,11 +486,13 @@ class SovereignLedger:
         root = tree.root_hash
         start_id, end_id = rows[0][0], rows[-1][0]
 
-        self.db.execute(
-            "INSERT INTO merkle_roots (root_hash, tx_start_id, tx_end_id, tx_count) VALUES (?, ?, ?, ?)",
+        conn.execute(
+            "INSERT INTO merkle_roots "
+            "(tenant_id, root_hash, tx_start_id, tx_end_id, tx_count) "
+            "VALUES ('__global__', ?, ?, ?, ?)",
             (root, start_id, end_id, len(rows)),
         )
-        self.db.commit()
+        conn.commit()
         return root
 
     async def create_checkpoint_async(self) -> str | None:
@@ -379,7 +501,9 @@ class SovereignLedger:
 
         async with self._lock:
             async with self._get_conn_proxy() as conn:  # type: ignore[reportAttributeAccessIssue]
-                cursor = await conn.execute("SELECT MAX(tx_end_id) FROM merkle_roots")
+                cursor = await conn.execute(
+                    "SELECT MAX(tx_end_id) FROM merkle_roots WHERE tenant_id = '__global__'"
+                )
                 row = await cursor.fetchone()
                 last_covered = row[0] or 0 if row else 0
 
@@ -398,8 +522,9 @@ class SovereignLedger:
                 start_id, end_id = rows[0][0], rows[-1][0]
 
                 await conn.execute(
-                    "INSERT INTO merkle_roots (root_hash, tx_start_id, tx_end_id, tx_count) "
-                    "VALUES (?, ?, ?, ?)",
+                    "INSERT INTO merkle_roots "
+                    "(tenant_id, root_hash, tx_start_id, tx_end_id, tx_count) "
+                    "VALUES ('__global__', ?, ?, ?, ?)",
                     (root, start_id, end_id, len(rows)),
                 )
                 await conn.commit()
@@ -414,14 +539,14 @@ class SovereignLedger:
             yield self.db
             return
 
-        if isinstance(self.db, sqlite3.Connection):
+        if self._is_sync_connection(self.db):
             raise RuntimeError("Async ledger operations require a CortexConnectionPool backend")
 
         pool = cast("CortexConnectionPool", self.db)
         async with pool.acquire() as conn:
             yield conn
 
-    async def audit_integrity_async(self) -> dict:
+    async def audit_integrity_async(self, tenant_id: str | None = None) -> dict:
         """Perform a full integrity audit asynchronously (Ω₁)."""
         violations = []
         tx_count = 0
@@ -429,42 +554,74 @@ class SovereignLedger:
         async with self._get_conn_proxy() as conn:
             started_at = now_iso()
             cursor = await conn.execute(
-                "SELECT id, project, action, detail, prev_hash, hash, timestamp "
-                "FROM transactions ORDER BY id"
+                "SELECT id, COALESCE(tenant_id, 'default'), project, action, detail, "
+                "prev_hash, hash, timestamp FROM transactions ORDER BY id"
             )
 
-            expected_prev = "GENESIS"
+            expected_prev_by_tenant: dict[str, str] = {}
+            expected_prev_global = "GENESIS"
             while True:
                 row = await cursor.fetchone()
                 if not row:
                     break
-                tid, proj, act, det, prev, h, ts = row
-                tx_count += 1
+                tid, tx_tenant_id, proj, act, det, prev, h, ts = row
+                in_scope = tenant_id is None or tx_tenant_id == tenant_id
 
-                if prev != expected_prev:
-                    violations.append({"id": tid, "type": "CHAIN_BREAK", "expected": expected_prev})
+                expected_prev = expected_prev_by_tenant.get(tx_tenant_id, "GENESIS")
+                computed_v3 = compute_tx_hash(prev, proj, act, det, ts, tenant_id=tx_tenant_id)
+                computed_v2 = compute_tx_hash(prev, proj, act, det, ts)
+                computed_v1 = compute_tx_hash_v1(prev, proj, act, det, ts)
 
-                # Verify with v2, fallback to v1
-                computed = compute_tx_hash(prev, proj, act, det, ts)
-                if computed != h:
-                    computed_v1 = compute_tx_hash_v1(prev, proj, act, det, ts)
-                    if computed_v1 != h:
+                if in_scope:
+                    tx_count += 1
+                    if computed_v3 == h:
+                        if prev != expected_prev:
+                            violations.append(
+                                {"id": tid, "type": "CHAIN_BREAK", "expected": expected_prev}
+                            )
+                    elif h in {computed_v2, computed_v1}:
+                        if prev != expected_prev_global:
+                            violations.append(
+                                {
+                                    "id": tid,
+                                    "type": "CHAIN_BREAK",
+                                    "expected": expected_prev,
+                                    "legacy_expected": expected_prev_global,
+                                }
+                            )
+                    else:
                         violations.append({"id": tid, "type": "TAMPER_DETECTED", "stored": h})
 
-                expected_prev = h
-                if tx_count % 100 == 0:
+                expected_prev_by_tenant[tx_tenant_id] = h
+                expected_prev_global = h
+                if tid % 100 == 0:
                     await asyncio.sleep(0)  # Yield
 
             # Verify Merkle Roots
-            cursor = await conn.execute(
-                "SELECT root_hash, tx_start_id, tx_end_id FROM merkle_roots"
-            )
-            roots = list(await cursor.fetchall())
-            for stored_root, start, end in roots:
-                c = await conn.execute(
-                    "SELECT hash FROM transactions WHERE id >= ? AND id <= ? ORDER BY id",
-                    (start, end),
+            if tenant_id is None:
+                cursor = await conn.execute(
+                    "SELECT COALESCE(tenant_id, 'default'), root_hash, tx_start_id, tx_end_id "
+                    "FROM merkle_roots"
                 )
+            else:
+                cursor = await conn.execute(
+                    "SELECT COALESCE(tenant_id, 'default'), root_hash, tx_start_id, tx_end_id "
+                    "FROM merkle_roots WHERE tenant_id = ?",
+                    (tenant_id,),
+                )
+            roots = list(await cursor.fetchall())
+            for root_tenant_id, stored_root, start, end in roots:
+                if root_tenant_id == "__global__":
+                    c = await conn.execute(
+                        "SELECT hash FROM transactions WHERE id >= ? AND id <= ? ORDER BY id",
+                        (start, end),
+                    )
+                else:
+                    c = await conn.execute(
+                        "SELECT hash FROM transactions "
+                        "WHERE tenant_id = ? AND id >= ? AND id <= ? ORDER BY id",
+                        (root_tenant_id, start, end),
+                    )
                 hashes = [r[0] for r in list(await c.fetchall())]
                 computed_root = MerkleTree(hashes).root_hash
                 if computed_root != stored_root:
@@ -474,7 +631,13 @@ class SovereignLedger:
             await conn.execute(
                 "INSERT INTO integrity_checks (check_type, status, details, started_at, completed_at) "
                 "VALUES (?, ?, ?, ?, ?)",
-                ("full", status, json.dumps(violations), started_at, now_iso()),
+                (
+                    "full" if tenant_id is None else "tenant",
+                    status,
+                    json.dumps(violations),
+                    started_at,
+                    now_iso(),
+                ),
             )
             await conn.commit()
 

--- a/cortex/migrations/mig_ledger.py
+++ b/cortex/migrations/mig_ledger.py
@@ -161,8 +161,7 @@ def _migration_025_tenant_bound_merkle_roots(conn: sqlite3.Connection):
     columns = {row[1] for row in conn.execute("PRAGMA table_info(merkle_roots)").fetchall()}
     if "tenant_id" not in columns:
         conn.execute(
-            "ALTER TABLE merkle_roots "
-            "ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '__global__'"
+            "ALTER TABLE merkle_roots ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '__global__'"
         )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_merkle_tenant_range "

--- a/cortex/migrations/mig_ledger.py
+++ b/cortex/migrations/mig_ledger.py
@@ -151,3 +151,21 @@ def _migration_014_vote_ledger_refinement(conn: sqlite3.Connection):
         )
     """)
     logger.info("Migration 014: Refined Immutable Ledger (vote_ledger + vote_merkle_roots)")
+
+
+# DOWNGRADE TARGET: 24
+# Rollback strategy: this is additive and preserves checkpoint data. A downgrade
+# should leave the tenant_id column in place; older readers ignore unknown columns.
+def _migration_025_tenant_bound_merkle_roots(conn: sqlite3.Connection):
+    """Add tenant scope metadata to transaction Merkle checkpoints."""
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(merkle_roots)").fetchall()}
+    if "tenant_id" not in columns:
+        conn.execute(
+            "ALTER TABLE merkle_roots "
+            "ADD COLUMN tenant_id TEXT NOT NULL DEFAULT '__global__'"
+        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_merkle_tenant_range "
+        "ON merkle_roots(tenant_id, tx_start_id, tx_end_id)"
+    )
+    logger.info("Migration 025: Added tenant scope metadata to merkle_roots")

--- a/cortex/migrations/registry.py
+++ b/cortex/migrations/registry.py
@@ -20,6 +20,7 @@ from cortex.migrations.mig_ledger import (
     _migration_011_link_facts_to_tx,
     _migration_012_ghosts_table,
     _migration_014_vote_ledger_refinement,
+    _migration_025_tenant_bound_merkle_roots,
 )
 from cortex.migrations.mig_security_hardening import _migration_018_security_hardening
 from cortex.migrations.mig_signals import _migration_019_signal_bus
@@ -56,4 +57,5 @@ MIGRATIONS = [
     (21, "Solid-State Substrate (entity_events)", _migration_021_solid_state),
     (22, "Stratified Cognition + Causal Anchoring", _migration_022_cognitive_layer),
     # (23) removed — mig_simplify_facts was never applied and is incompatible with live schema
+    (25, "Tenant-bound Merkle checkpoints", _migration_025_tenant_bound_merkle_roots),
 ]

--- a/cortex/utils/canonical.py
+++ b/cortex/utils/canonical.py
@@ -7,6 +7,7 @@ preimage and collision attacks on the hash chain.
 Hash Scheme Versions:
     v1: colon-delimited   f"{prev}:{project}:{action}:{detail}:{ts}"
     v2: null-byte canon   f"{prev}\\x00{project}\\x00{action}\\x00{canonical_detail}\\x00{ts}"
+    v3: tenant-bound      f"v3\\x00{tenant}\\x00{prev}\\x00{project}\\x00{action}\\x00{canonical_detail}\\x00{ts}"
 """
 
 from __future__ import annotations
@@ -57,7 +58,7 @@ def canonical_json(obj: Any) -> str:
 
 # ─── Transaction Hash ────────────────────────────────────────────
 
-HASH_VERSION = 2
+HASH_VERSION = 3
 
 
 def compute_tx_hash(
@@ -66,11 +67,14 @@ def compute_tx_hash(
     action: str,
     detail_json: str,
     timestamp: str,
+    tenant_id: str | None = None,
 ) -> str:
     """Compute transaction hash using null-byte separated canonical form.
 
     Uses \\x00 (null byte) as field separator to prevent boundary
-    confusion when fields contain colons or other delimiters.
+    confusion when fields contain colons or other delimiters. New
+    tenant-scoped writes should pass ``tenant_id`` so the digest cannot be
+    transplanted into another tenant chain while retaining the same hash.
 
     Args:
         prev_hash: Hash of the previous transaction, or "GENESIS".
@@ -78,11 +82,19 @@ def compute_tx_hash(
         action: Transaction action (store, deprecate, vote, etc.).
         detail_json: Canonical JSON string of transaction detail.
         timestamp: ISO 8601 UTC timestamp.
+        tenant_id: Optional tenant binding for v3 hashes. Omit only when
+            creating or verifying legacy v2 transactions.
 
     Returns:
         SHA-256 hex digest of the canonical input.
     """
-    h_input = f"{prev_hash}\x00{project}\x00{action}\x00{detail_json}\x00{timestamp}"
+    if tenant_id is None:
+        h_input = f"{prev_hash}\x00{project}\x00{action}\x00{detail_json}\x00{timestamp}"
+    else:
+        h_input = (
+            f"v3\x00{tenant_id}\x00{prev_hash}\x00{project}"
+            f"\x00{action}\x00{detail_json}\x00{timestamp}"
+        )
     return hashlib.sha256(h_input.encode("utf-8")).hexdigest()
 
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -163,6 +163,29 @@ cortex ledger stats     # Ledger statistics
 
 ---
 
+### `cortex forensics` (experimental)
+
+Commit local forensic evidence manifests to the tenant-bound transaction ledger.
+This command group is hidden unless `CORTEX_ENABLE_EXPERIMENTAL_CLI=1` is set.
+
+```bash
+CORTEX_ENABLE_EXPERIMENTAL_CLI=1 cortex forensics build-manifest evidence.txt \
+  --base-dir ./evidence --bundle-id audit-pack-001 --tenant-id tenant-a \
+  --output manifest.json
+
+CORTEX_ENABLE_EXPERIMENTAL_CLI=1 cortex forensics commit-manifest manifest.json \
+  --base-dir ./evidence --db ~/.cortex/cortex.db
+
+CORTEX_ENABLE_EXPERIMENTAL_CLI=1 cortex forensics verify-commit manifest.json \
+  --base-dir ./evidence --db ~/.cortex/cortex.db
+```
+
+The ledger stores only canonical manifest metadata, artifact hashes, byte counts,
+and the manifest hash. Raw evidence bytes remain local and are never written to
+the transaction detail.
+
+---
+
 ### `cortex compliance-report`
 
 Generate EU AI Act Article 12 compliance snapshot.

--- a/tests/test_forensic_cli.py
+++ b/tests/test_forensic_cli.py
@@ -154,7 +154,9 @@ def test_forensics_cli_rejects_manifest_paths_outside_base(tmp_path) -> None:
     base.mkdir()
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(
-        json.dumps({"schema": "cortex.forensics.evidence_manifest.v1", "artifacts": [{"path": "../x"}]}),
+        json.dumps(
+            {"schema": "cortex.forensics.evidence_manifest.v1", "artifacts": [{"path": "../x"}]}
+        ),
         encoding="utf-8",
     )
     runner = CliRunner()

--- a/tests/test_forensic_cli.py
+++ b/tests/test_forensic_cli.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from cortex.cli.forensics_cmds import forensics_cmds
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXED_TS = "2026-05-05T00:00:00+00:00"
+
+
+def _json_output(output: str) -> dict[str, object]:
+    return json.loads(output)
+
+
+def test_forensics_cli_build_verify_commit_round_trip(tmp_path) -> None:
+    base = tmp_path / "evidence"
+    artifact = base / "reports" / "summary.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("customer-confidential evidence\n", encoding="utf-8")
+    manifest_path = tmp_path / "manifest.json"
+    db_path = tmp_path / "ledger.db"
+    runner = CliRunner()
+
+    built = runner.invoke(
+        forensics_cmds,
+        [
+            "build-manifest",
+            str(artifact),
+            "--base-dir",
+            str(base),
+            "--bundle-id",
+            "bundle-cli",
+            "--tenant-id",
+            "tenant-cli",
+            "--project",
+            "cli-project",
+            "--generated-at",
+            FIXED_TS,
+            "--output",
+            str(manifest_path),
+        ],
+    )
+    assert built.exit_code == 0, built.output
+    built_payload = _json_output(built.output)
+    assert built_payload["valid"] is True
+    assert built_payload["artifact_count"] == 1
+    assert manifest_path.exists()
+
+    verified = runner.invoke(
+        forensics_cmds,
+        ["verify-manifest", str(manifest_path), "--base-dir", str(base)],
+    )
+    assert verified.exit_code == 0, verified.output
+    assert _json_output(verified.output)["valid"] is True
+
+    committed = runner.invoke(
+        forensics_cmds,
+        ["commit-manifest", str(manifest_path), "--base-dir", str(base), "--db", str(db_path)],
+    )
+    assert committed.exit_code == 0, committed.output
+    committed_payload = _json_output(committed.output)
+    assert committed_payload["committed"] is True
+    assert committed_payload["tenant_id"] == "tenant-cli"
+
+    verified_commit = runner.invoke(
+        forensics_cmds,
+        ["verify-commit", str(manifest_path), "--base-dir", str(base), "--db", str(db_path)],
+    )
+    assert verified_commit.exit_code == 0, verified_commit.output
+    assert _json_output(verified_commit.output)["valid"] is True
+
+
+def test_forensics_cli_missing_artifact_exits_nonzero(tmp_path) -> None:
+    base = tmp_path / "evidence"
+    artifact = base / "report.txt"
+    base.mkdir()
+    artifact.write_text("evidence\n", encoding="utf-8")
+    manifest_path = tmp_path / "manifest.json"
+    runner = CliRunner()
+
+    built = runner.invoke(
+        forensics_cmds,
+        [
+            "build-manifest",
+            str(artifact),
+            "--base-dir",
+            str(base),
+            "--bundle-id",
+            "bundle-missing",
+            "--tenant-id",
+            "tenant-cli",
+            "--generated-at",
+            FIXED_TS,
+            "--output",
+            str(manifest_path),
+        ],
+    )
+    assert built.exit_code == 0, built.output
+
+    artifact.unlink()
+    verified = runner.invoke(
+        forensics_cmds,
+        ["verify-manifest", str(manifest_path), "--base-dir", str(base)],
+    )
+
+    assert verified.exit_code == 1
+    payload = _json_output(verified.output)
+    assert payload["valid"] is False
+    assert {violation["type"] for violation in payload["violations"]} >= {
+        "ARTIFACT_MISSING",
+        "MANIFEST_TOTAL_BYTES_MISMATCH",
+    }
+
+
+def test_forensics_cli_build_manifest_refuses_to_overwrite_artifact(tmp_path) -> None:
+    base = tmp_path / "evidence"
+    artifact = base / "report.txt"
+    base.mkdir()
+    artifact.write_text("evidence\n", encoding="utf-8")
+    original = artifact.read_bytes()
+    runner = CliRunner()
+
+    result = runner.invoke(
+        forensics_cmds,
+        [
+            "build-manifest",
+            str(artifact),
+            "--base-dir",
+            str(base),
+            "--bundle-id",
+            "bundle-overwrite",
+            "--tenant-id",
+            "tenant-cli",
+            "--generated-at",
+            FIXED_TS,
+            "--output",
+            str(artifact),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "must not overwrite" in result.output
+    assert artifact.read_bytes() == original
+
+
+def test_forensics_cli_rejects_manifest_paths_outside_base(tmp_path) -> None:
+    base = tmp_path / "evidence"
+    base.mkdir()
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps({"schema": "cortex.forensics.evidence_manifest.v1", "artifacts": [{"path": "../x"}]}),
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(
+        forensics_cmds,
+        ["verify-manifest", str(manifest_path), "--base-dir", str(base)],
+    )
+
+    assert result.exit_code == 1
+    assert "unsafe artifact path" in result.output
+
+
+def test_forensics_command_is_experimental_in_root_cli() -> None:
+    assert _root_cli_has_forensics(None) is False
+    assert _root_cli_has_forensics("1") is True
+
+
+def _root_cli_has_forensics(flag: str | None) -> bool:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    if flag is None:
+        env.pop("CORTEX_ENABLE_EXPERIMENTAL_CLI", None)
+    else:
+        env["CORTEX_ENABLE_EXPERIMENTAL_CLI"] = flag
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from cortex.cli import cli; print('forensics' in cli.commands)",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout.strip().splitlines()[-1] == "True"

--- a/tests/test_forensic_evidence_bundle.py
+++ b/tests/test_forensic_evidence_bundle.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import aiosqlite
+import pytest
+
+from cortex.forensics.evidence_bundle import (
+    EVIDENCE_COMMIT_ACTION,
+    build_evidence_manifest,
+    canonical_json_bytes,
+    commit_evidence_manifest,
+    sha256_hex,
+    verify_evidence_commit,
+    verify_evidence_manifest,
+)
+from cortex.ledger import SovereignLedger
+from cortex.utils.canonical import canonical_json, compute_tx_hash, now_iso
+
+FIXED_TS = "2026-05-05T00:00:00+00:00"
+
+
+def _artifacts() -> dict[str, bytes]:
+    return {
+        "reports/summary.txt": b"customer secret evidence\n",
+        "traces/run.json": b'{"ok":true,"steps":3}',
+    }
+
+
+def _manifest(tenant_id: str = "tenant-a") -> dict[str, object]:
+    return build_evidence_manifest(
+        _artifacts(),
+        bundle_id="bundle-001",
+        tenant_id=tenant_id,
+        project="audit-pack",
+        generated_at=FIXED_TS,
+    )
+
+
+def _rehash_manifest(manifest: dict[str, object]) -> None:
+    body = dict(manifest)
+    body.pop("manifest_sha256", None)
+    manifest["manifest_sha256"] = sha256_hex(canonical_json_bytes(body))
+
+
+def _insert_legacy_tx(
+    conn: sqlite3.Connection,
+    *,
+    project: str,
+    action: str = "store",
+    detail: dict[str, object] | None = None,
+    tenant_id: str = "default",
+) -> None:
+    detail_json = canonical_json(detail or {})
+    timestamp = now_iso()
+    row = conn.execute("SELECT hash FROM transactions ORDER BY id DESC LIMIT 1").fetchone()
+    prev_hash = row[0] if row else "GENESIS"
+    tx_hash = compute_tx_hash(prev_hash, project, action, detail_json, timestamp)
+    conn.execute(
+        "INSERT INTO transactions (tenant_id, project, action, detail, prev_hash, hash, timestamp) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (tenant_id, project, action, detail_json, prev_hash, tx_hash, timestamp),
+    )
+    conn.commit()
+
+
+def test_manifest_is_deterministic_and_rejects_tampered_artifacts() -> None:
+    manifest = _manifest()
+    reordered = {
+        "traces/run.json": _artifacts()["traces/run.json"],
+        "reports/summary.txt": _artifacts()["reports/summary.txt"],
+    }
+
+    same_manifest = build_evidence_manifest(
+        reordered,
+        bundle_id="bundle-001",
+        tenant_id="tenant-a",
+        project="audit-pack",
+        generated_at=FIXED_TS,
+    )
+    assert same_manifest["manifest_sha256"] == manifest["manifest_sha256"]
+
+    report = verify_evidence_manifest(manifest, {"reports/summary.txt": b"tampered"})
+    assert report["valid"] is False
+    violation_types = {violation["type"] for violation in report["violations"]}
+    assert "ARTIFACT_HASH_MISMATCH" in violation_types
+    assert "ARTIFACT_MISSING" in violation_types
+
+
+@pytest.mark.parametrize("path", ["/abs.txt", "../secret.txt", "a/../b.txt", "a\\b.txt", ""])
+def test_manifest_rejects_unsafe_artifact_paths(path: str) -> None:
+    with pytest.raises(ValueError):
+        build_evidence_manifest(
+            {path: b"x"},
+            bundle_id="bundle-001",
+            tenant_id="tenant-a",
+            generated_at=FIXED_TS,
+        )
+
+
+def test_commit_manifest_is_idempotent_raw_free_and_tenant_bound(tmp_path) -> None:
+    db_path = str(tmp_path / "ledger.db")
+    manifest = _manifest()
+
+    first = commit_evidence_manifest(db_path, manifest, _artifacts())
+    second = commit_evidence_manifest(db_path, manifest, _artifacts())
+
+    assert first["valid"] is True
+    assert first["committed"] is True
+    assert first["already_committed"] is False
+    assert second["already_committed"] is True
+    assert second["tx_id"] == first["tx_id"]
+    assert second["tx_hash"] == first["tx_hash"]
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT tenant_id, action, detail, prev_hash, hash, timestamp FROM transactions"
+    ).fetchone()
+    conn.close()
+
+    assert row["tenant_id"] == "tenant-a"
+    assert row["action"] == EVIDENCE_COMMIT_ACTION
+    assert "customer secret evidence" not in row["detail"]
+
+    tenant_hash = compute_tx_hash(
+        row["prev_hash"],
+        "audit-pack",
+        EVIDENCE_COMMIT_ACTION,
+        row["detail"],
+        row["timestamp"],
+        tenant_id="tenant-a",
+    )
+    legacy_hash = compute_tx_hash(
+        row["prev_hash"],
+        "audit-pack",
+        EVIDENCE_COMMIT_ACTION,
+        row["detail"],
+        row["timestamp"],
+    )
+    assert row["hash"] == tenant_hash
+    assert row["hash"] != legacy_hash
+
+
+def test_commit_manifest_does_not_write_when_manifest_fails(tmp_path) -> None:
+    db_path = tmp_path / "ledger.db"
+    manifest = _manifest()
+    manifest["manifest_sha256"] = "bad"
+
+    result = commit_evidence_manifest(str(db_path), manifest, _artifacts())
+
+    assert result["valid"] is False
+    assert result["committed"] is False
+    assert not db_path.exists()
+
+
+def test_commit_manifest_returns_json_status_for_structurally_invalid_manifest(tmp_path) -> None:
+    db_path = tmp_path / "ledger.db"
+    manifest = _manifest()
+    manifest["tenant_id"] = ""
+    _rehash_manifest(manifest)
+
+    result = commit_evidence_manifest(str(db_path), manifest, _artifacts())
+
+    assert result["valid"] is False
+    assert result["committed"] is False
+    assert result["violations"][0]["type"] == "COMMIT_DETAIL_INVALID"
+    assert not db_path.exists()
+
+
+def test_verify_commit_returns_json_status_for_structurally_invalid_manifest(tmp_path) -> None:
+    db_path = tmp_path / "ledger.db"
+    manifest = _manifest()
+    manifest["bundle_id"] = ""
+    _rehash_manifest(manifest)
+
+    result = verify_evidence_commit(str(db_path), manifest, _artifacts())
+
+    assert result["valid"] is False
+    violation_types = {violation["type"] for violation in result["violations"]}
+    assert "COMMIT_DETAIL_INVALID" in violation_types
+
+
+def test_verify_commit_detects_missing_and_tampered_commit(tmp_path) -> None:
+    db_path = str(tmp_path / "ledger.db")
+    manifest = _manifest()
+
+    missing = verify_evidence_commit(db_path, manifest, _artifacts())
+    assert missing["valid"] is False
+    assert {violation["type"] for violation in missing["violations"]} == {"COMMIT_MISSING"}
+
+    commit_result = commit_evidence_manifest(db_path, manifest, _artifacts())
+    assert commit_result["committed"] is True
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT id, detail FROM transactions").fetchone()
+    detail = json.loads(row["detail"])
+    detail["total_bytes"] = 999
+    conn.execute(
+        "UPDATE transactions SET detail = ? WHERE id = ?",
+        (canonical_json(detail), row["id"]),
+    )
+    conn.commit()
+    conn.close()
+
+    tampered = verify_evidence_commit(db_path, manifest, _artifacts())
+    assert tampered["valid"] is False
+    violation_types = {violation["type"] for violation in tampered["violations"]}
+    assert "COMMIT_DETAIL_MISMATCH" in violation_types
+    assert "TAMPER_DETECTED" in violation_types
+
+
+def test_repeated_commit_fails_closed_if_existing_commit_is_corrupted(tmp_path) -> None:
+    db_path = str(tmp_path / "ledger.db")
+    manifest = _manifest()
+    commit_result = commit_evidence_manifest(db_path, manifest, _artifacts())
+    assert commit_result["committed"] is True
+
+    conn = sqlite3.connect(db_path)
+    conn.execute("UPDATE transactions SET prev_hash = 'CORRUPTED'")
+    conn.commit()
+    conn.close()
+
+    repeated = commit_evidence_manifest(db_path, manifest, _artifacts())
+
+    assert repeated["valid"] is False
+    assert repeated["committed"] is False
+    assert repeated["already_committed"] is True
+    violation_types = {violation["type"] for violation in repeated["violations"]}
+    assert "CHAIN_BREAK" in violation_types
+    conn = sqlite3.connect(db_path)
+    tx_count = conn.execute(
+        "SELECT COUNT(*) FROM transactions WHERE action = ?",
+        (EVIDENCE_COMMIT_ACTION,),
+    ).fetchone()[0]
+    conn.close()
+    assert tx_count == 1
+
+
+def test_verify_commit_checks_global_merkle_checkpoints(tmp_path) -> None:
+    db_path = str(tmp_path / "ledger.db")
+    manifest = _manifest()
+    commit_result = commit_evidence_manifest(db_path, manifest, _artifacts())
+    assert commit_result["committed"] is True
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO merkle_roots (tenant_id, root_hash, tx_start_id, tx_end_id, tx_count) "
+        "VALUES ('__global__', 'bad-root', 1, 1, 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    report = verify_evidence_commit(db_path, manifest, _artifacts())
+
+    assert report["valid"] is False
+    assert "MERKLE_MISMATCH" in {violation["type"] for violation in report["violations"]}
+
+
+async def test_ledger_audit_accepts_legacy_chain_and_tenant_bound_chain(tmp_path) -> None:
+    db_path = str(tmp_path / "ledger.db")
+    conn = sqlite3.connect(db_path)
+    ledger = SovereignLedger(conn)
+    _insert_legacy_tx(conn, project="legacy-1", detail={"x": 1})
+    ledger.record_transaction("tenant", "store", {"x": 2}, tenant_id="tenant-a")
+    _insert_legacy_tx(conn, project="legacy-2", detail={"x": 3})
+    conn.close()
+
+    async with aiosqlite.connect(db_path) as async_conn:
+        ledger = SovereignLedger(async_conn)
+        full_report = await ledger.audit_integrity_async()
+        tenant_report = await ledger.audit_integrity_async("tenant-a")
+        default_report = await ledger.audit_integrity_async("default")
+
+    assert full_report["valid"] is True
+    assert full_report["tx_count"] == 3
+    assert tenant_report["valid"] is True
+    assert tenant_report["tx_count"] == 1
+    assert default_report["valid"] is True
+    assert default_report["tx_count"] == 2
+
+
+def test_record_transaction_without_tenant_uses_default_tenant_bound_hash(tmp_path) -> None:
+    db_path = str(tmp_path / "ledger.db")
+    conn = sqlite3.connect(db_path)
+    SovereignLedger(conn).record_transaction("default-project", "store", {"x": 1})
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT tenant_id, project, action, detail, prev_hash, hash, timestamp FROM transactions"
+    ).fetchone()
+    conn.close()
+
+    assert row["tenant_id"] == "default"
+    assert row["hash"] == compute_tx_hash(
+        row["prev_hash"],
+        row["project"],
+        row["action"],
+        row["detail"],
+        row["timestamp"],
+        tenant_id="default",
+    )
+    assert row["hash"] != compute_tx_hash(
+        row["prev_hash"],
+        row["project"],
+        row["action"],
+        row["detail"],
+        row["timestamp"],
+    )
+
+
+async def test_ledger_audit_detects_tenant_transplant(tmp_path) -> None:
+    db_path = str(tmp_path / "ledger.db")
+    conn = sqlite3.connect(db_path)
+    SovereignLedger(conn).record_transaction("tenant", "store", {"x": 1}, tenant_id="tenant-a")
+    conn.execute("UPDATE transactions SET tenant_id = 'tenant-b'")
+    conn.commit()
+    conn.close()
+
+    async with aiosqlite.connect(db_path) as async_conn:
+        report = await SovereignLedger(async_conn).audit_integrity_async()
+
+    assert report["valid"] is False
+    assert {violation["type"] for violation in report["violations"]} == {"TAMPER_DETECTED"}

--- a/tests/test_forensic_ledger_migration.py
+++ b/tests/test_forensic_ledger_migration.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import sqlite3
+
+from cortex.database.schema import SCHEMA_VERSION
+from cortex.migrations import get_current_version, run_migrations
+from cortex.migrations.registry import MIGRATIONS
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _column_info(conn: sqlite3.Connection, table: str, column: str) -> sqlite3.Row:
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        f"SELECT * FROM pragma_table_info('{table}') WHERE name = ?",
+        (column,),
+    ).fetchone()
+    assert row is not None
+    return row
+
+
+def test_fresh_schema_has_tenant_scoped_merkle_roots() -> None:
+    conn = sqlite3.connect(":memory:")
+    applied = run_migrations(conn)
+
+    assert applied == 0
+    assert get_current_version(conn) == 25
+    assert "tenant_id" in _columns(conn, "merkle_roots")
+    tenant_id = _column_info(conn, "merkle_roots", "tenant_id")
+    assert tenant_id["notnull"] == 1
+    assert tenant_id["dflt_value"] == "'__global__'"
+    assert SCHEMA_VERSION == "5.4.2"
+
+
+def test_migration_025_adds_merkle_tenant_scope_without_data_loss() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT DEFAULT (datetime('now')),
+            description TEXT
+        );
+        INSERT INTO schema_version (version, description) VALUES (24, 'pre forensic baseline');
+        CREATE TABLE merkle_roots (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            root_hash       TEXT NOT NULL,
+            tx_start_id     INTEGER NOT NULL,
+            tx_end_id       INTEGER NOT NULL,
+            tx_count        INTEGER NOT NULL,
+            created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO merkle_roots (root_hash, tx_start_id, tx_end_id, tx_count)
+        VALUES ('root-a', 1, 3, 3);
+    """)
+
+    applied = run_migrations(conn)
+
+    assert applied == 1
+    assert get_current_version(conn) == 25
+    assert "tenant_id" in _columns(conn, "merkle_roots")
+    tenant_id = _column_info(conn, "merkle_roots", "tenant_id")
+    assert tenant_id["notnull"] == 1
+    assert tenant_id["dflt_value"] == "'__global__'"
+    row = conn.execute(
+        "SELECT tenant_id, root_hash, tx_start_id, tx_end_id, tx_count FROM merkle_roots"
+    ).fetchone()
+    assert tuple(row) == ("__global__", "root-a", 1, 3, 3)
+    indexes = {
+        row[1]
+        for row in conn.execute("PRAGMA index_list(merkle_roots)").fetchall()
+    }
+    assert "idx_merkle_tenant_range" in indexes
+
+
+def test_migration_registry_tracks_forensic_ledger_schema_version() -> None:
+    versions = [version for version, _description, _func in MIGRATIONS]
+    assert versions[-1] == 25
+    assert versions == sorted(versions)
+    assert len(versions) == len(set(versions))

--- a/tests/test_forensic_ledger_migration.py
+++ b/tests/test_forensic_ledger_migration.py
@@ -67,10 +67,7 @@ def test_migration_025_adds_merkle_tenant_scope_without_data_loss() -> None:
         "SELECT tenant_id, root_hash, tx_start_id, tx_end_id, tx_count FROM merkle_roots"
     ).fetchone()
     assert tuple(row) == ("__global__", "root-a", 1, 3, 3)
-    indexes = {
-        row[1]
-        for row in conn.execute("PRAGMA index_list(merkle_roots)").fetchall()
-    }
+    indexes = {row[1] for row in conn.execute("PRAGMA index_list(merkle_roots)").fetchall()}
     assert "idx_merkle_tenant_range" in indexes
 
 


### PR DESCRIPTION
## Summary
- Add canonical forensic evidence manifests and experimental `cortex forensics` CLI commands gated by `CORTEX_ENABLE_EXPERIMENTAL_CLI=1`.
- Commit verified manifest metadata to the tenant-bound transaction ledger without storing raw artifact bytes.
- Upgrade ledger hashes to v3 tenant-bound writes by default while preserving v1/v2 verification compatibility.
- Add migration 025 for tenant-scoped Merkle checkpoints and document the experimental CLI surface.

## Verification
- `python3 -m ruff check cortex/utils/canonical.py cortex/ledger/ledger_core.py cortex/engine/transaction_mixin.py cortex/forensics/evidence_bundle.py cortex/cli/forensics_cmds.py cortex/database/schema.py cortex/database/schema_extensions.py cortex/migrations/mig_ledger.py cortex/migrations/registry.py tests/test_forensic_evidence_bundle.py tests/test_forensic_cli.py tests/test_forensic_ledger_migration.py`
- `python3 -m pyright cortex/utils/canonical.py cortex/ledger/ledger_core.py cortex/engine/transaction_mixin.py cortex/forensics/evidence_bundle.py cortex/cli/forensics_cmds.py cortex/database/schema.py cortex/database/schema_extensions.py cortex/migrations/mig_ledger.py cortex/migrations/registry.py`
- `python3 -m pytest -q tests/test_forensic_evidence_bundle.py tests/test_forensic_cli.py tests/test_forensic_ledger_migration.py tests/test_ledger_checkpointing.py tests/test_ledger_l3.py tests/test_store_mixin.py tests/test_parent_decision_id.py tests/test_route_tenant_isolation.py`
- `CORTEX_ENABLE_EXPERIMENTAL_CLI=1 python3 -m cortex.cli forensics --help`