### PR TITLE
feat: enforce strict ledger origin signatures

### DIFF
--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -7,7 +7,15 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cortex.ledger.ledger_core import SovereignLedger
-    from cortex.ledger.models import LedgerEvent, SemanticStatus
+    from cortex.ledger.models import LedgerEvent, LedgerOriginSignature, SemanticStatus
+    from cortex.ledger.origin import (
+        OriginKeyRecord,
+        OriginKeyRegistry,
+        OriginSignatureError,
+        OriginSignaturePolicy,
+        sign_event_origin,
+        verify_event_origin,
+    )
     from cortex.ledger.public_export import (
         ExportAuthority,
         LedgerExportResult,
@@ -22,6 +30,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "LedgerEvent",
+    "LedgerOriginSignature",
     "SemanticStatus",
     "SovereignLedger",
     "ImmutableLedger",
@@ -31,18 +40,31 @@ __all__ = [
     "EnrichmentQueue",
     "ExportAuthority",
     "LedgerExportResult",
+    "OriginKeyRecord",
+    "OriginKeyRegistry",
+    "OriginSignatureError",
+    "OriginSignaturePolicy",
     "public_key_record",
+    "sign_event_origin",
     "write_public_ledger_export",
+    "verify_event_origin",
     "verify_export",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LedgerEvent": ("cortex.ledger.models", "LedgerEvent"),
+    "LedgerOriginSignature": ("cortex.ledger.models", "LedgerOriginSignature"),
     "SemanticStatus": ("cortex.ledger.models", "SemanticStatus"),
     "LedgerStore": ("cortex.ledger.store", "LedgerStore"),
     "LedgerWriter": ("cortex.ledger.writer", "LedgerWriter"),
     "LedgerVerifier": ("cortex.ledger.verifier", "LedgerVerifier"),
     "EnrichmentQueue": ("cortex.ledger.queue", "EnrichmentQueue"),
+    "OriginKeyRecord": ("cortex.ledger.origin", "OriginKeyRecord"),
+    "OriginKeyRegistry": ("cortex.ledger.origin", "OriginKeyRegistry"),
+    "OriginSignatureError": ("cortex.ledger.origin", "OriginSignatureError"),
+    "OriginSignaturePolicy": ("cortex.ledger.origin", "OriginSignaturePolicy"),
+    "sign_event_origin": ("cortex.ledger.origin", "sign_event_origin"),
+    "verify_event_origin": ("cortex.ledger.origin", "verify_event_origin"),
     "ExportAuthority": ("cortex.ledger.public_export", "ExportAuthority"),
     "LedgerExportResult": ("cortex.ledger.public_export", "LedgerExportResult"),
     "public_key_record": ("cortex.ledger.public_export", "public_key_record"),

--- a/cortex/ledger/models.py
+++ b/cortex/ledger/models.py
@@ -51,6 +51,19 @@ class ActionResult:
 
 
 @dataclass(frozen=True)
+class LedgerOriginSignature:
+    actor_id: str
+    key_id: str
+    signature_alg: str
+    signed_at: str
+    nonce: str
+    signature: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class LedgerEvent:
     event_id: str
     ts: str
@@ -62,6 +75,7 @@ class LedgerEvent:
     intent: IntentPayload | None = None
     correlation_id: str | None = None
     trace_id: str | None = None
+    origin: LedgerOriginSignature | None = None
     prev_hash: str | None = None
     hash: str | None = None
     semantic_status: SemanticStatus = "pending"
@@ -126,6 +140,7 @@ class LedgerEvent:
             "intent": self.intent.to_dict() if self.intent else None,
             "correlation_id": self.correlation_id,
             "trace_id": self.trace_id,
+            "origin": self.origin.to_dict() if self.origin else None,
             "prev_hash": self.prev_hash,
             "hash": self.hash,
             "semantic_status": self.semantic_status,

--- a/cortex/ledger/origin.py
+++ b/cortex/ledger/origin.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import dataclasses
+import secrets
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from cortex.ledger.models import LedgerEvent, LedgerOriginSignature
+from cortex.utils.canonical import canonical_json
+
+
+class OriginSignatureError(ValueError):
+    """Raised when a ledger event fails origin-authenticity validation."""
+
+
+@dataclass(frozen=True)
+class OriginKeyRecord:
+    key_id: str
+    actor_id: str
+    public_key: Ed25519PublicKey
+    permissions: frozenset[str]
+    actor_type: str = "agent"
+    status: str = "active"
+    environment: str = "test"
+    valid_from: str | None = None
+    valid_until: str | None = None
+    hardware_backed: bool = False
+
+    @staticmethod
+    def from_public_key(
+        *,
+        key_id: str,
+        actor_id: str,
+        public_key: Ed25519PublicKey,
+        permissions: Sequence[str],
+        actor_type: str = "agent",
+        status: str = "active",
+        environment: str = "test",
+        valid_from: str | None = None,
+        valid_until: str | None = None,
+        hardware_backed: bool = False,
+    ) -> OriginKeyRecord:
+        return OriginKeyRecord(
+            key_id=key_id,
+            actor_id=actor_id,
+            public_key=public_key,
+            permissions=frozenset(permissions),
+            actor_type=actor_type,
+            status=status,
+            environment=environment,
+            valid_from=valid_from,
+            valid_until=valid_until,
+            hardware_backed=hardware_backed,
+        )
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "actor_id": self.actor_id,
+            "actor_type": self.actor_type,
+            "algorithm": "ed25519",
+            "environment": self.environment,
+            "hardware_backed": self.hardware_backed,
+            "key_id": self.key_id,
+            "permissions": sorted(self.permissions),
+            "public_key": _public_key_b64url(self.public_key),
+            "status": self.status,
+            "valid_from": self.valid_from,
+            "valid_until": self.valid_until,
+        }
+
+
+class OriginKeyRegistry:
+    def __init__(self, records: Sequence[OriginKeyRecord] = ()) -> None:
+        self._records: dict[str, OriginKeyRecord] = {}
+        for record in records:
+            self.add(record)
+
+    def add(self, record: OriginKeyRecord) -> None:
+        if record.key_id in self._records:
+            raise ValueError(f"duplicate origin key id: {record.key_id}")
+        self._records[record.key_id] = record
+
+    def get(self, key_id: str) -> OriginKeyRecord | None:
+        return self._records.get(key_id)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "keys": [
+                record.to_public_dict()
+                for record in sorted(self._records.values(), key=lambda item: item.key_id)
+            ],
+            "schema_version": "cortex-origin-key-registry-v1",
+        }
+
+
+@dataclass(frozen=True)
+class OriginSignaturePolicy:
+    registry: OriginKeyRegistry
+    strict: bool = True
+
+    @staticmethod
+    def strict_mode(registry: OriginKeyRegistry) -> OriginSignaturePolicy:
+        return OriginSignaturePolicy(registry=registry, strict=True)
+
+    def validate_event(self, event: LedgerEvent) -> None:
+        if not self.strict:
+            return
+        verify_event_origin(event, self.registry)
+
+
+def sign_event_origin(
+    event: LedgerEvent,
+    *,
+    key_id: str,
+    private_key: Ed25519PrivateKey,
+    signed_at: str | None = None,
+    nonce: str | None = None,
+) -> LedgerEvent:
+    """Attach an Ed25519 origin envelope to an event before ledger persistence."""
+    unsigned_origin = LedgerOriginSignature(
+        actor_id=event.actor,
+        key_id=key_id,
+        signature_alg="ed25519",
+        signed_at=signed_at or _utc_now(),
+        nonce=nonce or secrets.token_urlsafe(24),
+        signature=None,
+    )
+    unsigned_event = dataclasses.replace(event, origin=unsigned_origin)
+    signature = _b64url_encode(private_key.sign(origin_signature_scope(unsigned_event)))
+    signed_origin = dataclasses.replace(unsigned_origin, signature=signature)
+    return dataclasses.replace(unsigned_event, origin=signed_origin)
+
+
+def verify_event_origin(event: LedgerEvent, registry: OriginKeyRegistry) -> None:
+    origin = event.origin
+    if origin is None or not origin.signature:
+        raise OriginSignatureError("origin_signature_missing")
+    if origin.signature_alg != "ed25519":
+        raise OriginSignatureError(f"origin_signature_alg_unsupported:{origin.signature_alg}")
+    if origin.actor_id != event.actor:
+        raise OriginSignatureError("origin_actor_mismatch")
+
+    key = registry.get(origin.key_id)
+    if key is None:
+        raise OriginSignatureError(f"origin_key_missing:{origin.key_id}")
+    if key.status != "active":
+        raise OriginSignatureError(f"origin_key_not_active:{origin.key_id}")
+    if key.actor_id != origin.actor_id:
+        raise OriginSignatureError("origin_key_actor_mismatch")
+    if event.action not in key.permissions:
+        raise OriginSignatureError(f"origin_key_permission_denied:{event.action}")
+    _validate_key_time(key, origin.signed_at)
+
+    try:
+        key.public_key.verify(_b64url_decode(origin.signature), origin_signature_scope(event))
+    except (InvalidSignature, ValueError) as exc:
+        raise OriginSignatureError("origin_signature_invalid") from exc
+
+
+def origin_signature_scope(event: LedgerEvent) -> bytes:
+    payload = event.to_payload()
+    payload.pop("hash", None)
+    payload.pop("prev_hash", None)
+    origin = payload.get("origin")
+    if not isinstance(origin, dict):
+        raise OriginSignatureError("origin_signature_missing")
+    signature_scope = dict(origin)
+    signature_scope.pop("signature", None)
+    payload["origin"] = signature_scope
+    return canonical_json(payload).encode("utf-8")
+
+
+def _validate_key_time(key: OriginKeyRecord, signed_at: str) -> None:
+    signed = _parse_utc(signed_at)
+    if key.valid_from is not None and signed < _parse_utc(key.valid_from):
+        raise OriginSignatureError(f"origin_key_not_yet_valid:{key.key_id}")
+    if key.valid_until is not None and signed > _parse_utc(key.valid_until):
+        raise OriginSignatureError(f"origin_key_expired:{key.key_id}")
+
+
+def _parse_utc(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise OriginSignatureError("origin_timestamp_invalid") from exc
+    if parsed.tzinfo is None:
+        raise OriginSignatureError("origin_timestamp_missing_timezone")
+    return parsed
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(value: str) -> bytes:
+    if not value:
+        raise ValueError("empty_base64url")
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.b64decode((value + padding).encode("ascii"), altchars=b"-_", validate=True)
+    except (binascii.Error, UnicodeEncodeError) as exc:
+        raise ValueError("invalid_base64url") from exc
+
+
+def _public_key_b64url(public_key: Ed25519PublicKey) -> str:
+    return _b64url_encode(public_key.public_bytes(Encoding.Raw, PublicFormat.Raw))

--- a/cortex/ledger/verifier.py
+++ b/cortex/ledger/verifier.py
@@ -4,7 +4,13 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from cortex.ledger.models import ActionResult, ActionTarget, IntentPayload, LedgerEvent
+from cortex.ledger.models import (
+    ActionResult,
+    ActionTarget,
+    IntentPayload,
+    LedgerEvent,
+    LedgerOriginSignature,
+)
 from cortex.ledger.store import LedgerStore
 
 if TYPE_CHECKING:
@@ -139,6 +145,11 @@ class LedgerVerifier:
         target = ActionTarget(**payload["target"])
         result = ActionResult(**payload["result"])
         intent = IntentPayload(**payload["intent"]) if payload.get("intent") else None
+        origin = (
+            LedgerOriginSignature(**payload["origin"])
+            if isinstance(payload.get("origin"), dict)
+            else None
+        )
 
         return LedgerEvent(
             event_id=payload["event_id"],
@@ -151,6 +162,7 @@ class LedgerVerifier:
             intent=intent,
             correlation_id=payload.get("correlation_id"),
             trace_id=payload.get("trace_id"),
+            origin=origin,
             prev_hash=payload.get("prev_hash"),
             hash=payload.get("hash"),
             semantic_status=payload.get("semantic_status", "pending"),

--- a/cortex/ledger/writer.py
+++ b/cortex/ledger/writer.py
@@ -1,16 +1,26 @@
 import dataclasses
 
 from cortex.ledger.models import LedgerEvent
+from cortex.ledger.origin import OriginSignaturePolicy
 from cortex.ledger.queue import EnrichmentQueue
 from cortex.ledger.store import LedgerStore
 
 
 class LedgerWriter:
-    def __init__(self, store: LedgerStore, queue: EnrichmentQueue) -> None:
+    def __init__(
+        self,
+        store: LedgerStore,
+        queue: EnrichmentQueue,
+        origin_policy: OriginSignaturePolicy | None = None,
+    ) -> None:
         self.store = store
         self.queue = queue
+        self.origin_policy = origin_policy
 
     def append(self, event: LedgerEvent) -> str:
+        if self.origin_policy is not None:
+            self.origin_policy.validate_event(event)
+
         with self.store.tx() as conn:
             # 1. Get last hash
             cursor = conn.execute("SELECT hash FROM ledger_events ORDER BY rowid DESC LIMIT 1")

--- a/docs/compliance/ORIGIN_SIGNATURE_STRICT_MODE.md
+++ b/docs/compliance/ORIGIN_SIGNATURE_STRICT_MODE.md
@@ -1,0 +1,66 @@
+# Origin Signature Strict Mode
+
+Status: draft
+
+M4 adds a runtime origin-authenticity gate for ledger events. The gate is
+opt-in at `LedgerWriter` construction so existing legacy ledger writes continue
+to run until a deployer explicitly enables strict mode for an agent write path.
+
+## Runtime Contract
+
+Strict mode validates a `LedgerEvent` before opening the SQLite transaction.
+If validation fails, no `ledger_events` row is inserted and no enrichment job is
+created.
+
+The event must carry an `origin` envelope:
+
+- `actor_id`: actor that produced the event.
+- `key_id`: registry key used to verify the event.
+- `signature_alg`: currently `ed25519`.
+- `signed_at`: timezone-aware timestamp.
+- `nonce`: origin-generated uniqueness token.
+- `signature`: base64url Ed25519 signature.
+
+## Signature Scope
+
+The signed payload is:
+
+```text
+canonical_json(event payload without hash and prev_hash, and with origin.signature removed)
+```
+
+The runtime hash-chain still commits the complete event payload after the
+origin signature is attached. This means the ledger hash commits the signature,
+and the origin signature commits the pre-persistence event intent.
+
+## Key Registry
+
+`OriginKeyRegistry` is an in-process registry of `OriginKeyRecord` entries.
+Each record binds:
+
+- `key_id`
+- `actor_id`
+- Ed25519 public key
+- allowed actions
+- key status
+- optional validity window
+- optional hardware-backed flag
+
+Strict mode rejects:
+
+- missing origin envelope;
+- unsupported signature algorithm;
+- actor/key mismatch;
+- missing, inactive, not-yet-valid, or expired key;
+- action not present in key permissions;
+- invalid signature over the canonical scope.
+
+## Current Limitations
+
+M4 does not add durable key-registry storage, replay tables, freshness windows,
+or nonce reservation. Those are M5 responsibilities.
+
+M4 also does not assert that event content is true. It distinguishes origin
+authenticity from content truth: a valid key can still sign false content, and
+that must be handled by guard validation, review workflows, and downstream
+forensic analysis.

--- a/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
+++ b/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
@@ -6,7 +6,8 @@ This document defines the forensic ledger export package produced for
 independent offline verification. The package is evidence packaging only: it
 does not enforce runtime origin signing, authorize agent actions, or export fact
 payloads. Runtime rejection of unsigned or badly signed origin events belongs to
-M4.
+M4. The runtime strict-mode contract is documented in
+[`ORIGIN_SIGNATURE_STRICT_MODE.md`](ORIGIN_SIGNATURE_STRICT_MODE.md).
 
 ## Required Artifacts
 
@@ -86,6 +87,11 @@ default.
 
 M3 assumes events already carry `public-v1-strict` fields, including
 `origin_signature`, `actor_key_id`, `nonce`, and hash-chain continuity.
+
+M4 adds a separate runtime `LedgerEvent.origin` envelope for pre-persistence
+origin-authenticity validation. A later adapter may map that runtime envelope
+into the public export event fields, but this package specification does not
+claim that bridge as automatic.
 
 M3 does not:
 

--- a/tests/test_ledger_origin_signatures.py
+++ b/tests/test_ledger_origin_signatures.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.ledger.models import ActionResult, ActionTarget, LedgerEvent
+from cortex.ledger.origin import (
+    OriginKeyRecord,
+    OriginKeyRegistry,
+    OriginSignatureError,
+    OriginSignaturePolicy,
+    sign_event_origin,
+    verify_event_origin,
+)
+from cortex.ledger.queue import EnrichmentQueue
+from cortex.ledger.store import LedgerStore
+from cortex.ledger.verifier import LedgerVerifier
+from cortex.ledger.writer import LedgerWriter
+
+ACTOR_ID = "agent-risk-01"
+KEY_ID = "ed25519:agent-risk-01:runtime-001"
+SIGNED_AT = "2026-02-03T10:15:30Z"
+NONCE = "nonce_01HXORIGIN000000000000001"
+
+
+def test_strict_origin_policy_accepts_signed_authorized_event(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+
+    event_id = writer.append(event)
+
+    with store.tx() as conn:
+        row = conn.execute(
+            "SELECT payload_json FROM ledger_events WHERE event_id = ?",
+            (event_id,),
+        ).fetchone()
+    assert row is not None
+    payload = json.loads(row["payload_json"])
+    assert payload["origin"]["key_id"] == KEY_ID
+    assert payload["origin"]["signature_alg"] == "ed25519"
+    assert payload["origin"]["nonce"] == NONCE
+    assert LedgerVerifier(store).verify_chain()["valid"] is True
+
+
+def test_strict_origin_policy_rejects_unsigned_event_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+
+    with pytest.raises(OriginSignatureError, match="origin_signature_missing"):
+        writer.append(_event())
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_tampered_event_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+    signed = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+    tampered = dataclasses.replace(signed, target=ActionTarget(app="Tampered"))
+
+    with pytest.raises(OriginSignatureError, match="origin_signature_invalid"):
+        writer.append(tampered)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_permission_denied_before_persistence(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.read"],
+            )
+        ]
+    )
+    store = LedgerStore(tmp_path / "ledger.db")
+    writer = LedgerWriter(
+        store,
+        EnrichmentQueue(store),
+        origin_policy=OriginSignaturePolicy.strict_mode(registry),
+    )
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+
+    with pytest.raises(OriginSignatureError, match="origin_key_permission_denied"):
+        writer.append(event)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_origin_signature_scope_verifies_independently() -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ]
+    )
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce=NONCE,
+    )
+
+    verify_event_origin(event, registry)
+
+
+def _strict_writer(
+    tmp_path: Path,
+    private_key: Ed25519PrivateKey,
+) -> tuple[LedgerStore, LedgerWriter]:
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ]
+    )
+    store = LedgerStore(tmp_path / "ledger.db")
+    return (
+        store,
+        LedgerWriter(
+            store,
+            EnrichmentQueue(store),
+            origin_policy=OriginSignaturePolicy.strict_mode(registry),
+        ),
+    )
+
+
+def _event() -> LedgerEvent:
+    return LedgerEvent.new(
+        tool="agent-runtime",
+        actor=ACTOR_ID,
+        action="fact.store",
+        target=ActionTarget(app="CORTEX", identifier="fact:001"),
+        result=ActionResult(ok=True, latency_ms=12, verified=True),
+        metadata={"project": "cortex-persist", "tenant_id": "tenant-acme"},
+    )
+
+
+def _row_count(store: LedgerStore, table_name: str) -> int:
+    if table_name not in {"ledger_events", "enrichment_jobs"}:
+        raise ValueError(f"unsupported table: {table_name}")
+    with store.tx() as conn:
+        row = conn.execute(f"SELECT COUNT(*) AS count FROM {table_name}").fetchone()
+    return int(row["count"])


