### PR TITLE
feat: prove crypto shredding evidence

### DIFF
--- a/cortex/crypto/shredder.py
+++ b/cortex/crypto/shredder.py
@@ -1,29 +1,22 @@
 """
-Crypto-Shredding Engine — GDPR Right to Erasure (Ω₃ / Ω₁₂).
+Crypto-shredding and erasure controls for mutable fact surfaces.
 
-Resolves the EU AI Act ↔ GDPR paradox:
-  - EU AI Act demands immutable audit trails for AI decisions.
-  - GDPR demands the right to erase personal data.
+Current repository-demonstrated behavior:
+  - Records an immutable erasure marker in `shredded_keys`.
+  - Replaces mutable fact payload surfaces with a non-PII tombstone.
+  - Purges mutable search/index side effects (`facts_fts`, `fact_embeddings`,
+    pending enrichment jobs) for the shredded fact.
+  - Leaves ledger continuity untouched because the append-only ledger is not
+    mutated by this module.
 
-Solution: Per-fact HKDF key derivation. Destroying the key makes the
-ciphertext irrecoverable without altering the ledger hash chain.
-The transaction log stays intact for regulators; the personal data
-becomes cryptographic noise.
-
-Architecture:
-  - Each fact's content is encrypted with a key derived from:
-    HKDF(master_key, info=f"{tenant_id}:fact:{fact_id}")
-  - Shredding = recording the fact_id in `shredded_keys` table
-    + invalidating the derived key from cache
-  - The ledger's hash chain uses the *encrypted* ciphertext, so
-    shredding doesn't break chain integrity.
-
-Edge-compatible: SQLite-only, no external services.
-GPU-native: N/A (crypto is CPU-bound, parallelizable via ProcessPool).
+This module does not claim per-fact envelope-key destruction beyond what the
+repository currently enforces. It implements the executable erasure boundary
+that the codebase can actually prove today.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 import time
@@ -37,6 +30,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger("cortex.crypto.shredder")
 
 __all__ = ["CryptoShredder", "ShredResult", "ShredBatchResult"]
+
+_TOMBSTONE_CONTENT = "CORTEX_ERASURE_TOMBSTONE"
+_TOMBSTONE_SOURCE = "subject-erased"
 
 
 @dataclass
@@ -63,15 +59,14 @@ class ShredBatchResult:
 
 
 class CryptoShredder:
-    """Sovereign Crypto-Shredding Engine.
-
-    Destroys per-fact encryption keys to make ciphertext irrecoverable.
-    The immutable ledger hash chain remains intact for EU AI Act compliance.
-    """
+    """Executable erasure controller for fact payloads and retrieval surfaces."""
 
     def __init__(self, conn: aiosqlite.Connection | sqlite3.Connection):
         self._conn = conn
         self._ensure_schema()
+
+    def _is_async_connection(self) -> bool:
+        return hasattr(self._conn, "_execute")
 
     def _ensure_schema(self) -> None:
         """Create shredded_keys table if it doesn't exist."""
