### PR TITLE
feat: add forensic ledger export package

### DIFF
--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -8,6 +8,12 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from cortex.ledger.ledger_core import SovereignLedger
     from cortex.ledger.models import LedgerEvent, SemanticStatus
+    from cortex.ledger.public_export import (
+        ExportAuthority,
+        LedgerExportResult,
+        public_key_record,
+        write_public_ledger_export,
+    )
     from cortex.ledger.public_verifier import verify_export
     from cortex.ledger.queue import EnrichmentQueue
     from cortex.ledger.store import LedgerStore
@@ -23,6 +29,10 @@ __all__ = [
     "LedgerWriter",
     "LedgerVerifier",
     "EnrichmentQueue",
+    "ExportAuthority",
+    "LedgerExportResult",
+    "public_key_record",
+    "write_public_ledger_export",
     "verify_export",
 ]
 
@@ -33,6 +43,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LedgerWriter": ("cortex.ledger.writer", "LedgerWriter"),
     "LedgerVerifier": ("cortex.ledger.verifier", "LedgerVerifier"),
     "EnrichmentQueue": ("cortex.ledger.queue", "EnrichmentQueue"),
+    "ExportAuthority": ("cortex.ledger.public_export", "ExportAuthority"),
+    "LedgerExportResult": ("cortex.ledger.public_export", "LedgerExportResult"),
+    "public_key_record": ("cortex.ledger.public_export", "public_key_record"),
+    "write_public_ledger_export": ("cortex.ledger.public_export", "write_public_ledger_export"),
     "verify_export": ("cortex.ledger.public_verifier", "verify_export"),
 }
 

