### PR TITLE
feat: add human oversight runtime controls

### DIFF
--- a/cortex/extensions/gate/__init__.py
+++ b/cortex/extensions/gate/__init__.py
@@ -5,12 +5,13 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cortex.extensions.gate.core import SovereignGate, get_gate, reset_gate
-    from cortex.extensions.gate.enums import ActionLevel, ActionStatus, GatePolicy
+    from cortex.extensions.gate.enums import ActionLevel, ActionStatus, GatePolicy, OversightState
     from cortex.extensions.gate.errors import (
         GateError,
         GateExpired,
         GateInvalidSignature,
         GateNotApproved,
+        GateUnauthorizedReviewer,
     )
     from cortex.extensions.gate.models import PendingAction
 
@@ -22,6 +23,8 @@ __all__ = [
     "GateInvalidSignature",
     "GateNotApproved",
     "GatePolicy",
+    "GateUnauthorizedReviewer",
+    "OversightState",
     "PendingAction",
     "SovereignGate",
     "get_gate",
@@ -31,10 +34,12 @@ __all__ = [
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "ActionLevel": ("cortex.extensions.gate.enums", "ActionLevel"),
     "ActionStatus": ("cortex.extensions.gate.enums", "ActionStatus"),
+    "OversightState": ("cortex.extensions.gate.enums", "OversightState"),
     "GateError": ("cortex.extensions.gate.errors", "GateError"),
     "GateExpired": ("cortex.extensions.gate.errors", "GateExpired"),
     "GateInvalidSignature": ("cortex.extensions.gate.errors", "GateInvalidSignature"),
     "GateNotApproved": ("cortex.extensions.gate.errors", "GateNotApproved"),
+    "GateUnauthorizedReviewer": ("cortex.extensions.gate.errors", "GateUnauthorizedReviewer"),
     "GatePolicy": ("cortex.extensions.gate.enums", "GatePolicy"),
     "PendingAction": ("cortex.extensions.gate.models", "PendingAction"),
     "SovereignGate": ("cortex.extensions.gate.core", "SovereignGate"),

--- a/cortex/extensions/gate/core.py
+++ b/cortex/extensions/gate/core.py
@@ -16,8 +16,14 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from .errors import GateError, GateExpired, GateInvalidSignature, GateNotApproved
-from .models import ActionLevel, ActionStatus, GatePolicy, PendingAction
+from .errors import (
+    GateError,
+    GateExpired,
+    GateInvalidSignature,
+    GateNotApproved,
+    GateUnauthorizedReviewer,
+)
+from .models import ActionLevel, ActionStatus, GatePolicy, OversightState, PendingAction
 
 __all__ = ["SovereignGate", "get_gate", "reset_gate"]
 
@@ -41,6 +47,9 @@ class SovereignGate:
     """
 
     DEFAULT_TIMEOUT = 300  # 5 minutes
+    DEFAULT_AUTHORIZED_REVIEWER_ROLES = frozenset(
+        {"operator", "risk_officer", "compliance_officer", "human_reviewer", "admin"}
+    )
 
     def __init__(
         self,
@@ -75,6 +84,7 @@ class SovereignGate:
 
         self._pending: dict[str, PendingAction] = {}
         self._audit_log: collections.deque[dict[str, Any]] = collections.deque(maxlen=10_000)
+        self._authorized_reviewer_roles = set(self.DEFAULT_AUTHORIZED_REVIEWER_ROLES)
 
         logger.info(
             "SovereignGate initialized — policy=%s timeout=%ds",
@@ -91,6 +101,10 @@ class SovereignGate:
         command: Optional[list[str]] = None,
         project: Optional[str] = None,
         context: Optional[dict[str, Any]] = None,
+        *,
+        high_risk: bool = False,
+        limitations: Optional[list[str]] = None,
+        provenance: Optional[dict[str, Any]] = None,
     ) -> PendingAction:
         """
         Register an L3/L4 action and generate an HMAC challenge.
@@ -125,6 +139,15 @@ class SovereignGate:
             project=project,
             context=context or {},
             hmac_challenge=challenge,
+            high_risk=high_risk,
+            requires_human_review=high_risk,
+            limitations=limitations or [],
+            provenance=provenance or {},
+            oversight_state=(
+                OversightState.REVIEW_REQUIRED
+                if high_risk
+                else OversightState.MACHINE_RECOMMENDATION
+            ),
         )
 
         self._pending[action_id] = action
@@ -144,6 +167,10 @@ class SovereignGate:
         action_id: str,
         signature: str,
         operator_id: str = "operator",
+        reviewer_role: Optional[str] = None,
+        reason_code: Optional[str] = None,
+        auth_method: str = "hmac",
+        strong_auth_token: Optional[str] = None,
     ) -> bool:
         """
         Approve an action with HMAC signature verification.
@@ -163,6 +190,24 @@ class SovereignGate:
             self._log_audit("INVALID_SIGNATURE", action)
             raise GateInvalidSignature(f"Invalid signature for action {action_id}")
 
+        if action.requires_human_review:
+            self._validate_human_review(
+                action,
+                reviewer_id=operator_id,
+                reviewer_role=reviewer_role,
+                reason_code=reason_code,
+                auth_method=auth_method,
+                strong_auth_token=strong_auth_token,
+            )
+            action.reviewed_at = time.time()
+            action.reviewer_id = operator_id
+            action.reviewer_role = reviewer_role
+            action.reason_code = reason_code
+            action.auth_method = auth_method
+            action.strong_auth_token = strong_auth_token
+            action.oversight_state = OversightState.HUMAN_REVIEWED
+            self._log_audit("ACTION_HUMAN_REVIEWED", action)
+
         action.status = ActionStatus.APPROVED
         action.approved_at = time.time()
         action.operator_id = operator_id
@@ -173,6 +218,51 @@ class SovereignGate:
             action_id,
             operator_id,
         )
+        return True
+
+    def override(
+        self,
+        action_id: str,
+        signature: str,
+        operator_id: str,
+        reviewer_role: str,
+        reason_code: str,
+        auth_method: str = "hmac",
+        strong_auth_token: Optional[str] = None,
+    ) -> bool:
+        """Apply an audited human override for a high-risk action."""
+        action = self._get_action(action_id)
+
+        if action.is_expired(self.timeout):
+            action.status = ActionStatus.EXPIRED
+            self._log_audit("ACTION_EXPIRED", action)
+            raise GateExpired(f"Action {action_id} expired after {self.timeout}s")
+
+        if not hmac.compare_digest(signature, action.hmac_challenge):
+            self._log_audit("INVALID_SIGNATURE", action)
+            raise GateInvalidSignature(f"Invalid signature for action {action_id}")
+
+        self._validate_human_review(
+            action,
+            reviewer_id=operator_id,
+            reviewer_role=reviewer_role,
+            reason_code=reason_code,
+            auth_method=auth_method,
+            strong_auth_token=strong_auth_token,
+        )
+        action.status = ActionStatus.APPROVED
+        action.approved_at = time.time()
+        action.operator_id = operator_id
+        action.reviewed_at = action.reviewed_at or time.time()
+        action.overridden_at = time.time()
+        action.reviewer_id = operator_id
+        action.reviewer_role = reviewer_role
+        action.override_reason_code = reason_code
+        action.reason_code = action.reason_code or reason_code
+        action.auth_method = auth_method
+        action.strong_auth_token = strong_auth_token
+        action.oversight_state = OversightState.HUMAN_OVERRIDE
+        self._log_audit("ACTION_HUMAN_OVERRIDE", action)
         return True
 
     def approve_interactive(self, action_id: str) -> bool:
@@ -257,6 +347,14 @@ class SovereignGate:
         if action.status != ActionStatus.APPROVED:
             raise GateNotApproved(f"Action {action_id} is {action.status.value}, not approved")
 
+        if action.requires_human_review and action.oversight_state not in {
+            OversightState.HUMAN_REVIEWED,
+            OversightState.HUMAN_OVERRIDE,
+        }:
+            raise GateNotApproved(
+                f"Action {action_id} is missing effective human review for final effect"
+            )
+
         if action.is_expired(self.timeout):
             action.status = ActionStatus.EXPIRED
             self._log_audit("ACTION_EXPIRED_PRE_EXEC", action)
@@ -272,6 +370,7 @@ class SovereignGate:
             "stdout_len": len(result.stdout or ""),
             "stderr_len": len(result.stderr or ""),
         }
+        action.oversight_state = OversightState.FINAL_EFFECT_EXECUTED
         self._log_audit("ACTION_EXECUTED", action)
         return result
 
@@ -312,6 +411,31 @@ class SovereignGate:
         if action is None:
             raise GateError(f"Unknown action ID: {action_id}")
         return action
+
+    def _validate_human_review(
+        self,
+        action: PendingAction,
+        *,
+        reviewer_id: str,
+        reviewer_role: Optional[str],
+        reason_code: Optional[str],
+        auth_method: str,
+        strong_auth_token: Optional[str],
+    ) -> None:
+        if not reviewer_id:
+            raise GateUnauthorizedReviewer("reviewer_id is required for human review")
+        if not reviewer_role:
+            raise GateUnauthorizedReviewer("reviewer_role is required for high-risk approval")
+        if reviewer_role not in self._authorized_reviewer_roles:
+            raise GateUnauthorizedReviewer(f"unauthorized reviewer role: {reviewer_role}")
+        if not reason_code:
+            raise GateUnauthorizedReviewer("reason_code is required for high-risk approval")
+        if not auth_method:
+            raise GateUnauthorizedReviewer("auth_method is required for high-risk approval")
+        if auth_method != "hmac" and not strong_auth_token:
+            raise GateUnauthorizedReviewer(
+                "strong_auth_token is required when auth_method is not hmac"
+            )
 
     def _sweep_expired(self) -> int:
         """Mark expired pending actions. Returns count of expired."""

--- a/cortex/extensions/gate/enums.py
+++ b/cortex/extensions/gate/enums.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 
-__all__ = ["ActionLevel", "GatePolicy", "ActionStatus"]
+__all__ = ["ActionLevel", "GatePolicy", "ActionStatus", "OversightState"]
 
 
 class ActionLevel(str, Enum):
@@ -31,3 +31,13 @@ class ActionStatus(str, Enum):
     EXPIRED = "expired"
     EXECUTED = "executed"
     FAILED = "failed"
+
+
+class OversightState(str, Enum):
+    """Human-oversight lifecycle for regulated or high-risk actions."""
+
+    MACHINE_RECOMMENDATION = "machine_recommendation"
+    REVIEW_REQUIRED = "review_required"
+    HUMAN_REVIEWED = "human_reviewed"
+    HUMAN_OVERRIDE = "human_override"
+    FINAL_EFFECT_EXECUTED = "final_effect_executed"

--- a/cortex/extensions/gate/errors.py
+++ b/cortex/extensions/gate/errors.py
@@ -7,6 +7,7 @@ __all__ = [
     "GateExpired",
     "GateInvalidSignature",
     "GateNotApproved",
+    "GateUnauthorizedReviewer",
 ]
 
 
@@ -24,3 +25,7 @@ class GateExpired(GateError):
 
 class GateInvalidSignature(GateError):
     """HMAC signature does not match."""
+
+
+class GateUnauthorizedReviewer(GateError):
+    """Reviewer lacks the required role or evidence fields."""

--- a/cortex/extensions/gate/models.py
+++ b/cortex/extensions/gate/models.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Optional
 
-from .enums import ActionLevel, ActionStatus, GatePolicy
+from .enums import ActionLevel, ActionStatus, GatePolicy, OversightState
 
 __all__ = ["PendingAction", "GatePolicy"]
 
@@ -23,11 +23,24 @@ class PendingAction:
     project: Optional[str] = None
     context: dict[str, Any] = field(default_factory=dict)
     status: ActionStatus = ActionStatus.PENDING
+    oversight_state: OversightState = OversightState.MACHINE_RECOMMENDATION
     created_at: float = field(default_factory=time.time)
     approved_at: Optional[float] = None
+    reviewed_at: Optional[float] = None
+    overridden_at: Optional[float] = None
     executed_at: Optional[float] = None
     hmac_challenge: str = ""
     operator_id: Optional[str] = None
+    reviewer_id: Optional[str] = None
+    reviewer_role: Optional[str] = None
+    reason_code: Optional[str] = None
+    auth_method: Optional[str] = None
+    strong_auth_token: Optional[str] = None
+    override_reason_code: Optional[str] = None
+    high_risk: bool = False
+    requires_human_review: bool = False
+    limitations: list[str] = field(default_factory=list)
+    provenance: dict[str, Any] = field(default_factory=dict)
     result: Optional[dict[str, Any]] = None
 
     def is_expired(self, timeout_seconds: float) -> bool:
@@ -43,11 +56,30 @@ class PendingAction:
             "command": self.command,
             "project": self.project,
             "status": self.status.value,
+            "oversight_state": self.oversight_state.value,
             "created_at": datetime.fromtimestamp(self.created_at, tz=timezone.utc).isoformat(),
             "approved_at": (
                 datetime.fromtimestamp(self.approved_at, tz=timezone.utc).isoformat()
                 if self.approved_at
                 else None
             ),
+            "reviewed_at": (
+                datetime.fromtimestamp(self.reviewed_at, tz=timezone.utc).isoformat()
+                if self.reviewed_at
+                else None
+            ),
+            "overridden_at": (
+                datetime.fromtimestamp(self.overridden_at, tz=timezone.utc).isoformat()
+                if self.overridden_at
+                else None
+            ),
             "operator_id": self.operator_id,
+            "reviewer_id": self.reviewer_id,
+            "reviewer_role": self.reviewer_role,
+            "reason_code": self.reason_code,
+            "auth_method": self.auth_method,
+            "high_risk": self.high_risk,
+            "requires_human_review": self.requires_human_review,
+            "limitations": self.limitations,
+            "provenance": self.provenance,
         }

--- a/cortex/routes/gate.py
+++ b/cortex/routes/gate.py
@@ -11,6 +11,7 @@ from cortex.extensions.gate import (
     GateError,
     GateExpired,
     GateInvalidSignature,
+    GateUnauthorizedReviewer,
     get_gate,
 )
 from cortex.types.models import (
@@ -61,12 +62,48 @@ async def approve_action(
             action_id=action_id,
             signature=request.signature,
             operator_id=request.operator_id or "api",
+            reviewer_role=request.reviewer_role,
+            reason_code=request.reason_code,
+            auth_method=request.auth_method,
+            strong_auth_token=request.strong_auth_token,
         )
         action = gate._get_action(action_id)
         return GateActionResponse(**action.to_dict())
     except GateExpired as e:
         raise HTTPException(status_code=410, detail=str(e)) from None
     except GateInvalidSignature as e:
+        raise HTTPException(status_code=403, detail=str(e)) from None
+    except GateUnauthorizedReviewer as e:
+        raise HTTPException(status_code=403, detail=str(e)) from None
+    except GateError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from None
+
+
+@router.post("/{action_id}/override", response_model=GateActionResponse)
+async def override_action(
+    action_id: str,
+    request: GateApprovalRequest,
+    _=Depends(require_permission("write")),
+):
+    """Apply an audited human override for a high-risk action."""
+    gate = get_gate()
+    try:
+        gate.override(
+            action_id=action_id,
+            signature=request.signature,
+            operator_id=request.operator_id or "api",
+            reviewer_role=request.reviewer_role or "",
+            reason_code=request.reason_code or "",
+            auth_method=request.auth_method,
+            strong_auth_token=request.strong_auth_token,
+        )
+        action = gate._get_action(action_id)
+        return GateActionResponse(**action.to_dict())
+    except GateExpired as e:
+        raise HTTPException(status_code=410, detail=str(e)) from None
+    except GateInvalidSignature as e:
+        raise HTTPException(status_code=403, detail=str(e)) from None
+    except GateUnauthorizedReviewer as e:
         raise HTTPException(status_code=403, detail=str(e)) from None
     except GateError as e:
         raise HTTPException(status_code=404, detail=str(e)) from None

--- a/cortex/types/models.py
+++ b/cortex/types/models.py
@@ -470,6 +470,12 @@ class MejoraloShipResponse(BaseModel):
 class GateApprovalRequest(BaseModel):
     signature: str = Field(..., description="HMAC-SHA256 signature of the challenge")
     operator_id: str | None = Field(None, description="Operator identifier")
+    reviewer_role: str | None = Field(None, description="Authorized human reviewer role")
+    reason_code: str | None = Field(None, description="Structured human review reason code")
+    auth_method: str = Field("hmac", description="Authentication method used by the reviewer")
+    strong_auth_token: str | None = Field(
+        None, description="Strong-authentication evidence or reference when required"
+    )
 
 
 class GateActionResponse(BaseModel):
@@ -479,9 +485,20 @@ class GateActionResponse(BaseModel):
     command: list[str] | None = None
     project: str | None = None
     status: str
+    oversight_state: str
     created_at: str
     approved_at: str | None = None
+    reviewed_at: str | None = None
+    overridden_at: str | None = None
     operator_id: str | None = None
+    reviewer_id: str | None = None
+    reviewer_role: str | None = None
+    reason_code: str | None = None
+    auth_method: str | None = None
+    high_risk: bool = False
+    requires_human_review: bool = False
+    limitations: list[str] = Field(default_factory=list)
+    provenance: dict[str, Any] = Field(default_factory=dict)
 
 
 class GateStatusResponse(BaseModel):

--- a/tests/test_human_oversight_gate.py
+++ b/tests/test_human_oversight_gate.py
@@ -1,0 +1,125 @@
+from cortex.extensions.gate.core import SovereignGate
+from cortex.extensions.gate.enums import ActionLevel, GatePolicy, OversightState
+from cortex.extensions.gate.errors import GateNotApproved, GateUnauthorizedReviewer
+
+
+def _new_gate() -> SovereignGate:
+    return SovereignGate(policy=GatePolicy.ENFORCE, secret="test-secret", timeout=300)
+
+
+def test_high_risk_action_requires_human_review_before_final_effect() -> None:
+    gate = _new_gate()
+    action = gate.request_approval(
+        level=ActionLevel.L4_MUTATE,
+        description="Apply high-risk lending decision",
+        command=["python3", "-c", "print('ok')"],
+        project="banking",
+        context={"taint": "tainted", "event_context": {"decision_id": "dec-001"}},
+        high_risk=True,
+        limitations=["model recommendation only"],
+        provenance={"reason_codes": ["THALAMUS_REJECT", "LOW_CONFIDENCE"]},
+    )
+
+    assert action.oversight_state is OversightState.REVIEW_REQUIRED
+    assert action.requires_human_review is True
+
+    try:
+        gate.execute_subprocess(action.action_id, ["python3", "-c", "print('ok')"], capture_output=True, text=True)
+    except GateNotApproved:
+        pass
+    else:
+        raise AssertionError("high-risk action executed without human review")
+
+    approved = gate.approve(
+        action.action_id,
+        signature=action.hmac_challenge,
+        operator_id="reviewer-1",
+        reviewer_role="risk_officer",
+        reason_code="MANUAL_REVIEW_ACCEPTED",
+        auth_method="webauthn",
+        strong_auth_token="webauthn-assertion-001",
+    )
+    assert approved is True
+
+    result = gate.execute_subprocess(
+        action.action_id,
+        ["python3", "-c", "print('ok')"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+    persisted = gate._get_action(action.action_id)
+    assert persisted.oversight_state is OversightState.FINAL_EFFECT_EXECUTED
+    assert persisted.reviewer_role == "risk_officer"
+    assert persisted.reason_code == "MANUAL_REVIEW_ACCEPTED"
+    assert persisted.limitations == ["model recommendation only"]
+    assert persisted.provenance["reason_codes"] == ["THALAMUS_REJECT", "LOW_CONFIDENCE"]
+
+
+def test_high_risk_review_requires_authorized_role_and_reason_code() -> None:
+    gate = _new_gate()
+    action = gate.request_approval(
+        level=ActionLevel.L4_MUTATE,
+        description="Finalize adverse customer action",
+        high_risk=True,
+    )
+
+    try:
+        gate.approve(
+            action.action_id,
+            signature=action.hmac_challenge,
+            operator_id="reviewer-2",
+            reviewer_role="intern",
+            reason_code="MANUAL_REVIEW_ACCEPTED",
+        )
+    except GateUnauthorizedReviewer:
+        pass
+    else:
+        raise AssertionError("unauthorized reviewer role should be rejected")
+
+    try:
+        gate.approve(
+            action.action_id,
+            signature=action.hmac_challenge,
+            operator_id="reviewer-2",
+            reviewer_role="risk_officer",
+        )
+    except GateUnauthorizedReviewer:
+        pass
+    else:
+        raise AssertionError("missing reason_code should be rejected")
+
+
+def test_high_risk_override_is_audited_and_enables_execution() -> None:
+    gate = _new_gate()
+    action = gate.request_approval(
+        level=ActionLevel.L3_EXECUTE,
+        description="Release disputed payment block",
+        command=["python3", "-c", "print('override')"],
+        high_risk=True,
+    )
+
+    overridden = gate.override(
+        action.action_id,
+        signature=action.hmac_challenge,
+        operator_id="reviewer-3",
+        reviewer_role="compliance_officer",
+        reason_code="OVERRIDE_CASE_REOPENED",
+        auth_method="webauthn",
+        strong_auth_token="webauthn-assertion-002",
+    )
+    assert overridden is True
+
+    persisted = gate._get_action(action.action_id)
+    assert persisted.oversight_state is OversightState.HUMAN_OVERRIDE
+    assert persisted.override_reason_code == "OVERRIDE_CASE_REOPENED"
+
+    result = gate.execute_subprocess(
+        action.action_id,
+        ["python3", "-c", "print('override')"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert gate._get_action(action.action_id).oversight_state is OversightState.FINAL_EFFECT_EXECUTED


### PR DESCRIPTION
## Summary
- add a human-oversight lifecycle to SovereignGate for high-risk actions
- require authorized reviewer role, reason code, and audit evidence before final effect
- add audited override support and tests for recommendation -> review -> override -> final effect

## Testing
- pytest -q tests/test_human_oversight_gate.py
- ruff check cortex/extensions/gate cortex/routes/gate.py cortex/types/models.py tests/test_human_oversight_gate.py
- pyright cortex/extensions/gate cortex/routes/gate.py cortex/types/models.py tests/test_human_oversight_gate.py

## Notes
- closes #286
- high-risk final effect remains blocked until effective human review or audited override
- audit/API responses now carry limitations, provenance, reviewer role, reason code, and oversight state