@@ -87,11 +82,209 @@ class CryptoShredder:
             );
         """
         try:
-            if isinstance(self._conn, sqlite3.Connection):
+            if not self._is_async_connection():
                 self._conn.execute(sql)
                 self._conn.commit()
         except sqlite3.Error as e:
             logger.warning("Schema creation skipped (may exist): %s", e)
+
+    def _fact_row(self, fact_id: int, tenant_id: str) -> Any:
+        if self._is_async_connection():
+            raise TypeError("Use async APIs for async connections")
+        cursor: Any = self._conn.execute(
+            "SELECT id FROM facts WHERE id = ? AND tenant_id = ?",
+            (fact_id, tenant_id),
+        )
+        return cursor.fetchone()
+
+    async def _fact_row_async(self, fact_id: int, tenant_id: str) -> Any:
+        cursor = await self._conn.execute(  # type: ignore[reportAttributeAccessIssue]
+            "SELECT id FROM facts WHERE id = ? AND tenant_id = ?",
+            (fact_id, tenant_id),
+        )
+        return await cursor.fetchone()
+
+    def _table_exists(self, table_name: str) -> bool:
+        if self._is_async_connection():
+            raise TypeError("Use async APIs for async connections")
+        cursor: Any = self._conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?",
+            (table_name,),
+        )
+        return cursor.fetchone() is not None
+
+    async def _table_exists_async(self, table_name: str) -> bool:
+        cursor = await self._conn.execute(  # type: ignore[reportAttributeAccessIssue]
+            "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ?",
+            (table_name,),
+        )
+        return (await cursor.fetchone()) is not None
+
+    def _column_exists(self, table_name: str, column_name: str) -> bool:
+        if self._is_async_connection():
+            raise TypeError("Use async APIs for async connections")
+        cursor: Any = self._conn.execute(f"PRAGMA table_info({table_name})")  # nosec B608
+        return any(row[1] == column_name for row in cursor.fetchall())
+
+    async def _column_exists_async(self, table_name: str, column_name: str) -> bool:
+        cursor = await self._conn.execute(  # type: ignore[reportAttributeAccessIssue]
+            f"PRAGMA table_info({table_name})"  # nosec B608
+        )
+        rows = await cursor.fetchall()
+        return any(row[1] == column_name for row in rows)
+
+    def _tombstone_metadata(
+        self,
+        *,
+        fact_id: int,
+        tenant_id: str,
+        shredded_at: str,
+        reason: str,
+        shredded_by: Optional[str],
+    ) -> str:
+        tombstone = {
+            "erasure_status": "shredded",
+            "tombstoned_at": shredded_at,
+            "tombstone_reason": reason,
+            "shredded_by": shredded_by or "system",
+            "subject_ref": f"erased:{tenant_id}:{fact_id}",
+        }
+        return json.dumps(tombstone, sort_keys=True)
+
+    def _redact_fact_surfaces(
+        self,
+        fact_id: int,
+        tenant_id: str,
+        reason: str,
+        shredded_by: Optional[str],
+        shredded_at: str,
+    ) -> None:
+        if self._is_async_connection():
+            raise TypeError("Use async APIs for async connections")
+
+        facts_columns = {
+            "valid_until": self._column_exists("facts", "valid_until"),
+            "is_tombstoned": self._column_exists("facts", "is_tombstoned"),
+            "updated_at": self._column_exists("facts", "updated_at"),
+            "metadata": self._column_exists("facts", "metadata"),
+            "source": self._column_exists("facts", "source"),
+            "tags": self._column_exists("facts", "tags"),
+        }
+
+        set_clauses = ["content = ?"]
+        params: list[Any] = [_TOMBSTONE_CONTENT]
+
+        if facts_columns["valid_until"]:
+            set_clauses.append("valid_until = ?")
+            params.append(shredded_at)
+        if facts_columns["is_tombstoned"]:
+            set_clauses.append("is_tombstoned = 1")
+        if facts_columns["updated_at"]:
+            set_clauses.append("updated_at = ?")
+            params.append(shredded_at)
+        if facts_columns["metadata"]:
+            set_clauses.append("metadata = ?")
+            params.append(
+                self._tombstone_metadata(
+                    fact_id=fact_id,
+                    tenant_id=tenant_id,
+                    shredded_at=shredded_at,
+                    reason=reason,
+                    shredded_by=shredded_by,
+                )
+            )
+        if facts_columns["source"]:
+            set_clauses.append("source = ?")
+            params.append(_TOMBSTONE_SOURCE)
+        if facts_columns["tags"]:
+            set_clauses.append("tags = '[]'")
+
+        params.extend([fact_id, tenant_id])
+        self._conn.execute(
+            f"UPDATE facts SET {', '.join(set_clauses)} WHERE id = ? AND tenant_id = ?",
+            tuple(params),
+        )
+
+        for statement, statement_params in self._purge_related_surfaces_sql(fact_id):
+            self._conn.execute(statement, statement_params)
+
+    async def _redact_fact_surfaces_async(
+        self,
+        fact_id: int,
+        tenant_id: str,
+        reason: str,
+        shredded_by: Optional[str],
+        shredded_at: str,
+    ) -> None:
+        facts_columns = {
+            "valid_until": await self._column_exists_async("facts", "valid_until"),
+            "is_tombstoned": await self._column_exists_async("facts", "is_tombstoned"),
+            "updated_at": await self._column_exists_async("facts", "updated_at"),
+            "metadata": await self._column_exists_async("facts", "metadata"),
+            "source": await self._column_exists_async("facts", "source"),
+            "tags": await self._column_exists_async("facts", "tags"),
+        }
+
+        set_clauses = ["content = ?"]
+        params: list[Any] = [_TOMBSTONE_CONTENT]
+
+        if facts_columns["valid_until"]:
+            set_clauses.append("valid_until = ?")
+            params.append(shredded_at)
+        if facts_columns["is_tombstoned"]:
+            set_clauses.append("is_tombstoned = 1")
+        if facts_columns["updated_at"]:
+            set_clauses.append("updated_at = ?")
+            params.append(shredded_at)
+        if facts_columns["metadata"]:
+            set_clauses.append("metadata = ?")
+            params.append(
+                self._tombstone_metadata(
+                    fact_id=fact_id,
+                    tenant_id=tenant_id,
+                    shredded_at=shredded_at,
+                    reason=reason,
+                    shredded_by=shredded_by,
+                )
+            )
+        if facts_columns["source"]:
+            set_clauses.append("source = ?")
+            params.append(_TOMBSTONE_SOURCE)
+        if facts_columns["tags"]:
+            set_clauses.append("tags = '[]'")
+
+        params.extend([fact_id, tenant_id])
+        await self._conn.execute(  # type: ignore[reportAttributeAccessIssue]
+            f"UPDATE facts SET {', '.join(set_clauses)} WHERE id = ? AND tenant_id = ?",
+            tuple(params),
+        )
+
+        for statement, statement_params in await self._purge_related_surfaces_sql_async(fact_id):
+            await self._conn.execute(statement, statement_params)  # type: ignore[reportAttributeAccessIssue]
+
+    def _purge_related_surfaces_sql(self, fact_id: int) -> list[tuple[str, tuple[Any, ...]]]:
+        if self._is_async_connection():
+            raise TypeError("Use async APIs for async connections")
+        statements: list[tuple[str, tuple[Any, ...]]] = []
+        if self._table_exists("fact_embeddings"):
+            statements.append(("DELETE FROM fact_embeddings WHERE fact_id = ?", (fact_id,)))
+        if self._table_exists("facts_fts"):
+            statements.append(("DELETE FROM facts_fts WHERE rowid = ?", (fact_id,)))
+        if self._table_exists("enrichment_jobs"):
+            statements.append(("DELETE FROM enrichment_jobs WHERE fact_id = ?", (fact_id,)))
+        return statements
+
+    async def _purge_related_surfaces_sql_async(
+        self, fact_id: int
+    ) -> list[tuple[str, tuple[Any, ...]]]:
+        statements: list[tuple[str, tuple[Any, ...]]] = []
+        if await self._table_exists_async("fact_embeddings"):
+            statements.append(("DELETE FROM fact_embeddings WHERE fact_id = ?", (fact_id,)))
+        if await self._table_exists_async("facts_fts"):
+            statements.append(("DELETE FROM facts_fts WHERE rowid = ?", (fact_id,)))
+        if await self._table_exists_async("enrichment_jobs"):
+            statements.append(("DELETE FROM enrichment_jobs WHERE fact_id = ?", (fact_id,)))
+        return statements
 
     async def _ensure_schema_async(self) -> None:
         """Async variant for aiosqlite connections."""
@@ -114,9 +307,9 @@ class CryptoShredder:
 
     def is_shredded(self, fact_id: int, tenant_id: str = "default") -> bool:
         """Check if a fact's key has been shredded (sync)."""