### PR DESCRIPTION
Closes #282.

## Scope
- Adds a runtime LedgerEvent.origin signature envelope for pre-persistence provenance.
- Adds OriginKeyRegistry, OriginKeyRecord, and OriginSignaturePolicy.strict_mode for in-process key registry and actor-action permissions.
- Enforces strict origin signature validation in LedgerWriter.append before SQLite transaction creation when an origin policy is configured.
- Adds adversarial tests for unsigned, tampered, and permission-denied events proving no ledger row or enrichment job is written on rejection.
- Documents the strict-mode contract and keeps M5 replay/freshness/nonce reservation explicitly out of scope.

## Validation
- pytest tests/test_ledger_origin_signatures.py tests/test_ledger_integrity_verification.py tests/test_ledger_checkpointing.py tests/test_ledger_survives_without_embeddings.py tests/test_public_ledger_export.py tests/test_public_ledger_verifier.py -v
- ruff check cortex/ledger/models.py cortex/ledger/origin.py cortex/ledger/writer.py cortex/ledger/verifier.py cortex/ledger/__init__.py tests/test_ledger_origin_signatures.py
- ruff format --check cortex/ledger/models.py cortex/ledger/origin.py cortex/ledger/writer.py cortex/ledger/verifier.py cortex/ledger/__init__.py tests/test_ledger_origin_signatures.py
- pyright cortex/ledger/models.py cortex/ledger/origin.py cortex/ledger/writer.py cortex/ledger/verifier.py tests/test_ledger_origin_signatures.py
- python3 -m py_compile cortex/ledger/models.py cortex/ledger/origin.py cortex/ledger/writer.py cortex/ledger/verifier.py tests/test_ledger_origin_signatures.py

## Stacking
This is PR-4 and is intentionally stacked on PR-3 (codex/forensic-ledger-export-package).