--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -7,7 +7,15 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cortex.ledger.ledger_core import SovereignLedger
-    from cortex.ledger.models import LedgerEvent, SemanticStatus
+    from cortex.ledger.models import LedgerEvent, LedgerOriginSignature, SemanticStatus
+    from cortex.ledger.origin import (
+        OriginKeyRecord,
+        OriginKeyRegistry,
+        OriginSignatureError,
+        OriginSignaturePolicy,
+        sign_event_origin,
+        verify_event_origin,
+    )
     from cortex.ledger.public_export import (
         ExportAuthority,
         LedgerExportResult,
@@ -22,6 +30,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "LedgerEvent",
+    "LedgerOriginSignature",
     "SemanticStatus",
     "SovereignLedger",
     "ImmutableLedger",
@@ -31,18 +40,31 @@ __all__ = [
     "EnrichmentQueue",
     "ExportAuthority",
     "LedgerExportResult",
+    "OriginKeyRecord",
+    "OriginKeyRegistry",
+    "OriginSignatureError",
+    "OriginSignaturePolicy",
     "public_key_record",
+    "sign_event_origin",
     "write_public_ledger_export",
+    "verify_event_origin",
     "verify_export",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LedgerEvent": ("cortex.ledger.models", "LedgerEvent"),
+    "LedgerOriginSignature": ("cortex.ledger.models", "LedgerOriginSignature"),
     "SemanticStatus": ("cortex.ledger.models", "SemanticStatus"),
     "LedgerStore": ("cortex.ledger.store", "LedgerStore"),
     "LedgerWriter": ("cortex.ledger.writer", "LedgerWriter"),
     "LedgerVerifier": ("cortex.ledger.verifier", "LedgerVerifier"),
     "EnrichmentQueue": ("cortex.ledger.queue", "EnrichmentQueue"),
+    "OriginKeyRecord": ("cortex.ledger.origin", "OriginKeyRecord"),
+    "OriginKeyRegistry": ("cortex.ledger.origin", "OriginKeyRegistry"),
+    "OriginSignatureError": ("cortex.ledger.origin", "OriginSignatureError"),
+    "OriginSignaturePolicy": ("cortex.ledger.origin", "OriginSignaturePolicy"),
+    "sign_event_origin": ("cortex.ledger.origin", "sign_event_origin"),
+    "verify_event_origin": ("cortex.ledger.origin", "verify_event_origin"),
     "ExportAuthority": ("cortex.ledger.public_export", "ExportAuthority"),
     "LedgerExportResult": ("cortex.ledger.public_export", "LedgerExportResult"),
     "public_key_record": ("cortex.ledger.public_export", "public_key_record"),

--- a/cortex/ledger/models.py
+++ b/cortex/ledger/models.py
@@ -51,6 +51,19 @@ class ActionResult:
 
 
 @dataclass(frozen=True)
+class LedgerOriginSignature:
+    actor_id: str
+    key_id: str
+    signature_alg: str
+    signed_at: str
+    nonce: str
+    signature: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class LedgerEvent:
     event_id: str
     ts: str
@@ -62,6 +75,7 @@ class LedgerEvent:
     intent: IntentPayload | None = None
     correlation_id: str | None = None
     trace_id: str | None = None
+    origin: LedgerOriginSignature | None = None
     prev_hash: str | None = None
     hash: str | None = None
     semantic_status: SemanticStatus = "pending"
@@ -126,6 +140,7 @@ class LedgerEvent:
             "intent": self.intent.to_dict() if self.intent else None,
             "correlation_id": self.correlation_id,
             "trace_id": self.trace_id,
+            "origin": self.origin.to_dict() if self.origin else None,
             "prev_hash": self.prev_hash,
             "hash": self.hash,
             "semantic_status": self.semantic_status,

--- a/cortex/ledger/origin.py
+++ b/cortex/ledger/origin.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import dataclasses
+import secrets
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from cortex.ledger.models import LedgerEvent, LedgerOriginSignature
+from cortex.utils.canonical import canonical_json
+
+
+class OriginSignatureError(ValueError):
+    """Raised when a ledger event fails origin-authenticity validation."""
+
+
+@dataclass(frozen=True)
+class OriginKeyRecord:
+    key_id: str
+    actor_id: str
+    public_key: Ed25519PublicKey
+    permissions: frozenset[str]
+    actor_type: str = "agent"
+    status: str = "active"
+    environment: str = "test"
+    valid_from: str | None = None
+    valid_until: str | None = None
+    hardware_backed: bool = False
+
+    @staticmethod
+    def from_public_key(
+        *,
+        key_id: str,
+        actor_id: str,
+        public_key: Ed25519PublicKey,
+        permissions: Sequence[str],
+        actor_type: str = "agent",
+        status: str = "active",
+        environment: str = "test",
+        valid_from: str | None = None,
+        valid_until: str | None = None,
+        hardware_backed: bool = False,
+    ) -> OriginKeyRecord:
+        return OriginKeyRecord(
+            key_id=key_id,
+            actor_id=actor_id,
+            public_key=public_key,
+            permissions=frozenset(permissions),
+            actor_type=actor_type,
+            status=status,
+            environment=environment,
+            valid_from=valid_from,
+            valid_until=valid_until,
+            hardware_backed=hardware_backed,
+        )
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "actor_id": self.actor_id,
+            "actor_type": self.actor_type,
+            "algorithm": "ed25519",
+            "environment": self.environment,
+            "hardware_backed": self.hardware_backed,
+            "key_id": self.key_id,
+            "permissions": sorted(self.permissions),
+            "public_key": _public_key_b64url(self.public_key),
+            "status": self.status,
+            "valid_from": self.valid_from,
+            "valid_until": self.valid_until,
+        }
+
+
+class OriginKeyRegistry:
+    def __init__(self, records: Sequence[OriginKeyRecord] = ()) -> None:
+        self._records: dict[str, OriginKeyRecord] = {}
+        for record in records:
+            self.add(record)
+
+    def add(self, record: OriginKeyRecord) -> None:
+        if record.key_id in self._records:
+            raise ValueError(f"duplicate origin key id: {record.key_id}")
+        self._records[record.key_id] = record
+
+    def get(self, key_id: str) -> OriginKeyRecord | None:
+        return self._records.get(key_id)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "keys": [
+                record.to_public_dict()
+                for record in sorted(self._records.values(), key=lambda item: item.key_id)
+            ],
+            "schema_version": "cortex-origin-key-registry-v1",
+        }
+
+
+@dataclass(frozen=True)
+class OriginSignaturePolicy:
+    registry: OriginKeyRegistry
+    strict: bool = True
+
+    @staticmethod
+    def strict_mode(registry: OriginKeyRegistry) -> OriginSignaturePolicy:
+        return OriginSignaturePolicy(registry=registry, strict=True)
+
+    def validate_event(self, event: LedgerEvent) -> None:
+        if not self.strict:
+            return
+        verify_event_origin(event, self.registry)
+
+
+def sign_event_origin(
+    event: LedgerEvent,
+    *,
+    key_id: str,
+    private_key: Ed25519PrivateKey,
+    signed_at: str | None = None,
+    nonce: str | None = None,
+) -> LedgerEvent:
+    """Attach an Ed25519 origin envelope to an event before ledger persistence."""
+    unsigned_origin = LedgerOriginSignature(
+        actor_id=event.actor,
+        key_id=key_id,
+        signature_alg="ed25519",
+        signed_at=signed_at or _utc_now(),
+        nonce=nonce or secrets.token_urlsafe(24),
+        signature=None,
+    )
+    unsigned_event = dataclasses.replace(event, origin=unsigned_origin)
+    signature = _b64url_encode(private_key.sign(origin_signature_scope(unsigned_event)))
+    signed_origin = dataclasses.replace(unsigned_origin, signature=signature)
+    return dataclasses.replace(unsigned_event, origin=signed_origin)
+
+
+def verify_event_origin(event: LedgerEvent, registry: OriginKeyRegistry) -> None:
+    origin = event.origin
+    if origin is None or not origin.signature:
+        raise OriginSignatureError("origin_signature_missing")
+    if origin.signature_alg != "ed25519":
+        raise OriginSignatureError(f"origin_signature_alg_unsupported:{origin.signature_alg}")
+    if origin.actor_id != event.actor:
+        raise OriginSignatureError("origin_actor_mismatch")
+
+    key = registry.get(origin.key_id)
+    if key is None:
+        raise OriginSignatureError(f"origin_key_missing:{origin.key_id}")
+    if key.status != "active":
+        raise OriginSignatureError(f"origin_key_not_active:{origin.key_id}")
+    if key.actor_id != origin.actor_id:
+        raise OriginSignatureError("origin_key_actor_mismatch")
+    if event.action not in key.permissions:
+        raise OriginSignatureError(f"origin_key_permission_denied:{event.action}")
+    _validate_key_time(key, origin.signed_at)
+
+    try:
+        key.public_key.verify(_b64url_decode(origin.signature), origin_signature_scope(event))
+    except (InvalidSignature, ValueError) as exc:
+        raise OriginSignatureError("origin_signature_invalid") from exc
+
+
+def origin_signature_scope(event: LedgerEvent) -> bytes:
+    payload = event.to_payload()
+    payload.pop("hash", None)
+    payload.pop("prev_hash", None)
+    origin = payload.get("origin")
+    if not isinstance(origin, dict):
+        raise OriginSignatureError("origin_signature_missing")
+    signature_scope = dict(origin)
+    signature_scope.pop("signature", None)
+    payload["origin"] = signature_scope
+    return canonical_json(payload).encode("utf-8")
+
+
+def _validate_key_time(key: OriginKeyRecord, signed_at: str) -> None:
+    signed = _parse_utc(signed_at)
+    if key.valid_from is not None and signed < _parse_utc(key.valid_from):
+        raise OriginSignatureError(f"origin_key_not_yet_valid:{key.key_id}")
+    if key.valid_until is not None and signed > _parse_utc(key.valid_until):
+        raise OriginSignatureError(f"origin_key_expired:{key.key_id}")
+
+
+def _parse_utc(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise OriginSignatureError("origin_timestamp_invalid") from exc
+    if parsed.tzinfo is None:
+        raise OriginSignatureError("origin_timestamp_missing_timezone")
+    return parsed
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(value: str) -> bytes:
+    if not value:
+        raise ValueError("empty_base64url")
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.b64decode((value + padding).encode("ascii"), altchars=b"-_", validate=True)
+    except (binascii.Error, UnicodeEncodeError) as exc:
+        raise ValueError("invalid_base64url") from exc
+
+
+def _public_key_b64url(public_key: Ed25519PublicKey) -> str:
+    return _b64url_encode(public_key.public_bytes(Encoding.Raw, PublicFormat.Raw))

--- a/cortex/ledger/public_export.py
+++ b/cortex/ledger/public_export.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from cortex.ledger.public_verifier import verify_export
+
+
+@dataclass(frozen=True)
+class ExportAuthority:
+    key_id: str
+    actor_id: str
+    private_key: Ed25519PrivateKey
+    environment: str = "test"
+
+
+@dataclass(frozen=True)
+class LedgerExportResult:
+    export_dir: Path
+    manifest_path: Path
+    events_path: Path
+    public_keys_path: Path
+    verification_report_path: Path | None
+    manifest_hash: str
+    verification_result: str | None
+
+
+def write_public_ledger_export(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    export_dir: str | Path,
+    public_keys: Sequence[Mapping[str, Any]],
+    export_authority: ExportAuthority,
+    export_id: str,
+    tenant_id: str,
+    stream_id: str,
+    purpose: str = "forensic_ledger_export",
+    environment: str = "test",
+    created_at: str | None = None,
+    include_verification_report: bool = False,
+) -> LedgerExportResult:
+    """Write a signed public ledger export package without exporting fact payloads."""
+    if not events:
+        raise ValueError("at least one ledger event is required")
+    root = Path(export_dir)
+    root.mkdir(parents=True, exist_ok=True)
+
+    event_objects = [dict(event) for event in events]
+    _validate_event_package_scope(event_objects, tenant_id=tenant_id, stream_id=stream_id)
+
+    events_path = root / "events.jsonl"
+    public_keys_path = root / "public-keys.json"
+    key_events_path = root / "key-events.jsonl"
+    schema_path = root / "schema.json"
+    verification_profile_path = root / "verification-profile.json"
+    manifest_path = root / "manifest.json"
+    verification_report_path = root / "verification-report.json"
+
+    _write_text_atomic(
+        events_path,
+        "".join(_canonical_json(event) + "\n" for event in event_objects),
+    )
+    _write_text_atomic(key_events_path, "")
+    _write_json_atomic(schema_path, _schema_document())
+    _write_json_atomic(verification_profile_path, _verification_profile_document())
+    _write_json_atomic(
+        public_keys_path,
+        _key_registry_document(
+            tenant_id=tenant_id,
+            public_keys=public_keys,
+            export_authority=export_authority,
+            generated_at=created_at or _utc_now(),
+        ),
+    )
+
+    manifest_without_signature = _manifest_document(
+        events=event_objects,
+        export_id=export_id,
+        tenant_id=tenant_id,
+        stream_id=stream_id,
+        created_by=export_authority.actor_id,
+        created_at=created_at or _utc_now(),
+        purpose=purpose,
+        environment=environment,
+        root=root,
+    )
+    manifest = dict(manifest_without_signature)
+    manifest["signature"] = {
+        "key_id": export_authority.key_id,
+        "signature_scope": "canonical_manifest_without_signature",
+        "value": _b64url_encode(
+            export_authority.private_key.sign(
+                _canonical_json(manifest_without_signature).encode("utf-8")
+            )
+        ),
+    }
+    _write_json_atomic(manifest_path, manifest)
+
+    verification_result: str | None = None
+    if include_verification_report:
+        report = verify_export(root)
+        verification_result = str(report["result"])
+        _write_json_atomic(verification_report_path, report)
+    else:
+        verification_report_path = None
+
+    return LedgerExportResult(
+        export_dir=root,
+        manifest_path=manifest_path,
+        events_path=events_path,
+        public_keys_path=public_keys_path,
+        verification_report_path=verification_report_path,
+        manifest_hash=_sha256_file(manifest_path),
+        verification_result=verification_result,
+    )
+
+
+def public_key_record(
+    *,
+    key_id: str,
+    actor_id: str,
+    public_key: Ed25519PublicKey,
+    permissions: Sequence[str],
+    actor_type: str = "agent",
+    environment: str = "test",
+    valid_from: str = "2026-01-01T00:00:00Z",
+    valid_until: str = "2027-01-01T00:00:00Z",
+    hardware_backed: bool = False,
+) -> dict[str, Any]:
+    """Build a public key registry record for exported ledger verification."""
+    return {
+        "actor_id": actor_id,
+        "actor_type": actor_type,
+        "algorithm": "ed25519",
+        "environment": environment,
+        "hardware_backed": hardware_backed,
+        "key_id": key_id,
+        "permissions": list(permissions),
+        "public_key": _public_key_b64url(public_key),
+        "status": "active",
+        "valid_from": valid_from,
+        "valid_until": valid_until,
+    }
+
+
+def _manifest_document(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    export_id: str,
+    tenant_id: str,
+    stream_id: str,
+    created_by: str,
+    created_at: str,
+    purpose: str,
+    environment: str,
+    root: Path,
+) -> dict[str, Any]:
+    hashes = [str(event["hash"]) for event in events]
+    first = events[0]
+    last = events[-1]
+    return {
+        "algorithms": {
+            "event_hash": "sha256",
+            "manifest_hash": "sha256",
+            "merkle": "merkle-profile-v1",
+            "signature": "ed25519",
+        },
+        "counts": {
+            "erasure_tombstone_count": 0,
+            "event_count": len(events),
+            "redacted_event_count": 0,
+        },
+        "created_at": created_at,
+        "created_by": created_by,
+        "environment": environment,
+        "export_id": export_id,
+        "hashes": {
+            "events_file_sha256": _sha256_file(root / "events.jsonl"),
+            "first_event_hash": hashes[0],
+            "key_events_file_sha256": _sha256_file(root / "key-events.jsonl"),
+            "last_event_hash": hashes[-1],
+            "merkle_root": _merkle_root_v1(hashes),
+            "public_keys_file_sha256": _sha256_file(root / "public-keys.json"),
+            "schema_file_sha256": _sha256_file(root / "schema.json"),
+            "verification_profile_sha256": _sha256_file(root / "verification-profile.json"),
+        },
+        "limitations": [],
+        "purpose": purpose,
+        "range": {
+            "first_recorded_at": first["recorded_at"],
+            "first_sequence": first["sequence"],
+            "last_recorded_at": last["recorded_at"],
+            "last_sequence": last["sequence"],
+        },
+        "schema_version": "cortex-forensic-export-manifest-v1",
+        "stream_id": stream_id,
+        "tenant_id": tenant_id,
+    }
+
+
+def _key_registry_document(
+    *,
+    tenant_id: str,
+    public_keys: Sequence[Mapping[str, Any]],
+    export_authority: ExportAuthority,
+    generated_at: str,
+) -> dict[str, Any]:
+    keys = [dict(key) for key in public_keys]
+    if not any(key.get("key_id") == export_authority.key_id for key in keys):
+        keys.append(
+            public_key_record(
+                key_id=export_authority.key_id,
+                actor_id=export_authority.actor_id,
+                actor_type="export_authority",
+                environment=export_authority.environment,
+                public_key=export_authority.private_key.public_key(),
+                permissions=["ledger.export"],
+            )
+        )
+    return {
+        "generated_at": generated_at,
+        "keys": sorted(keys, key=lambda key: str(key["key_id"])),
+        "schema_version": "cortex-key-registry-v1",
+        "tenant_id": tenant_id,
+    }
+
+
+def _schema_document() -> dict[str, str]:
+    return {"profile": "public-v1-strict", "schema_version": "cortex-ledger-event-schema-v1"}
+
+
+def _verification_profile_document() -> dict[str, str]:
+    return {
+        "canonicalization": "canonical-json-v1",
+        "merkle": "merkle-profile-v1",
+        "profile": "public-v1-strict",
+        "schema_version": "cortex-verification-profile-v1",
+    }
+
+
+def _validate_event_package_scope(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    tenant_id: str,
+    stream_id: str,
+) -> None:
+    previous_sequence: int | None = None
+    previous_hash = "GENESIS"
+    for event in events:
+        if event.get("tenant_id") != tenant_id:
+            raise ValueError(f"event tenant mismatch: {event.get('event_id')}")
+        if event.get("stream_id") != stream_id:
+            raise ValueError(f"event stream mismatch: {event.get('event_id')}")
+        detail = event.get("detail")
+        if isinstance(detail, Mapping) and any(
+            field in detail for field in ("content", "payload", "plaintext", "fact_content")
+        ):
+            raise ValueError(f"event contains inline fact payload: {event.get('event_id')}")
+        if event.get("prev_hash") != previous_hash:
+            raise ValueError(f"event chain break before export: {event.get('event_id')}")
+        sequence = event.get("sequence")
+        if not isinstance(sequence, int):
+            raise ValueError(f"event sequence invalid: {event.get('event_id')}")
+        if previous_sequence is not None and sequence != previous_sequence + 1:
+            raise ValueError(f"event sequence gap: {event.get('event_id')}")
+        previous_sequence = sequence
+        previous_hash = str(event.get("hash"))
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _write_json_atomic(path: Path, value: Mapping[str, Any]) -> None:
+    _write_text_atomic(path, _canonical_json(value))
+
+
+def _write_text_atomic(path: Path, value: str) -> None:
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(value, encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _public_key_b64url(public_key: Ed25519PublicKey) -> str:
+    return _b64url_encode(public_key.public_bytes(Encoding.Raw, PublicFormat.Raw))
+
+
+def _merkle_root_v1(event_hashes: Sequence[str]) -> str:
+    nodes = [
+        _sha256_bytes(("CORTEX-MERKLE-LEAF-v1:" + event_hash).encode("utf-8"))
+        for event_hash in event_hashes
+    ]
+    if not nodes:
+        return _sha256_bytes(b"CORTEX-MERKLE-EMPTY-v1")
+
+    while len(nodes) > 1:
+        next_nodes: list[str] = []
+        for index in range(0, len(nodes), 2):
+            left = nodes[index]
+            right = nodes[index + 1] if index + 1 < len(nodes) else None
+            if right is None:
+                next_nodes.append(left)
+            else:
+                next_nodes.append(
+                    _sha256_bytes(("CORTEX-MERKLE-NODE-v1:" + left + right).encode("utf-8"))
+                )
+        nodes = next_nodes
+    return nodes[0]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/cortex/ledger/verifier.py
+++ b/cortex/ledger/verifier.py
@@ -4,7 +4,13 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from cortex.ledger.models import ActionResult, ActionTarget, IntentPayload, LedgerEvent
+from cortex.ledger.models import (
+    ActionResult,
+    ActionTarget,
+    IntentPayload,
+    LedgerEvent,
+    LedgerOriginSignature,
+)
 from cortex.ledger.store import LedgerStore
 
 if TYPE_CHECKING:
@@ -139,6 +145,11 @@ class LedgerVerifier:
         target = ActionTarget(**payload["target"])
         result = ActionResult(**payload["result"])
         intent = IntentPayload(**payload["intent"]) if payload.get("intent") else None
+        origin = (
+            LedgerOriginSignature(**payload["origin"])
+            if isinstance(payload.get("origin"), dict)
+            else None
+        )
 
         return LedgerEvent(
             event_id=payload["event_id"],
@@ -151,6 +162,7 @@ class LedgerVerifier:
             intent=intent,
             correlation_id=payload.get("correlation_id"),
             trace_id=payload.get("trace_id"),
+            origin=origin,
             prev_hash=payload.get("prev_hash"),
             hash=payload.get("hash"),
             semantic_status=payload.get("semantic_status", "pending"),

--- a/cortex/ledger/writer.py
+++ b/cortex/ledger/writer.py
@@ -1,16 +1,26 @@
 import dataclasses
 
 from cortex.ledger.models import LedgerEvent
+from cortex.ledger.origin import OriginSignaturePolicy
 from cortex.ledger.queue import EnrichmentQueue
 from cortex.ledger.store import LedgerStore
 
 
 class LedgerWriter:
-    def __init__(self, store: LedgerStore, queue: EnrichmentQueue) -> None:
+    def __init__(
+        self,
+        store: LedgerStore,
+        queue: EnrichmentQueue,
+        origin_policy: OriginSignaturePolicy | None = None,
+    ) -> None:
         self.store = store
         self.queue = queue
+        self.origin_policy = origin_policy
 
     def append(self, event: LedgerEvent) -> str:
+        if self.origin_policy is not None:
+            self.origin_policy.validate_event(event)
+
         with self.store.tx() as conn:
             # 1. Get last hash
             cursor = conn.execute("SELECT hash FROM ledger_events ORDER BY rowid DESC LIMIT 1")

--- a/docs/compliance/ORIGIN_SIGNATURE_STRICT_MODE.md
+++ b/docs/compliance/ORIGIN_SIGNATURE_STRICT_MODE.md
@@ -1,0 +1,66 @@
+# Origin Signature Strict Mode
+
+Status: draft
+
+M4 adds a runtime origin-authenticity gate for ledger events. The gate is
+opt-in at `LedgerWriter` construction so existing legacy ledger writes continue
+to run until a deployer explicitly enables strict mode for an agent write path.
+
+## Runtime Contract
+
+Strict mode validates a `LedgerEvent` before opening the SQLite transaction.
+If validation fails, no `ledger_events` row is inserted and no enrichment job is
+created.
+
+The event must carry an `origin` envelope:
+
+- `actor_id`: actor that produced the event.
+- `key_id`: registry key used to verify the event.
+- `signature_alg`: currently `ed25519`.
+- `signed_at`: timezone-aware timestamp.
+- `nonce`: origin-generated uniqueness token.
+- `signature`: base64url Ed25519 signature.
+
+## Signature Scope
+
+The signed payload is:
+
+```text
+canonical_json(event payload without hash and prev_hash, and with origin.signature removed)
+```
+
+The runtime hash-chain still commits the complete event payload after the
+origin signature is attached. This means the ledger hash commits the signature,
+and the origin signature commits the pre-persistence event intent.
+
+## Key Registry
+
+`OriginKeyRegistry` is an in-process registry of `OriginKeyRecord` entries.
+Each record binds:
+
+- `key_id`
+- `actor_id`
+- Ed25519 public key
+- allowed actions
+- key status
+- optional validity window
+- optional hardware-backed flag
+
+Strict mode rejects:
+
+- missing origin envelope;
+- unsupported signature algorithm;
+- actor/key mismatch;
+- missing, inactive, not-yet-valid, or expired key;
+- action not present in key permissions;
+- invalid signature over the canonical scope.
+
+## Current Limitations
+
+M4 does not add durable key-registry storage, replay tables, freshness windows,
+or nonce reservation. Those are M5 responsibilities.
+
+M4 also does not assert that event content is true. It distinguishes origin
+authenticity from content truth: a valid key can still sign false content, and
+that must be handled by guard validation, review workflows, and downstream
+forensic analysis.

--- a/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
+++ b/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
@@ -1,0 +1,98 @@
+# Public Ledger Export Package
+
+Status: draft
+
+This document defines the forensic ledger export package produced for
+independent offline verification. The package is evidence packaging only: it
+does not enforce runtime origin signing, authorize agent actions, or export fact
+payloads. Runtime rejection of unsigned or badly signed origin events belongs to
+M4.
+
+## Required Artifacts
+
+An export directory contains:
+
+- `events.jsonl`: canonical JSON Lines ledger events.
+- `manifest.json`: signed export manifest over package artifacts and event
+  range.
+- `public-keys.json`: actor and export-authority public key registry.
+- `key-events.jsonl`: reserved key lifecycle event stream.
+- `schema.json`: event schema/profile descriptor.
+- `verification-profile.json`: canonicalization, hash, signature, and Merkle
+  profile descriptor.
+
+When requested, the exporter also writes:
+
+- `verification-report.json`: deterministic output from the offline verifier.
+
+The package must not contain `facts.jsonl` or plaintext fact payload files.
+Fact export is a separate product surface with separate retention, redaction,
+and erasure controls.
+
+## Manifest Scope
+
+`manifest.json` includes:
+
+- export identity, tenant, stream, purpose, environment, creator, and creation
+  time;
+- event count and sequence/time range;
+- SHA-256 hashes of `events.jsonl`, `public-keys.json`, `key-events.jsonl`,
+  `schema.json`, and `verification-profile.json`;
+- first and last event hash;
+- `merkle-profile-v1` root over event hashes;
+- Ed25519 signature by an export authority key.
+
+The manifest signature scope is:
+
+```text
+Ed25519.sign(export_authority_private_key, canonical_json(manifest without signature))
+```
+
+## Event Payload Boundary
+
+The public ledger export may include references to encrypted or externally
+controlled fact material, for example `payload_ref` or `subject_ref`.
+
+The export builder rejects common inline fact payload keys inside event
+`detail`:
+
+- `content`
+- `payload`
+- `plaintext`
+- `fact_content`
+
+This is a guardrail for forensic packaging, not a complete PII detector. M6 is
+the enforcement milestone for immutable-ledger no-PII policy.
+
+## Guarantee Split
+
+If the optional verifier report is generated, it must preserve the offline
+guarantee split:
+
+- `integrity_verified`
+- `origin_authenticity_verified`
+- `authority_verified`
+- `replay_consistency_verified`
+- `temporal_consistency_verified`
+- `online_freshness_verified`
+- `completeness_verified`
+- `truth_verified`
+
+For offline exports, `online_freshness_verified` remains false. The verifier
+does not assert that event contents are true; `truth_verified` remains false by
+default.
+
+## Current Limitations
+
+M3 assumes events already carry `public-v1-strict` fields, including
+`origin_signature`, `actor_key_id`, `nonce`, and hash-chain continuity.
+
+M3 does not:
+
+- sign ledger events on behalf of actors;
+- reject unsigned runtime writes before persistence;
+- create actor-key authorization policy;
+- prove that a source database contains no omitted events;
+- export plaintext facts or reconstruct fact contents.
+
+Those controls belong to later milestones, especially M4 and M5.

--- a/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
+++ b/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
@@ -6,7 +6,8 @@ This document defines the forensic ledger export package produced for
 independent offline verification. The package is evidence packaging only: it
 does not enforce runtime origin signing, authorize agent actions, or export fact
 payloads. Runtime rejection of unsigned or badly signed origin events belongs to
-M4.
+M4. The runtime strict-mode contract is documented in
+[`ORIGIN_SIGNATURE_STRICT_MODE.md`](ORIGIN_SIGNATURE_STRICT_MODE.md).
 
 ## Required Artifacts
 
@@ -86,6 +87,11 @@ default.
 
 M3 assumes events already carry `public-v1-strict` fields, including
 `origin_signature`, `actor_key_id`, `nonce`, and hash-chain continuity.
+
+M4 adds a separate runtime `LedgerEvent.origin` envelope for pre-persistence
+origin-authenticity validation. A later adapter may map that runtime envelope
+into the public export event fields, but this package specification does not
+claim that bridge as automatic.
 
 M3 does not:
 

--- a/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
+++ b/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
@@ -6,6 +6,9 @@ This document defines the minimum contract for an offline public verifier for
 CORTEX ledger exports. The verifier must validate exported bytes without
 accessing SQLite, network services, or a running CORTEX process.
 
+The matching package layout is documented in
+[`PUBLIC_LEDGER_EXPORT_PACKAGE.md`](PUBLIC_LEDGER_EXPORT_PACKAGE.md).
+
 ## Profiles
 
 - `legacy-v0`: verifies the current transaction hash shape for legacy data. It

--- a/tests/test_ledger_origin_signatures.py
+++ b/tests/test_ledger_origin_signatures.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.ledger.models import ActionResult, ActionTarget, LedgerEvent
+from cortex.ledger.origin import (
+    OriginKeyRecord,
+    OriginKeyRegistry,
+    OriginSignatureError,
+    OriginSignaturePolicy,
+    sign_event_origin,
+    verify_event_origin,
+)
+from cortex.ledger.queue import EnrichmentQueue
+from cortex.ledger.store import LedgerStore
+from cortex.ledger.verifier import LedgerVerifier
+from cortex.ledger.writer import LedgerWriter
+
+ACTOR_ID = "agent-risk-01"
+KEY_ID = "ed25519:agent-risk-01:runtime-001"
+SIGNED_AT = "2026-02-03T10:15:30Z"
+NONCE = "nonce_01HXORIGIN000000000000001"
+
+
+def test_strict_origin_policy_accepts_signed_authorized_event(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+
+    event_id = writer.append(event)
+
+    with store.tx() as conn:
+        row = conn.execute(
+            "SELECT payload_json FROM ledger_events WHERE event_id = ?",
+            (event_id,),
+        ).fetchone()
+    assert row is not None
+    payload = json.loads(row["payload_json"])
+    assert payload["origin"]["key_id"] == KEY_ID
+    assert payload["origin"]["signature_alg"] == "ed25519"
+    assert payload["origin"]["nonce"] == NONCE
+    assert LedgerVerifier(store).verify_chain()["valid"] is True
+
+
+def test_strict_origin_policy_rejects_unsigned_event_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+
+    with pytest.raises(OriginSignatureError, match="origin_signature_missing"):
+        writer.append(_event())
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_tampered_event_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+    signed = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+    tampered = dataclasses.replace(signed, target=ActionTarget(app="Tampered"))
+
+    with pytest.raises(OriginSignatureError, match="origin_signature_invalid"):
+        writer.append(tampered)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_permission_denied_before_persistence(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.read"],
+            )
+        ]
+    )
+    store = LedgerStore(tmp_path / "ledger.db")
+    writer = LedgerWriter(
+        store,
+        EnrichmentQueue(store),
+        origin_policy=OriginSignaturePolicy.strict_mode(registry),
+    )
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+
+    with pytest.raises(OriginSignatureError, match="origin_key_permission_denied"):
+        writer.append(event)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_origin_signature_scope_verifies_independently() -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ]
+    )
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+
+    verify_event_origin(event, registry)
+
+
+def _strict_writer(
+    tmp_path: Path,
+    private_key: Ed25519PrivateKey,
+) -> tuple[LedgerStore, LedgerWriter]:
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ]
+    )
+    store = LedgerStore(tmp_path / "ledger.db")
+    return (
+        store,
+        LedgerWriter(
+            store,
+            EnrichmentQueue(store),
+            origin_policy=OriginSignaturePolicy.strict_mode(registry),
+        ),
+    )
+
+
+def _event() -> LedgerEvent:
+    return LedgerEvent.new(
+        tool="agent-runtime",
+        actor=ACTOR_ID,
+        action="fact.store",
+        target=ActionTarget(app="CORTEX", identifier="fact:001"),
+        result=ActionResult(ok=True, latency_ms=12, verified=True),
+        metadata={"project": "cortex-persist", "tenant_id": "tenant-acme"},
+    )
+
+
+def _row_count(store: LedgerStore, table_name: str) -> int:
+    if table_name not in {"ledger_events", "enrichment_jobs"}:
+        raise ValueError(f"unsupported table: {table_name}")
+    with store.tx() as conn:
+        row = conn.execute(f"SELECT COUNT(*) AS count FROM {table_name}").fetchone()
+    return int(row["count"])