-        if not isinstance(self._conn, sqlite3.Connection):
+        if self._is_async_connection():
             raise TypeError("Use is_shredded_async for async connections")
-        cursor = self._conn.execute(
+        cursor: Any = self._conn.execute(
             "SELECT 1 FROM shredded_keys WHERE fact_id = ? AND tenant_id = ?",
             (fact_id, tenant_id),
         )
@@ -132,9 +325,9 @@ class CryptoShredder:
 
     def get_shredded_fact_ids(self, tenant_id: str = "default") -> set[int]:
         """Return all shredded fact IDs for a tenant (sync)."""
-        if not isinstance(self._conn, sqlite3.Connection):
+        if self._is_async_connection():
             raise TypeError("Use get_shredded_fact_ids_async for async")
-        cursor = self._conn.execute(
+        cursor: Any = self._conn.execute(
             "SELECT fact_id FROM shredded_keys WHERE tenant_id = ?",
             (tenant_id,),
         )
@@ -164,8 +357,17 @@ class CryptoShredder:
         This also invalidates the HKDF-derived key from the encrypter's cache
         to prevent in-memory access after shredding.
         """
-        if not isinstance(self._conn, sqlite3.Connection):
+        if self._is_async_connection():
             raise TypeError("Use shred_fact_async for async connections")
+
+        if self._fact_row(fact_id, tenant_id) is None:
+            return ShredResult(
+                fact_id=fact_id,
+                tenant_id=tenant_id,
+                success=False,
+                reason=reason,
+                error="fact_not_found",
+            )
 
         # Check if already shredded
         if self.is_shredded(fact_id, tenant_id):
@@ -179,11 +381,19 @@ class CryptoShredder:
 
         try:
             ts = datetime.fromtimestamp(time.time(), tz=timezone.utc).isoformat()
+            self._conn.execute("BEGIN IMMEDIATE")
             self._conn.execute(
                 "INSERT INTO shredded_keys "
                 "(fact_id, tenant_id, reason, shredded_by, shredded_at) "
                 "VALUES (?, ?, ?, ?, ?)",
                 (fact_id, tenant_id, reason, shredded_by, ts),
+            )
+            self._redact_fact_surfaces(
+                fact_id,
+                tenant_id,
+                reason,
+                shredded_by,
+                ts,
             )
 
             # Invalidate the fact-specific derived key from the encrypter cache
@@ -203,6 +413,7 @@ class CryptoShredder:
                 reason=reason,
             )
         except sqlite3.IntegrityError:
+            self._conn.rollback()
             return ShredResult(
                 fact_id=fact_id,
                 tenant_id=tenant_id,
@@ -211,6 +422,7 @@ class CryptoShredder:
                 was_already_shredded=True,
             )
         except (sqlite3.Error, OSError) as e:
+            self._conn.rollback()
             logger.error("Shred failed for fact #%d: %s", fact_id, e)
             return ShredResult(
                 fact_id=fact_id,
@@ -228,6 +440,15 @@ class CryptoShredder:
         shredded_by: Optional[str] = None,
     ) -> ShredResult:
         """Destroy the encryption key for a single fact (async)."""
+        await self._ensure_schema_async()
+        if await self._fact_row_async(fact_id, tenant_id) is None:
+            return ShredResult(
+                fact_id=fact_id,
+                tenant_id=tenant_id,
+                success=False,
+                reason=reason,
+                error="fact_not_found",
+            )
         if await self.is_shredded_async(fact_id, tenant_id):
             return ShredResult(
                 fact_id=fact_id,
@@ -239,11 +460,19 @@ class CryptoShredder:
 
         try:
             ts = datetime.fromtimestamp(time.time(), tz=timezone.utc).isoformat()
+            await self._conn.execute("BEGIN IMMEDIATE")  # type: ignore[reportAttributeAccessIssue]
             await self._conn.execute(  # type: ignore[reportAttributeAccessIssue]
                 "INSERT INTO shredded_keys "
                 "(fact_id, tenant_id, reason, shredded_by, shredded_at) "
                 "VALUES (?, ?, ?, ?, ?)",
                 (fact_id, tenant_id, reason, shredded_by, ts),
+            )
+            await self._redact_fact_surfaces_async(
+                fact_id,
+                tenant_id,
+                reason,
+                shredded_by,
+                ts,
             )
 
             self._invalidate_fact_key(fact_id, tenant_id)
@@ -262,6 +491,7 @@ class CryptoShredder:
                 reason=reason,
             )
         except sqlite3.IntegrityError:
+            await self._conn.rollback()  # type: ignore[reportAttributeAccessIssue]
             return ShredResult(
                 fact_id=fact_id,
                 tenant_id=tenant_id,
@@ -270,6 +500,7 @@ class CryptoShredder:
                 was_already_shredded=True,
             )
         except (sqlite3.Error, OSError) as e:
+            await self._conn.rollback()  # type: ignore[reportAttributeAccessIssue]
             logger.error("Shred failed for fact #%d: %s", fact_id, e)
             return ShredResult(
                 fact_id=fact_id,

--- a/docs/compliance/CRYPTO_SHREDDING_EXECUTABLE_EVIDENCE.md
+++ b/docs/compliance/CRYPTO_SHREDDING_EXECUTABLE_EVIDENCE.md
@@ -1,0 +1,31 @@
+# Crypto-Shredding Executable Evidence
+
+Status: implemented evidence for issue `#285`.
+
+## What the repository demonstrates now
+
+- A fact can be marked as erased in `shredded_keys`.
+- Mutable payload surfaces in `facts` are replaced with a non-PII tombstone.
+- Mutable retrieval/index surfaces are purged for the erased fact:
+  - `facts_fts`
+  - `fact_embeddings`
+  - pending `enrichment_jobs`
+- Ledger continuity remains valid because `ledger_events` is not mutated by the erasure path.
+- Subject-scoped erasure can be executed through `shred_by_source(...)`.
+
+## What the repository does not claim yet
+
+- Per-fact envelope-key destruction proven independently of payload-surface redaction.
+- Backup/media destruction outside the live SQLite surfaces touched by this module.
+- External anchor or third-party cache erasure.
+
+## Evidence tests
+
+- `tests/test_crypto_shredding_end_to_end.py`
+- `tests/test_crypto_shredder.py`
+
+## Residual limitation
+
+The current codebase proves executable unreadability of mutable fact surfaces and
+search indexes. It does not, by itself, prove a fully separated per-fact key
+hierarchy across every encrypted field in the repository.

--- a/tests/test_crypto_shredding_end_to_end.py
+++ b/tests/test_crypto_shredding_end_to_end.py
@@ -1,0 +1,294 @@
+import json
+import sqlite3
+
+import aiosqlite
+import pytest
+
+from cortex.crypto.aes import CortexEncrypter
+from cortex.crypto.shredder import CryptoShredder
+from cortex.database.schema import CREATE_FACTS
+from cortex.database.schema_extensions import CREATE_FACTS_FTS
+from cortex.engine.fact_store_core import insert_fact_record
+from cortex.ledger.models import ActionResult, ActionTarget, LedgerEvent
+from cortex.ledger.queue import EnrichmentQueue
+from cortex.ledger.store import LedgerStore
+from cortex.ledger.verifier import LedgerVerifier
+from cortex.ledger.writer import LedgerWriter
+
+TEST_MASTER_KEY = b"2" * 32
+
+
+async def _setup_fact_db(conn: aiosqlite.Connection) -> None:
+    await conn.executescript("""
+        CREATE TABLE causal_edges (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            fact_id INTEGER NOT NULL,
+            parent_id INTEGER,
+            signal_id INTEGER,
+            edge_type TEXT NOT NULL DEFAULT 'triggered_by',
+            project TEXT,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        CREATE TABLE fact_tags (
+            fact_id INTEGER NOT NULL,
+            tag TEXT NOT NULL,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            PRIMARY KEY (fact_id, tag)
+        );
+        CREATE TABLE fact_embeddings (
+            fact_id INTEGER PRIMARY KEY,
+            embedding BLOB,
+            k INTEGER,
+            distance REAL
+        );
+        CREATE TABLE enrichment_jobs (
+            fact_id INTEGER PRIMARY KEY,
+            job_type TEXT NOT NULL,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE TABLE transactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            hash TEXT NOT NULL,
+            timestamp TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+    """)
+    for stmt in CREATE_FACTS.strip().split(";"):
+        s = stmt.strip()
+        if s:
+            await conn.execute(s + ";")
+    await conn.executescript(CREATE_FACTS_FTS)
+    await conn.commit()
+
+
+def _setup_fact_db_sync(conn: sqlite3.Connection) -> None:
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS facts (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id TEXT NOT NULL DEFAULT 'default',
+            project TEXT NOT NULL,
+            content TEXT NOT NULL,
+            fact_type TEXT NOT NULL DEFAULT 'knowledge',
+            metadata TEXT DEFAULT '{}',
+            hash TEXT,
+            valid_until TEXT,
+            source TEXT,
+            confidence TEXT DEFAULT 'C3',
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            is_tombstoned INTEGER NOT NULL DEFAULT 0,
+            tags TEXT DEFAULT '[]'
+        );
+        CREATE TABLE IF NOT EXISTS fact_embeddings (
+            fact_id INTEGER PRIMARY KEY,
+            embedding BLOB
+        );
+        CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts USING fts5(content, project, tags, fact_type, tenant_id);
+        CREATE TABLE IF NOT EXISTS enrichment_jobs (
+            fact_id INTEGER PRIMARY KEY,
+            job_type TEXT NOT NULL,
+            status TEXT NOT NULL,
+            priority INTEGER NOT NULL DEFAULT 0
+        );
+    """)
+    conn.commit()
+
+
+@pytest.fixture
+def encrypter() -> CortexEncrypter:
+    return CortexEncrypter(TEST_MASTER_KEY)
+
+
+@pytest.mark.asyncio
+async def test_crypto_shred_fact_redacts_payload_and_indexes(monkeypatch, encrypter):
+    monkeypatch.setattr("cortex.crypto.get_default_encrypter", lambda: encrypter)
+
+    conn = await aiosqlite.connect(":memory:")
+    await _setup_fact_db(conn)
+
+    fact_id = await insert_fact_record(
+        conn,
+        tenant_id="default",
+        project="gdpr",
+        content="alice@example.com visited Madrid branch",
+        fact_type="knowledge",
+        tags=["customer", "retail"],
+        confidence="C5",
+        ts=None,
+        source="user:alice@example.com",
+        meta={"subject_ref": "customer:alice"},
+        tx_id=None,
+    )
+    await conn.execute(
+        "INSERT OR REPLACE INTO fact_embeddings (fact_id, embedding, k, distance) VALUES (?, ?, ?, ?)",
+        (fact_id, b"vec", 1, 0.0),
+    )
+    await conn.commit()
+
+    async with conn.execute("SELECT content FROM facts WHERE id = ?", (fact_id,)) as cursor:
+        row = await cursor.fetchone()
+    assert row[0].startswith(encrypter.PREFIX)
+    assert "alice@example.com" not in row[0]
+
+    shredder = CryptoShredder(conn)
+    result = await shredder.shred_fact_async(fact_id, shredded_by="dpo")
+    assert result.success
+
+    async with conn.execute(
+        "SELECT content, metadata, source, tags, is_tombstoned FROM facts WHERE id = ?",
+        (fact_id,),
+    ) as cursor:
+        fact_row = await cursor.fetchone()
+
+    assert fact_row[0] == "CORTEX_ERASURE_TOMBSTONE"
+    assert fact_row[2] == "subject-erased"
+    assert fact_row[3] == "[]"
+    assert fact_row[4] == 1
+
+    tombstone_meta = json.loads(fact_row[1])
+    assert tombstone_meta["erasure_status"] == "shredded"
+    assert tombstone_meta["tombstone_reason"] == "gdpr_erasure"
+    assert "alice@example.com" not in fact_row[1]
+
+    async with conn.execute("SELECT COUNT(*) FROM facts_fts WHERE rowid = ?", (fact_id,)) as cursor:
+        assert (await cursor.fetchone())[0] == 0
+    async with conn.execute(
+        "SELECT COUNT(*) FROM fact_embeddings WHERE fact_id = ?",
+        (fact_id,),
+    ) as cursor:
+        assert (await cursor.fetchone())[0] == 0
+    async with conn.execute(
+        "SELECT COUNT(*) FROM enrichment_jobs WHERE fact_id = ?",
+        (fact_id,),
+    ) as cursor:
+        assert (await cursor.fetchone())[0] == 0
+
+    await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_crypto_shred_by_source_is_subject_scoped(monkeypatch, encrypter):
+    monkeypatch.setattr("cortex.crypto.get_default_encrypter", lambda: encrypter)
+
+    conn = await aiosqlite.connect(":memory:")
+    await _setup_fact_db(conn)
+
+    alice_one = await insert_fact_record(
+        conn,
+        tenant_id="default",
+        project="gdpr",
+        content="alice@example.com first fact",
+        fact_type="knowledge",
+        tags=["customer"],
+        confidence="C5",
+        ts=None,
+        source="user:alice@example.com",
+        meta={"subject_ref": "customer:alice"},
+        tx_id=None,
+    )
+    alice_two = await insert_fact_record(
+        conn,
+        tenant_id="default",
+        project="gdpr",
+        content="alice@example.com second fact",
+        fact_type="knowledge",
+        tags=["customer"],
+        confidence="C5",
+        ts=None,
+        source="user:alice@example.com",
+        meta={"subject_ref": "customer:alice"},
+        tx_id=None,
+    )
+    bob_one = await insert_fact_record(
+        conn,
+        tenant_id="default",
+        project="gdpr",
+        content="bob@example.com retained fact",
+        fact_type="knowledge",
+        tags=["customer"],
+        confidence="C5",
+        ts=None,
+        source="user:bob@example.com",
+        meta={"subject_ref": "customer:bob"},
+        tx_id=None,
+    )
+    await conn.executemany(
+        "INSERT OR REPLACE INTO fact_embeddings (fact_id, embedding, k, distance) VALUES (?, ?, ?, ?)",
+        [(alice_one, b"vec", 1, 0.0), (alice_two, b"vec", 1, 0.0), (bob_one, b"vec", 1, 0.0)],
+    )
+    await conn.commit()
+
+    shredder = CryptoShredder(conn)
+    batch = await shredder.shred_by_source("user:alice@example.com", shredded_by="dpo")
+
+    assert batch.total_requested == 2
+    assert batch.shredded == 2
+    assert batch.failed == 0
+
+    async with conn.execute(
+        "SELECT id, content, source, is_tombstoned FROM facts ORDER BY id"
+    ) as cursor:
+        rows = await cursor.fetchall()
+
+    erased_rows = {row[0]: row for row in rows if row[0] in {alice_one, alice_two}}
+    for row in erased_rows.values():
+        assert row[1] == "CORTEX_ERASURE_TOMBSTONE"
+        assert row[2] == "subject-erased"
+        assert row[3] == 1
+
+    retained_row = next(row for row in rows if row[0] == bob_one)
+    assert retained_row[1].startswith(encrypter.PREFIX)
+    assert retained_row[2] == "user:bob@example.com"
+    assert retained_row[3] == 0
+
+    await conn.close()
+
+
+def test_crypto_shred_preserves_ledger_continuity(tmp_path):
+    db_path = tmp_path / "crypto_shred_ledger.db"
+
+    store = LedgerStore(str(db_path))
+    queue = EnrichmentQueue(store)
+    writer = LedgerWriter(store, queue)
+    verifier = LedgerVerifier(store)
+
+    target = ActionTarget(app="Test")
+    result = ActionResult(ok=True, latency_ms=5)
+    for idx in range(3):
+        writer.append(
+            LedgerEvent.new(
+                tool="cli",
+                actor="tester",
+                action=f"fact-{idx}",
+                target=target,
+                result=result,
+                metadata={"project": "gdpr"},
+            )
+        )
+
+    before = verifier.verify_chain()
+    assert before["valid"]
+
+    conn = sqlite3.connect(db_path)
+    _setup_fact_db_sync(conn)
+    conn.execute(
+        "INSERT INTO facts (id, tenant_id, project, content, source, metadata) VALUES (?, ?, ?, ?, ?, ?)",
+        (1, "default", "gdpr", "secret payload", "user:alice@example.com", '{"subject_ref":"alice"}'),
+    )
+    conn.execute("INSERT INTO fact_embeddings (fact_id, embedding) VALUES (?, ?)", (1, b"vec"))
+    conn.execute(
+        "INSERT INTO facts_fts (rowid, content, project, tags, fact_type, tenant_id) VALUES (?, ?, ?, ?, ?, ?)",
+        (1, "secret payload", "gdpr", "[]", "knowledge", "default"),
+    )
+    conn.commit()
+
+    shredder = CryptoShredder(conn)
+    shred = shredder.shred_fact(1, shredded_by="dpo")
+    assert shred.success
+
+    after = verifier.verify_chain()
+    assert after["valid"]
+    assert after["checked_events"] == before["checked_events"]
+
+    conn.close()


### PR DESCRIPTION
## Summary
- make the crypto shredder erase mutable fact payload surfaces and retrieval side effects
- add executable evidence for fact-scoped and source-scoped erasure without mutating ledger continuity
- document the demonstrated boundary and residual limitations honestly

## Testing
- pytest -q tests/test_crypto_shredding_end_to_end.py tests/test_crypto_shredder.py
- ruff check cortex/crypto/shredder.py tests/test_crypto_shredding_end_to_end.py
- pyright cortex/crypto/shredder.py tests/test_crypto_shredding_end_to_end.py
- python3 -m py_compile cortex/crypto/shredder.py tests/test_crypto_shredding_end_to_end.py

## Notes
- closes #285
- scope is intentionally limited to executable evidence on mutable fact surfaces (`facts`, `facts_fts`, `fact_embeddings`, `enrichment_jobs`)
- this PR does not claim a repository-proven per-fact envelope-key hierarchy beyond what the code actually enforces today
