### PR TITLE
feat: add replay freshness protection

### DIFF
--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -24,6 +24,11 @@ if TYPE_CHECKING:
     )
     from cortex.ledger.public_verifier import verify_export
     from cortex.ledger.queue import EnrichmentQueue
+    from cortex.ledger.replay import (
+        FreshnessPolicy,
+        ReplayProtectionError,
+        ReplayProtectionPolicy,
+    )
     from cortex.ledger.store import LedgerStore
     from cortex.ledger.verifier import LedgerVerifier
     from cortex.ledger.writer import LedgerWriter
@@ -44,6 +49,9 @@ __all__ = [
     "OriginKeyRegistry",
     "OriginSignatureError",
     "OriginSignaturePolicy",
+    "FreshnessPolicy",
+    "ReplayProtectionError",
+    "ReplayProtectionPolicy",
     "public_key_record",
     "sign_event_origin",
     "write_public_ledger_export",
@@ -65,6 +73,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "OriginSignaturePolicy": ("cortex.ledger.origin", "OriginSignaturePolicy"),
     "sign_event_origin": ("cortex.ledger.origin", "sign_event_origin"),
     "verify_event_origin": ("cortex.ledger.origin", "verify_event_origin"),
+    "FreshnessPolicy": ("cortex.ledger.replay", "FreshnessPolicy"),
+    "ReplayProtectionError": ("cortex.ledger.replay", "ReplayProtectionError"),
+    "ReplayProtectionPolicy": ("cortex.ledger.replay", "ReplayProtectionPolicy"),
     "ExportAuthority": ("cortex.ledger.public_export", "ExportAuthority"),
     "LedgerExportResult": ("cortex.ledger.public_export", "LedgerExportResult"),
     "public_key_record": ("cortex.ledger.public_export", "public_key_record"),

--- a/cortex/ledger/replay.py
+++ b/cortex/ledger/replay.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from cortex.ledger.models import LedgerEvent
+
+
+class ReplayProtectionError(ValueError):
+    """Raised when strict ledger replay or freshness checks fail."""
+
+
+@dataclass(frozen=True)
+class FreshnessPolicy:
+    max_age_seconds: int = 300
+    max_future_skew_seconds: int = 60
+
+
+@dataclass(frozen=True)
+class ReplayProtectionPolicy:
+    freshness: FreshnessPolicy = FreshnessPolicy()
+    now: Callable[[], datetime] | None = None
+
+    def validate_freshness(self, event: LedgerEvent) -> None:
+        origin = event.origin
+        if origin is None:
+            raise ReplayProtectionError("origin_required_for_replay_protection")
+        signed_at = _parse_utc(origin.signed_at)
+        now = self._now()
+        if signed_at < now - timedelta(seconds=self.freshness.max_age_seconds):
+            raise ReplayProtectionError("origin_signature_stale")
+        if signed_at > now + timedelta(seconds=self.freshness.max_future_skew_seconds):
+            raise ReplayProtectionError("origin_signature_from_future")
+
+    def is_idempotent_retry(self, conn: sqlite3.Connection, event: LedgerEvent) -> bool:
+        origin = _require_origin(event)
+        tenant_id = _tenant_id(event)
+        rows = conn.execute(
+            """
+            SELECT event_id, nonce, origin_signature
+            FROM ledger_origin_replay
+            WHERE tenant_id = ?
+              AND (
+                (actor_id = ? AND key_id = ? AND nonce = ?)
+                OR event_id = ?
+              )
+            """,
+            (tenant_id, origin.actor_id, origin.key_id, origin.nonce, event.event_id),
+        ).fetchall()
+
+        for row in rows:
+            same_signed_event = (
+                row["event_id"] == event.event_id
+                and row["nonce"] == origin.nonce
+                and row["origin_signature"] == origin.signature
+            )
+            if same_signed_event:
+                persisted = conn.execute(
+                    "SELECT 1 FROM ledger_events WHERE event_id = ?",
+                    (event.event_id,),
+                ).fetchone()
+                if persisted is not None:
+                    return True
+                raise ReplayProtectionError("origin_replay_orphan_reservation")
+            if row["nonce"] == origin.nonce:
+                raise ReplayProtectionError("origin_nonce_replay")
+            raise ReplayProtectionError("origin_event_id_replay")
+
+        legacy_event = conn.execute(
+            "SELECT 1 FROM ledger_events WHERE event_id = ?",
+            (event.event_id,),
+        ).fetchone()
+        if legacy_event is not None:
+            raise ReplayProtectionError("origin_event_id_replay")
+        return False
+
+    def reserve(self, conn: sqlite3.Connection, event: LedgerEvent) -> None:
+        origin = _require_origin(event)
+        if not event.hash:
+            raise ReplayProtectionError("origin_replay_requires_event_hash")
+        tenant_id = _tenant_id(event)
+        try:
+            conn.execute(
+                """
+                INSERT INTO ledger_origin_replay (
+                    tenant_id,
+                    actor_id,
+                    key_id,
+                    nonce,
+                    event_id,
+                    signed_at,
+                    origin_signature,
+                    event_hash
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    tenant_id,
+                    origin.actor_id,
+                    origin.key_id,
+                    origin.nonce,
+                    event.event_id,
+                    origin.signed_at,
+                    origin.signature,
+                    event.hash,
+                ),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ReplayProtectionError("origin_replay_conflict") from exc
+
+    def _now(self) -> datetime:
+        current = self.now() if self.now is not None else datetime.now(timezone.utc)
+        if current.tzinfo is None:
+            raise ReplayProtectionError("freshness_clock_missing_timezone")
+        return current
+
+
+def _require_origin(event: LedgerEvent):
+    origin = event.origin
+    if origin is None or not origin.signature:
+        raise ReplayProtectionError("origin_required_for_replay_protection")
+    return origin
+
+
+def _tenant_id(event: LedgerEvent) -> str:
+    tenant_id = event.metadata.get("tenant_id")
+    if isinstance(tenant_id, str) and tenant_id:
+        return tenant_id
+    return "default"
+
+
+def _parse_utc(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ReplayProtectionError("origin_timestamp_invalid") from exc
+    if parsed.tzinfo is None:
+        raise ReplayProtectionError("origin_timestamp_missing_timezone")
+    return parsed

--- a/cortex/ledger/store.py
+++ b/cortex/ledger/store.py
@@ -20,6 +20,10 @@ class LedgerStore:
 
         return connect(self.db_path, row_factory=sqlite3.Row)
 
+    def connect(self) -> sqlite3.Connection:
+        """Open a managed ledger connection for specialized transactional writers."""
+        return self._connect()
+
     @contextmanager
     def tx(self) -> Iterator[sqlite3.Connection]:
         conn = self._connect()
@@ -61,6 +65,21 @@ class LedgerStore:
                     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
                 );
 
+                CREATE TABLE IF NOT EXISTS ledger_origin_replay (
+                    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tenant_id        TEXT NOT NULL DEFAULT 'default',
+                    actor_id         TEXT NOT NULL,
+                    key_id           TEXT NOT NULL,
+                    nonce            TEXT NOT NULL,
+                    event_id         TEXT NOT NULL,
+                    signed_at        TEXT NOT NULL,
+                    origin_signature TEXT NOT NULL,
+                    event_hash       TEXT,
+                    created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                    UNIQUE(tenant_id, actor_id, key_id, nonce),
+                    UNIQUE(tenant_id, event_id)
+                );
+
                 CREATE TABLE IF NOT EXISTS enrichment_jobs (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     job_id TEXT UNIQUE,
@@ -82,6 +101,12 @@ class LedgerStore:
                 CREATE INDEX IF NOT EXISTS idx_ledger_events_hash ON ledger_events(hash);
                 CREATE INDEX IF NOT EXISTS idx_ledger_events_semantic_status
                     ON ledger_events(semantic_status);
+                CREATE INDEX IF NOT EXISTS idx_ledger_origin_replay_nonce
+                    ON ledger_origin_replay(tenant_id, actor_id, key_id, nonce);
+                CREATE INDEX IF NOT EXISTS idx_ledger_origin_replay_event
+                    ON ledger_origin_replay(tenant_id, event_id);
+                CREATE INDEX IF NOT EXISTS idx_ledger_origin_replay_signed_at
+                    ON ledger_origin_replay(signed_at);
 
                 CREATE TABLE IF NOT EXISTS ledger_enrichment_jobs (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/cortex/ledger/writer.py
+++ b/cortex/ledger/writer.py
@@ -1,9 +1,11 @@
 import dataclasses
+import sqlite3
 
 from cortex.ledger.models import LedgerEvent
 from cortex.ledger.origin import OriginSignaturePolicy
 from cortex.ledger.queue import EnrichmentQueue
-from cortex.ledger.store import LedgerStore
+from cortex.ledger.replay import ReplayProtectionError, ReplayProtectionPolicy
+from cortex.ledger.store import LedgerStore, LedgerStoreError
 
 
 class LedgerWriter:
@@ -12,14 +14,21 @@ class LedgerWriter:
         store: LedgerStore,
         queue: EnrichmentQueue,
         origin_policy: OriginSignaturePolicy | None = None,
+        replay_policy: ReplayProtectionPolicy | None = None,
     ) -> None:
+        if replay_policy is not None and origin_policy is None:
+            raise ValueError("replay_policy_requires_origin_policy")
         self.store = store
         self.queue = queue
         self.origin_policy = origin_policy
+        self.replay_policy = replay_policy
 
     def append(self, event: LedgerEvent) -> str:
         if self.origin_policy is not None:
             self.origin_policy.validate_event(event)
+        if self.replay_policy is not None:
+            self.replay_policy.validate_freshness(event)
+            return self._append_with_replay_protection(event)
 
         with self.store.tx() as conn:
             # 1. Get last hash
@@ -54,6 +63,59 @@ class LedgerWriter:
                     event.trace_id,
                 ),
             )
+
+        self.queue.enqueue(event.event_id)
+        return event.event_id
+
+    def _append_with_replay_protection(self, event: LedgerEvent) -> str:
+        assert self.replay_policy is not None
+        conn = self.store.connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            if self.replay_policy.is_idempotent_retry(conn, event):
+                conn.commit()
+                return event.event_id
+
+            cursor = conn.execute("SELECT hash FROM ledger_events ORDER BY rowid DESC LIMIT 1")
+            row = cursor.fetchone()
+            prev_hash = row["hash"] if row else "GENESIS"
+
+            new_hash = event.compute_hash(prev_hash)
+            event = dataclasses.replace(event, prev_hash=prev_hash, hash=new_hash)
+            self.replay_policy.reserve(conn, event)
+
+            conn.execute(
+                """
+                INSERT INTO ledger_events (
+                    event_id, ts, tool, actor, action, payload_json,
+                    prev_hash, hash,
+                    semantic_status, semantic_error, correlation_id, trace_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+                """,
+                (
+                    event.event_id,
+                    event.ts,
+                    event.tool,
+                    event.actor,
+                    event.action,
+                    event.to_json(),
+                    event.prev_hash,
+                    event.hash,
+                    event.semantic_status,
+                    event.correlation_id,
+                    event.trace_id,
+                ),
+            )
+            conn.commit()
+        except ReplayProtectionError:
+            conn.rollback()
+            raise
+        except sqlite3.Error as exc:
+            conn.rollback()
+            raise LedgerStoreError(str(exc)) from exc
+        finally:
+            conn.close()
 
         self.queue.enqueue(event.event_id)
         return event.event_id

--- a/cortex/migrations/mig_ledger_replay.py
+++ b/cortex/migrations/mig_ledger_replay.py
@@ -1,0 +1,42 @@
+"""Migration 023 — Ledger origin replay protection.
+
+# DOWNGRADE TARGET: 22
+
+Rollback strategy:
+    DROP TABLE ledger_origin_replay;
+
+Dropping the table disables replay protection but does not mutate ledger_events
+or any existing hash-chain payload. No data is rewritten or rehashed.
+
+sqlite-vec impact: none.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+
+def _migration_023_ledger_origin_replay(conn: sqlite3.Connection) -> None:
+    """Create sidecar replay reservations for strict ledger origin signatures."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS ledger_origin_replay (
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id        TEXT NOT NULL DEFAULT 'default',
+            actor_id         TEXT NOT NULL,
+            key_id           TEXT NOT NULL,
+            nonce            TEXT NOT NULL,
+            event_id         TEXT NOT NULL,
+            signed_at        TEXT NOT NULL,
+            origin_signature TEXT NOT NULL,
+            event_hash       TEXT,
+            created_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            UNIQUE(tenant_id, actor_id, key_id, nonce),
+            UNIQUE(tenant_id, event_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_ledger_origin_replay_nonce
+            ON ledger_origin_replay(tenant_id, actor_id, key_id, nonce);
+        CREATE INDEX IF NOT EXISTS idx_ledger_origin_replay_event
+            ON ledger_origin_replay(tenant_id, event_id);
+        CREATE INDEX IF NOT EXISTS idx_ledger_origin_replay_signed_at
+            ON ledger_origin_replay(signed_at);
+    """)

--- a/cortex/migrations/registry.py
+++ b/cortex/migrations/registry.py
@@ -21,10 +21,9 @@ from cortex.migrations.mig_ledger import (
     _migration_012_ghosts_table,
     _migration_014_vote_ledger_refinement,
 )
+from cortex.migrations.mig_ledger_replay import _migration_023_ledger_origin_replay
 from cortex.migrations.mig_security_hardening import _migration_018_security_hardening
 from cortex.migrations.mig_signals import _migration_019_signal_bus
-
-# migration 23 (mig_simplify_facts) removed — incompatible with live schema (Ω₃)
 from cortex.migrations.mig_solid_state import _migration_021_solid_state
 from cortex.migrations.mig_tenant import _migration_015_tenant_unification
 from cortex.migrations.mig_tombstone import _migration_020_tombstone
@@ -55,5 +54,6 @@ MIGRATIONS = [
     (20, "Tombstoning GC columns", _migration_020_tombstone),
     (21, "Solid-State Substrate (entity_events)", _migration_021_solid_state),
     (22, "Stratified Cognition + Causal Anchoring", _migration_022_cognitive_layer),
-    # (23) removed — mig_simplify_facts was never applied and is incompatible with live schema
+    (23, "Ledger origin replay protection", _migration_023_ledger_origin_replay),
+    # mig_simplify_facts removed — it was never applied and is incompatible with live schema
 ]

--- a/docs/compliance/ORIGIN_SIGNATURE_STRICT_MODE.md
+++ b/docs/compliance/ORIGIN_SIGNATURE_STRICT_MODE.md
@@ -58,7 +58,8 @@ Strict mode rejects:
 ## Current Limitations
 
 M4 does not add durable key-registry storage, replay tables, freshness windows,
-or nonce reservation. Those are M5 responsibilities.
+or nonce reservation. M5 adds replay/freshness controls in
+[`REPLAY_FRESHNESS_STRICT_MODE.md`](REPLAY_FRESHNESS_STRICT_MODE.md).
 
 M4 also does not assert that event content is true. It distinguishes origin
 authenticity from content truth: a valid key can still sign false content, and

--- a/docs/compliance/REPLAY_FRESHNESS_STRICT_MODE.md
+++ b/docs/compliance/REPLAY_FRESHNESS_STRICT_MODE.md
@@ -1,0 +1,84 @@
+# Replay And Freshness Strict Mode
+
+Status: draft
+
+M5 adds replay and freshness protection for signed ledger-origin events. It
+builds on M4 origin signatures and does not replace signature validation.
+
+## Runtime Contract
+
+`LedgerWriter` can be configured with `ReplayProtectionPolicy`. When enabled,
+the writer:
+
+- requires an M4 `OriginSignaturePolicy`;
+- checks `origin.signed_at` against a freshness window before persistence;
+- opens a SQLite `BEGIN IMMEDIATE` transaction for the protected write;
+- detects idempotent retries before computing a new chain hash;
+- reserves the origin nonce and event id in `ledger_origin_replay`;
+- inserts the ledger event in the same transaction;
+- enqueues enrichment only after the transaction commits.
+
+If replay reservation succeeds but the ledger insert fails, the transaction
+rolls back and the nonce reservation is removed with it.
+
+## Replay Table
+
+`ledger_origin_replay` is a sidecar table. It does not mutate existing
+`ledger_events` rows and does not alter historical hash-chain payloads.
+
+Constraints:
+
+- `UNIQUE(tenant_id, actor_id, key_id, nonce)`
+- `UNIQUE(tenant_id, event_id)`
+
+The table stores:
+
+- tenant id;
+- actor id;
+- key id;
+- nonce;
+- event id;
+- signed timestamp;
+- origin signature;
+- committed event hash.
+
+## Idempotent Retry
+
+Retrying the same signed event with the same tenant, event id, nonce, and
+origin signature returns the existing event id. It does not insert another
+ledger row and does not enqueue another enrichment job.
+
+Reusing a nonce for a different event is rejected. Reusing an event id with a
+different signed origin is rejected.
+
+## Freshness
+
+Default policy:
+
+- max age: 300 seconds;
+- max future clock skew: 60 seconds.
+
+Events older than the max age are rejected as stale. Events signed too far in
+the future are rejected as clock-skew/tampering candidates.
+
+## Migration
+
+Migration 23 creates `ledger_origin_replay`.
+
+Downgrade target: 22.
+
+Rollback strategy:
+
+```sql
+DROP TABLE ledger_origin_replay;
+```
+
+Rollback disables replay protection but does not rewrite `ledger_events`, fact
+tables, vector tables, or hash-chain data.
+
+## Current Limitations
+
+M5 does not persist a durable key registry, does not perform TPM/HSM key
+attestation, and does not prove global completeness across independent
+databases. It provides per-database replay/freshness enforcement for protected
+ledger writes.

--- a/tests/test_ledger_replay_migration.py
+++ b/tests/test_ledger_replay_migration.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from cortex.migrations.mig_ledger_replay import _migration_023_ledger_origin_replay
+from cortex.migrations.registry import MIGRATIONS
+
+
+def test_migration_registry_includes_ledger_origin_replay_version() -> None:
+    assert any(
+        version == 23 and func is _migration_023_ledger_origin_replay
+        for version, _, func in MIGRATIONS
+    )
+
+
+def test_migration_023_creates_replay_table_and_constraints() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+
+    _migration_023_ledger_origin_replay(conn)
+
+    columns = {row["name"] for row in conn.execute("PRAGMA table_info(ledger_origin_replay)")}
+    assert {
+        "tenant_id",
+        "actor_id",
+        "key_id",
+        "nonce",
+        "event_id",
+        "signed_at",
+        "origin_signature",
+        "event_hash",
+    } <= columns
+
+    conn.execute(
+        """
+        INSERT INTO ledger_origin_replay (
+            tenant_id, actor_id, key_id, nonce, event_id, signed_at, origin_signature
+        )
+        VALUES ('tenant-acme', 'agent-risk-01', 'key-1', 'nonce-1', 'event-1', 'ts', 'sig')
+        """
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO ledger_origin_replay (
+                tenant_id, actor_id, key_id, nonce, event_id, signed_at, origin_signature
+            )
+            VALUES ('tenant-acme', 'agent-risk-01', 'key-1', 'nonce-1', 'event-2', 'ts', 'sig')
+            """
+        )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO ledger_origin_replay (
+                tenant_id, actor_id, key_id, nonce, event_id, signed_at, origin_signature
+            )
+            VALUES ('tenant-acme', 'agent-risk-01', 'key-1', 'nonce-2', 'event-1', 'ts', 'sig')
+            """
+        )
+
+    conn.close()

--- a/tests/test_ledger_replay_protection.py
+++ b/tests/test_ledger_replay_protection.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import dataclasses
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.ledger.models import ActionResult, ActionTarget, LedgerEvent
+from cortex.ledger.origin import (
+    OriginKeyRecord,
+    OriginKeyRegistry,
+    OriginSignaturePolicy,
+    sign_event_origin,
+)
+from cortex.ledger.queue import EnrichmentQueue
+from cortex.ledger.replay import ReplayProtectionError, ReplayProtectionPolicy
+from cortex.ledger.store import LedgerStore, LedgerStoreError
+from cortex.ledger.writer import LedgerWriter
+
+ACTOR_ID = "agent-risk-01"
+KEY_ID = "ed25519:agent-risk-01:runtime-001"
+SIGNED_AT = "2026-02-03T10:15:30Z"
+NOW = datetime(2026, 2, 3, 10, 16, 0, tzinfo=timezone.utc)
+
+
+def test_replay_policy_reserves_nonce_atomically_with_ledger_event(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    event = _signed_event(private_key, nonce="nonce-001")
+
+    event_id = writer.append(event)
+
+    with store.tx() as conn:
+        row = conn.execute(
+            """
+            SELECT event_id, nonce, event_hash
+            FROM ledger_origin_replay
+            WHERE event_id = ?
+            """,
+            (event_id,),
+        ).fetchone()
+    assert row is not None
+    assert row["nonce"] == "nonce-001"
+    assert isinstance(row["event_hash"], str)
+
+
+def test_replay_policy_requires_origin_policy(tmp_path: Path) -> None:
+    store = LedgerStore(tmp_path / "ledger.db")
+
+    with pytest.raises(ValueError, match="replay_policy_requires_origin_policy"):
+        LedgerWriter(
+            store,
+            EnrichmentQueue(store),
+            replay_policy=ReplayProtectionPolicy(now=lambda: NOW),
+        )
+
+
+def test_replay_policy_handles_idempotent_retry_without_duplicate_side_effects(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    event = _signed_event(private_key, nonce="nonce-001")
+
+    first = writer.append(event)
+    second = writer.append(event)
+
+    assert second == first
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "ledger_origin_replay") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+
+
+def test_replay_policy_rejects_nonce_replay_for_different_event(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    writer.append(_signed_event(private_key, nonce="nonce-001"))
+    replay = _signed_event(private_key, nonce="nonce-001", event_id="evt-replay-002")
+
+    with pytest.raises(ReplayProtectionError, match="origin_nonce_replay"):
+        writer.append(replay)
+
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "ledger_origin_replay") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+
+
+def test_replay_policy_rejects_stale_signature_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    stale = _signed_event(private_key, nonce="nonce-stale", signed_at="2026-02-03T10:00:00Z")
+
+    with pytest.raises(ReplayProtectionError, match="origin_signature_stale"):
+        writer.append(stale)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "ledger_origin_replay") == 0
+
+
+def test_replay_policy_rejects_future_signature_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    future = _signed_event(private_key, nonce="nonce-future", signed_at="2026-02-03T10:18:00Z")
+
+    with pytest.raises(ReplayProtectionError, match="origin_signature_from_future"):
+        writer.append(future)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "ledger_origin_replay") == 0
+
+
+def test_replay_reservation_rolls_back_when_ledger_insert_fails(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    invalid_event = dataclasses.replace(_event(), tool=cast(str, None))
+    signed_invalid = sign_event_origin(
+        invalid_event,
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=SIGNED_AT,
+        nonce="nonce-rollback",
+    )
+
+    with pytest.raises(LedgerStoreError):
+        writer.append(signed_invalid)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "ledger_origin_replay") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_concurrent_idempotent_retry_writes_one_event(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    event = _signed_event(private_key, nonce="nonce-concurrent")
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: writer.append(event), range(2)))
+
+    assert results == [event.event_id, event.event_id]
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "ledger_origin_replay") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+
+
+def _writer(
+    tmp_path: Path,
+    private_key: Ed25519PrivateKey,
+) -> tuple[LedgerStore, LedgerWriter]:
+    registry = OriginKeyRegistry(
+        [
+            OriginKeyRecord.from_public_key(
+                key_id=KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ]
+    )
+    store = LedgerStore(tmp_path / "ledger.db")
+    return (
+        store,
+        LedgerWriter(
+            store,
+            EnrichmentQueue(store),
+            origin_policy=OriginSignaturePolicy.strict_mode(registry),
+            replay_policy=ReplayProtectionPolicy(now=lambda: NOW),
+        ),
+    )
+
+
+def _signed_event(
+    private_key: Ed25519PrivateKey,
+    *,
+    nonce: str,
+    event_id: str = "evt-replay-001",
+    signed_at: str = SIGNED_AT,
+) -> LedgerEvent:
+    return sign_event_origin(
+        dataclasses.replace(_event(), event_id=event_id),
+        key_id=KEY_ID,
+        private_key=private_key,
+        signed_at=signed_at,
+        nonce=nonce,
+    )
+
+
+def _event() -> LedgerEvent:
+    return LedgerEvent.new(
+        tool="agent-runtime",
+        actor=ACTOR_ID,
+        action="fact.store",
+        target=ActionTarget(app="CORTEX", identifier="fact:001"),
+        result=ActionResult(ok=True, latency_ms=12, verified=True),
+        metadata={"project": "cortex-persist", "tenant_id": "tenant-acme"},
+    )
+
+
+def _row_count(store: LedgerStore, table_name: str) -> int:
+    if table_name not in {"ledger_events", "ledger_origin_replay", "enrichment_jobs"}:
+        raise ValueError(f"unsupported table: {table_name}")
+    with store.tx() as conn:
+        row = conn.execute(f"SELECT COUNT(*) AS count FROM {table_name}").fetchone()
+    return int(row["count"])


### PR DESCRIPTION
Closes #283.

## Scope
- Adds ledger_origin_replay sidecar table via migration 23 and LedgerStore bootstrap DDL.
- Adds ReplayProtectionPolicy and FreshnessPolicy for per-database replay and clock-skew checks.
- Integrates replay/freshness with LedgerWriter under strict origin policy only.
- Uses BEGIN IMMEDIATE and same-transaction nonce reservation plus ledger insert for rollback-safe atomic writes.
- Handles idempotent retry of the same signed event without duplicate ledger rows or enrichment jobs.
- Adds tests for stale/future signatures, nonce replay, idempotent retry, rollback safety, concurrency, and migration constraints.

## Validation
- pytest tests/test_ledger_replay_protection.py tests/test_ledger_replay_migration.py tests/test_ledger_origin_signatures.py tests/test_ledger_integrity_verification.py tests/test_ledger_checkpointing.py tests/test_ledger_survives_without_embeddings.py tests/test_public_ledger_export.py tests/test_public_ledger_verifier.py -v
- ruff check cortex/ledger/replay.py cortex/ledger/writer.py cortex/ledger/store.py cortex/ledger/__init__.py cortex/migrations/mig_ledger_replay.py cortex/migrations/registry.py tests/test_ledger_replay_protection.py tests/test_ledger_replay_migration.py
- ruff format --check cortex/ledger/replay.py cortex/ledger/writer.py cortex/ledger/store.py cortex/ledger/__init__.py cortex/migrations/mig_ledger_replay.py cortex/migrations/registry.py tests/test_ledger_replay_protection.py tests/test_ledger_replay_migration.py
- pyright cortex/ledger/replay.py cortex/ledger/writer.py tests/test_ledger_replay_protection.py tests/test_ledger_replay_migration.py
- python3 -m py_compile cortex/ledger/replay.py cortex/ledger/writer.py cortex/ledger/store.py cortex/migrations/mig_ledger_replay.py tests/test_ledger_replay_protection.py tests/test_ledger_replay_migration.py

## Migration Review
- Alembic checks attempted but repo has no script_location configured.
- Local migration registry advances from 22 to 23.
- Downgrade target: 22; rollback drops ledger_origin_replay only and does not rewrite ledger_events.
- sqlite-vec impact: none.

## Stacking
This is PR-5 and is intentionally stacked on PR-4 (codex/strict-origin-signatures).