### PR TITLE
feat: enforce no pii immutable ledger policy

### DIFF
--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
         sign_event_origin,
         verify_event_origin,
     )
+    from cortex.ledger.pii import LedgerPIIError, LedgerPIIPolicy, scrub_text
     from cortex.ledger.public_export import (
         ExportAuthority,
         LedgerExportResult,
@@ -49,10 +50,13 @@ __all__ = [
     "OriginKeyRegistry",
     "OriginSignatureError",
     "OriginSignaturePolicy",
+    "LedgerPIIError",
+    "LedgerPIIPolicy",
     "FreshnessPolicy",
     "ReplayProtectionError",
     "ReplayProtectionPolicy",
     "public_key_record",
+    "scrub_text",
     "sign_event_origin",
     "write_public_ledger_export",
     "verify_event_origin",
@@ -73,6 +77,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "OriginSignaturePolicy": ("cortex.ledger.origin", "OriginSignaturePolicy"),
     "sign_event_origin": ("cortex.ledger.origin", "sign_event_origin"),
     "verify_event_origin": ("cortex.ledger.origin", "verify_event_origin"),
+    "LedgerPIIError": ("cortex.ledger.pii", "LedgerPIIError"),
+    "LedgerPIIPolicy": ("cortex.ledger.pii", "LedgerPIIPolicy"),
+    "scrub_text": ("cortex.ledger.pii", "scrub_text"),
     "FreshnessPolicy": ("cortex.ledger.replay", "FreshnessPolicy"),
     "ReplayProtectionError": ("cortex.ledger.replay", "ReplayProtectionError"),
     "ReplayProtectionPolicy": ("cortex.ledger.replay", "ReplayProtectionPolicy"),

--- a/cortex/ledger/pii.py
+++ b/cortex/ledger/pii.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from cortex.ledger.models import LedgerEvent
+
+
+class LedgerPIIError(ValueError):
+    """Raised when a ledger event contains direct identifiers."""
+
+
+DEFAULT_ALLOWED_METADATA_KEYS = frozenset(
+    {
+        "decision_ref",
+        "parent_decision_id",
+        "payload_ref",
+        "project",
+        "reason_code",
+        "risk_ref",
+        "subject_ref",
+        "taint",
+        "tenant_id",
+        "trace_ref",
+    }
+)
+
+FORBIDDEN_KEY_TOKENS = frozenset(
+    {
+        "account",
+        "address",
+        "customer_email",
+        "email",
+        "full_name",
+        "iban",
+        "name",
+        "passport",
+        "phone",
+        "plaintext",
+        "ssn",
+        "user_email",
+    }
+)
+
+OPAQUE_VALUE_KEYS = frozenset(
+    {
+        "hash",
+        "origin_signature",
+        "prev_hash",
+        "public_key",
+        "signature",
+    }
+)
+
+DIRECT_IDENTIFIER_PATTERNS = (
+    re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE),
+    re.compile(r"\+\d{8,15}\b"),
+    re.compile(r"\b\d{3}[\s.-]\d{3}[\s.-]\d{4}\b"),
+    re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    re.compile(r"\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b"),
+    re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+)
+
+
+@dataclass(frozen=True)
+class LedgerPIIPolicy:
+    allowed_metadata_keys: frozenset[str] = DEFAULT_ALLOWED_METADATA_KEYS
+
+    def validate_event(self, event: LedgerEvent) -> None:
+        validate_no_direct_identifiers(
+            event.to_payload(), allowed_metadata_keys=self.allowed_metadata_keys
+        )
+
+
+def validate_no_direct_identifiers(
+    value: Any,
+    *,
+    allowed_metadata_keys: frozenset[str] = DEFAULT_ALLOWED_METADATA_KEYS,
+    path: str = "event",
+) -> None:
+    if isinstance(value, str):
+        if _contains_direct_identifier(value):
+            raise LedgerPIIError(f"ledger_direct_identifier:{path}")
+        return
+    if isinstance(value, Mapping):
+        _validate_mapping(value, allowed_metadata_keys=allowed_metadata_keys, path=path)
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            validate_no_direct_identifiers(
+                item,
+                allowed_metadata_keys=allowed_metadata_keys,
+                path=f"{path}[{index}]",
+            )
+
+
+def scrub_text(value: str) -> str:
+    scrubbed = value
+    for pattern in DIRECT_IDENTIFIER_PATTERNS:
+        scrubbed = pattern.sub("[REDACTED]", scrubbed)
+    return scrubbed
+
+
+def _validate_mapping(
+    value: Mapping[Any, Any],
+    *,
+    allowed_metadata_keys: frozenset[str],
+    path: str,
+) -> None:
+    for key, item in value.items():
+        key_text = str(key)
+        child_path = f"{path}.{_safe_path_token(key_text)}"
+        _validate_key(key_text, child_path)
+        if path == "event.metadata" and key_text not in allowed_metadata_keys:
+            raise LedgerPIIError(f"ledger_metadata_key_not_allowlisted:{child_path}")
+        if key_text in OPAQUE_VALUE_KEYS:
+            continue
+        validate_no_direct_identifiers(
+            item,
+            allowed_metadata_keys=allowed_metadata_keys,
+            path=child_path,
+        )
+
+
+def _validate_key(key: str, path: str) -> None:
+    normalized = key.lower().replace("-", "_")
+    if _contains_direct_identifier(key):
+        raise LedgerPIIError(f"ledger_direct_identifier_key:{path}")
+    if normalized in FORBIDDEN_KEY_TOKENS:
+        raise LedgerPIIError(f"ledger_forbidden_identifier_key:{path}")
+
+
+def _contains_direct_identifier(value: str) -> bool:
+    return any(pattern.search(value) for pattern in DIRECT_IDENTIFIER_PATTERNS)
+
+
+def _safe_path_token(value: str) -> str:
+    if not value or _contains_direct_identifier(value):
+        return "<redacted-key>"
+    return re.sub(r"[^A-Za-z0-9_:-]", "_", value)[:64]

--- a/cortex/ledger/public_export.py
+++ b/cortex/ledger/public_export.py
@@ -13,6 +13,7 @@ from typing import Any
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
+from cortex.ledger.pii import LedgerPIIError, validate_no_direct_identifiers
 from cortex.ledger.public_verifier import verify_export
 
 
@@ -261,6 +262,10 @@ def _validate_event_package_scope(
             raise ValueError(f"event tenant mismatch: {event.get('event_id')}")
         if event.get("stream_id") != stream_id:
             raise ValueError(f"event stream mismatch: {event.get('event_id')}")
+        try:
+            validate_no_direct_identifiers(event, path="event")
+        except LedgerPIIError as exc:
+            raise ValueError(f"event contains direct identifier: {exc}") from exc
         detail = event.get("detail")
         if isinstance(detail, Mapping) and any(
             field in detail for field in ("content", "payload", "plaintext", "fact_content")

--- a/cortex/ledger/writer.py
+++ b/cortex/ledger/writer.py
@@ -3,6 +3,7 @@ import sqlite3
 
 from cortex.ledger.models import LedgerEvent
 from cortex.ledger.origin import OriginSignaturePolicy
+from cortex.ledger.pii import LedgerPIIPolicy
 from cortex.ledger.queue import EnrichmentQueue
 from cortex.ledger.replay import ReplayProtectionError, ReplayProtectionPolicy
 from cortex.ledger.store import LedgerStore, LedgerStoreError
@@ -15,6 +16,7 @@ class LedgerWriter:
         queue: EnrichmentQueue,
         origin_policy: OriginSignaturePolicy | None = None,
         replay_policy: ReplayProtectionPolicy | None = None,
+        pii_policy: LedgerPIIPolicy | None = None,
     ) -> None:
         if replay_policy is not None and origin_policy is None:
             raise ValueError("replay_policy_requires_origin_policy")
@@ -22,8 +24,11 @@ class LedgerWriter:
         self.queue = queue
         self.origin_policy = origin_policy
         self.replay_policy = replay_policy
+        self.pii_policy = pii_policy
 
     def append(self, event: LedgerEvent) -> str:
+        if self.pii_policy is not None:
+            self.pii_policy.validate_event(event)
         if self.origin_policy is not None:
             self.origin_policy.validate_event(event)
         if self.replay_policy is not None:

--- a/docs/compliance/NO_PII_IMMUTABLE_LEDGER_POLICY.md
+++ b/docs/compliance/NO_PII_IMMUTABLE_LEDGER_POLICY.md
@@ -1,0 +1,76 @@
+# No-PII Immutable Ledger Policy
+
+Status: draft
+
+M6 adds a strict pre-persistence policy for immutable ledger events. The policy
+is designed to prevent direct identifiers from entering hash-chained ledger
+payloads. It does not delete or rewrite historical ledger rows.
+
+## Runtime Contract
+
+`LedgerWriter` can be configured with `LedgerPIIPolicy`. When enabled, the
+writer validates the event before origin signatures, replay checks, hash
+calculation, SQLite insert, and enrichment enqueue.
+
+If validation fails:
+
+- no `ledger_events` row is inserted;
+- no replay reservation is created;
+- no enrichment job is created;
+- the rejection error names only the field path, not the rejected value.
+
+## Allowlisted Metadata
+
+Strict metadata keys are allowlisted. The default allowlist is:
+
+- `decision_ref`
+- `parent_decision_id`
+- `payload_ref`
+- `project`
+- `reason_code`
+- `risk_ref`
+- `subject_ref`
+- `taint`
+- `tenant_id`
+- `trace_ref`
+
+Unknown metadata keys are rejected in strict mode. Direct-identifier key names
+such as `email`, `phone`, `full_name`, `passport`, `iban`, and `ssn` are always
+rejected.
+
+## Direct Identifier Detection
+
+The policy rejects common direct identifiers in string fields:
+
+- email addresses;
+- E.164-like phone numbers;
+- common dashed phone numbers;
+- US SSN shape;
+- IBAN-like account identifiers;
+- IPv4 addresses.
+
+Cryptographic opaque values such as hashes, public keys, and signatures are not
+scanned as plaintext identifiers.
+
+## Export Boundary
+
+Public forensic ledger export validates events with the same no-direct-
+identifier guard before writing `events.jsonl`. Export rejection errors do not
+include the sensitive value.
+
+## Operator Notes And Reports
+
+`scrub_text()` is available for operator-note and report surfaces that need to
+display human-entered text. It replaces detected direct identifiers with
+`[REDACTED]`.
+
+## Current Limitations
+
+This is not a full DLP engine and does not prove that pseudonymous references
+cannot be linked outside CORTEX. Hashes or HMACs can still be personal data
+under GDPR if they are linkable by a controller with auxiliary data.
+
+Historical ledger rows are not rewritten. If direct identifiers already entered
+an immutable ledger, remediation must use legal hold, access restriction,
+crypto-shredding of associated fact payloads where possible, and documented
+residual risk.

--- a/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
+++ b/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
@@ -30,6 +30,10 @@ The package must not contain `facts.jsonl` or plaintext fact payload files.
 Fact export is a separate product surface with separate retention, redaction,
 and erasure controls.
 
+Public ledger events are also checked against the no-direct-identifier policy
+documented in
+[`NO_PII_IMMUTABLE_LEDGER_POLICY.md`](NO_PII_IMMUTABLE_LEDGER_POLICY.md).
+
 ## Manifest Scope
 
 `manifest.json` includes:

--- a/tests/test_ledger_no_pii_policy.py
+++ b/tests/test_ledger_no_pii_policy.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.ledger.models import ActionResult, ActionTarget, LedgerEvent
+from cortex.ledger.pii import LedgerPIIError, LedgerPIIPolicy, scrub_text
+from cortex.ledger.public_export import ExportAuthority, write_public_ledger_export
+from cortex.ledger.queue import EnrichmentQueue
+from cortex.ledger.store import LedgerStore
+from cortex.ledger.writer import LedgerWriter
+
+
+def test_pii_policy_rejects_email_before_ledger_persistence(tmp_path: Path) -> None:
+    store, writer = _writer(tmp_path)
+    event = _event(target=ActionTarget(app="CORTEX", title="alice@example.com"))
+
+    with pytest.raises(LedgerPIIError) as exc:
+        writer.append(event)
+
+    assert "alice@example.com" not in str(exc.value)
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_pii_policy_rejects_non_allowlisted_metadata_key(tmp_path: Path) -> None:
+    store, writer = _writer(tmp_path)
+    event = _event(metadata={"project": "cortex-persist", "email": "redacted-ref"})
+
+    with pytest.raises(LedgerPIIError, match="ledger_forbidden_identifier_key"):
+        writer.append(event)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_pii_policy_accepts_allowlisted_references(tmp_path: Path) -> None:
+    store, writer = _writer(tmp_path)
+    event = _event(
+        metadata={
+            "payload_ref": "blob:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "project": "cortex-persist",
+            "subject_ref": "subject:hmac-sha256:01HX",
+            "tenant_id": "tenant-acme",
+        }
+    )
+
+    event_id = writer.append(event)
+
+    assert isinstance(event_id, str)
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+
+
+def test_scrub_text_removes_direct_identifiers() -> None:
+    scrubbed = scrub_text("Operator note: alice@example.com / +34600111222 / 123-45-6789")
+
+    assert "alice@example.com" not in scrubbed
+    assert "+34600111222" not in scrubbed
+    assert "123-45-6789" not in scrubbed
+    assert scrubbed.count("[REDACTED]") == 3
+
+
+def test_public_ledger_export_rejects_direct_identifier_without_echo(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    event = {
+        "detail": {"fact_type": "decision", "subject_ref": "alice@example.com"},
+        "event_id": "evt-pii-001",
+        "hash": "abc",
+        "prev_hash": "GENESIS",
+        "recorded_at": "2026-02-03T10:15:30Z",
+        "sequence": 1,
+        "stream_id": "tenant:acme:ledger:primary",
+        "tenant_id": "tenant-acme",
+    }
+
+    with pytest.raises(ValueError) as exc:
+        write_public_ledger_export(
+            events=[event],
+            export_dir=tmp_path / "export",
+            public_keys=[],
+            export_authority=ExportAuthority(
+                key_id="ed25519:export:test",
+                actor_id="export-authority-01",
+                private_key=private_key,
+            ),
+            export_id="export-pii-001",
+            tenant_id="tenant-acme",
+            stream_id="tenant:acme:ledger:primary",
+            created_at="2026-02-03T10:15:30Z",
+        )
+
+    assert "alice@example.com" not in str(exc.value)
+
+
+def _writer(tmp_path: Path) -> tuple[LedgerStore, LedgerWriter]:
+    store = LedgerStore(tmp_path / "ledger.db")
+    return store, LedgerWriter(store, EnrichmentQueue(store), pii_policy=LedgerPIIPolicy())
+
+
+def _event(
+    *,
+    target: ActionTarget | None = None,
+    metadata: dict[str, object] | None = None,
+) -> LedgerEvent:
+    return LedgerEvent.new(
+        tool="agent-runtime",
+        actor="agent-risk-01",
+        action="fact.store",
+        target=target or ActionTarget(app="CORTEX", identifier="fact:001"),
+        result=ActionResult(ok=True, latency_ms=12, verified=True),
+        metadata=metadata or {"project": "cortex-persist", "tenant_id": "tenant-acme"},
+    )
+
+
+def _row_count(store: LedgerStore, table_name: str) -> int:
+    if table_name not in {"ledger_events", "enrichment_jobs"}:
+        raise ValueError(f"unsupported table: {table_name}")
+    with store.tx() as conn:
+        row = conn.execute(f"SELECT COUNT(*) AS count FROM {table_name}").fetchone()
+    return int(row["count"])


### PR DESCRIPTION
Closes #284.

## Scope
- Adds LedgerPIIPolicy with direct-identifier detection and strict metadata allowlist for immutable ledger events.
- Enforces the policy in LedgerWriter before origin signatures, replay checks, hashing, persistence, and enrichment enqueue.
- Reuses the same no-direct-identifier guard in public forensic export generation.
- Adds scrub_text for operator-note/report surfaces that need identifier redaction.
- Ensures rejection errors point to field paths and do not echo the rejected value.
- Documents the no-PII immutable-ledger policy and its limits on historical immutable rows.

## Validation
- pytest tests/test_ledger_no_pii_policy.py tests/test_public_ledger_export.py tests/test_ledger_replay_protection.py tests/test_ledger_origin_signatures.py tests/test_public_ledger_verifier.py -v
- ruff check cortex/ledger/pii.py cortex/ledger/writer.py cortex/ledger/public_export.py cortex/ledger/__init__.py tests/test_ledger_no_pii_policy.py
- ruff format --check cortex/ledger/pii.py cortex/ledger/writer.py cortex/ledger/public_export.py cortex/ledger/__init__.py tests/test_ledger_no_pii_policy.py
- pyright cortex/ledger/pii.py cortex/ledger/writer.py cortex/ledger/public_export.py tests/test_ledger_no_pii_policy.py
- python3 -m py_compile cortex/ledger/pii.py cortex/ledger/writer.py cortex/ledger/public_export.py tests/test_ledger_no_pii_policy.py

## Stacking
This is PR-6 and is intentionally stacked on PR-5 (codex/replay-freshness-atomic-writes).