--- a/tests/test_public_ledger_export.py
+++ b/tests/test_public_ledger_export.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.ledger.public_export import (
+    ExportAuthority,
+    public_key_record,
+    write_public_ledger_export,
+)
+from cortex.ledger.public_verifier import verify_export
+
+TENANT_ID = "tenant-acme"
+STREAM_ID = "tenant:acme:ledger:primary"
+ACTOR_ID = "agent-risk-01"
+ACTOR_KEY_ID = "ed25519:agent-risk-01:test-export-001"
+EXPORT_KEY_ID = "ed25519:export-authority:test-export-001"
+CREATED_AT = "2026-02-03T10:15:30Z"
+
+
+def test_write_public_ledger_export_package_with_verification_report(tmp_path: Path) -> None:
+    actor_private_key = Ed25519PrivateKey.generate()
+    export_private_key = Ed25519PrivateKey.generate()
+    event = _signed_event(actor_private_key)
+    export_dir = tmp_path / "forensic-export"
+
+    result = write_public_ledger_export(
+        events=[event],
+        export_dir=export_dir,
+        public_keys=[
+            public_key_record(
+                key_id=ACTOR_KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=actor_private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ],
+        export_authority=ExportAuthority(
+            key_id=EXPORT_KEY_ID,
+            actor_id="export-authority-01",
+            private_key=export_private_key,
+        ),
+        export_id="export-2026-02-03-001",
+        tenant_id=TENANT_ID,
+        stream_id=STREAM_ID,
+        created_at=CREATED_AT,
+        include_verification_report=True,
+    )
+
+    expected_files = {
+        "events.jsonl",
+        "key-events.jsonl",
+        "manifest.json",
+        "public-keys.json",
+        "schema.json",
+        "verification-profile.json",
+        "verification-report.json",
+    }
+    assert expected_files <= {path.name for path in export_dir.iterdir()}
+    assert not (export_dir / "facts.jsonl").exists()
+    assert result.verification_report_path == export_dir / "verification-report.json"
+    assert result.verification_result == "VALID_FULL_STRICT"
+    assert result.manifest_hash == _sha256_file(export_dir / "manifest.json")
+
+    report = verify_export(export_dir)
+    assert report["result"] == "VALID_FULL_STRICT"
+    assert report["guarantees"]["integrity_verified"] is True
+    assert report["guarantees"]["origin_authenticity_verified"] is True
+    assert report["guarantees"]["authority_verified"] is True
+    assert report["guarantees"]["completeness_verified"] is True
+    assert report["guarantees"]["truth_verified"] is False
+    assert report == _load_json(export_dir / "verification-report.json")
+
+    manifest = _load_json(export_dir / "manifest.json")
+    public_keys = _load_json(export_dir / "public-keys.json")
+    assert manifest["signature"]["key_id"] == EXPORT_KEY_ID
+    assert manifest["hashes"]["events_file_sha256"] == _sha256_file(export_dir / "events.jsonl")
+    assert manifest["hashes"]["public_keys_file_sha256"] == _sha256_file(
+        export_dir / "public-keys.json"
+    )
+    assert {key["key_id"] for key in public_keys["keys"]} == {ACTOR_KEY_ID, EXPORT_KEY_ID}
+    assert manifest["counts"]["event_count"] == 1
+    assert manifest["range"]["first_sequence"] == 1
+    assert manifest["range"]["last_sequence"] == 1
+
+
+def test_write_public_ledger_export_rejects_inline_fact_payload(tmp_path: Path) -> None:
+    actor_private_key = Ed25519PrivateKey.generate()
+    export_private_key = Ed25519PrivateKey.generate()
+    event = _signed_event(actor_private_key)
+    event["detail"] = dict(event["detail"])
+    event["detail"]["payload"] = "plaintext fact body"
+
+    with pytest.raises(ValueError, match="inline fact payload"):
+        write_public_ledger_export(
+            events=[event],
+            export_dir=tmp_path / "forensic-export",
+            public_keys=[
+                public_key_record(
+                    key_id=ACTOR_KEY_ID,
+                    actor_id=ACTOR_ID,
+                    public_key=actor_private_key.public_key(),
+                    permissions=["fact.store"],
+                )
+            ],
+            export_authority=ExportAuthority(
+                key_id=EXPORT_KEY_ID,
+                actor_id="export-authority-01",
+                private_key=export_private_key,
+            ),
+            export_id="export-2026-02-03-001",
+            tenant_id=TENANT_ID,
+            stream_id=STREAM_ID,
+            created_at=CREATED_AT,
+        )
+
+
+def _signed_event(private_key: Ed25519PrivateKey) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "action": "fact.store",
+        "actor_id": ACTOR_ID,
+        "actor_key_id": ACTOR_KEY_ID,
+        "detail": {
+            "fact_type": "risk_signal",
+            "payload_ref": "facts/tenant-acme/fact-001.enc.json",
+            "subject_ref": "subject:hmac-sha256:01HX",
+        },
+        "event_id": "evt_01HXEXPORT0000000000000001",
+        "hash_alg": "sha256",
+        "issued_at": CREATED_AT,
+        "nonce": "nonce_01HXEXPORT0000000000000001",
+        "prev_hash": "GENESIS",
+        "project": "cortex-persist",
+        "recorded_at": CREATED_AT,
+        "schema_version": "cortex-ledger-event-v1",
+        "sequence": 1,
+        "signature_alg": "ed25519",
+        "stream_id": STREAM_ID,
+        "target": "fact:001",
+        "tenant_id": TENANT_ID,
+    }
+    event["hash"] = _event_hash(event)
+    event["origin_signature"] = _b64url_encode(
+        private_key.sign(_canonical_json(event).encode("utf-8"))
+    )
+    return event
+
+
+def _event_hash(event: dict[str, Any]) -> str:
+    scope = dict(event)
+    scope.pop("hash", None)
+    scope.pop("origin_signature", None)
+    return hashlib.sha256(_canonical_json(scope).encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value


### PR DESCRIPTION
Closes #281.\n\n## Scope\n- Adds a public forensic ledger export builder for already-signed public-v1-strict events.\n- Writes events.jsonl, signed manifest.json, public-keys.json, key-events.jsonl, schema/profile files, and optional verification-report.json.\n- Keeps fact export separate and rejects common inline fact payload keys in event detail.\n- Documents the package contract and the M3/M4 boundary: this PR does not enforce runtime origin signatures.\n\n## Validation\n- pytest tests/test_public_ledger_export.py tests/test_public_ledger_verifier.py tests/test_public_ledger_verifier_vectors.py -v\n- ruff check cortex/ledger/public_export.py cortex/ledger/__init__.py tests/test_public_ledger_export.py\n- ruff format --check cortex/ledger/public_export.py cortex/ledger/__init__.py tests/test_public_ledger_export.py\n- pyright cortex/ledger/public_export.py tests/test_public_ledger_export.py\n\n## Stacking\nThis is PR-3 and is intentionally stacked on PR-2 (codex/offline-ledger-verifier).