### PR TITLE
ci(pypi): add trusted publisher workflow for PyPI releasesAdd GitHub Actions workflow for publishing to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI
+
+on:
+  release:
+      types: [published]
+        workflow_dispatch:
+
+        permissions:
+          id-token: write
+            contents: read
+
+            jobs:
+              build:
+                  name: Build distribution
+                      runs-on: ubuntu-latest
+                          steps:
+                                - uses: actions/checkout@v4
+                                      - name: Set up Python
+                                              uses: actions/setup-python@v5
+                                                      with:
+                                                                python-version: "3.12"
+                                                                      - name: Install build tools
+                                                                              run: pip install build
+                                                                                    - name: Build package
+                                                                                            run: python -m build
+                                                                                                  - name: Upload artifacts
+                                                                                                          uses: actions/upload-artifact@v4
+                                                                                                                  with:
+                                                                                                                            name: python-package-distributions
+                                                                                                                                      path: dist/
+                                                                                                                                      
+                                                                                                                                        publish-pypi:
+                                                                                                                                            name: Publish to PyPI
+                                                                                                                                                needs: build
+                                                                                                                                                    runs-on: ubuntu-latest
+                                                                                                                                                        environment:
+                                                                                                                                                              name: pypi
+                                                                                                                                                                    url: https://pypi.org/p/cortex-persist
+                                                                                                                                                                        steps:
+                                                                                                                                                                              - name: Download artifacts
+                                                                                                                                                                                      uses: actions/download-artifact@v4
+                                                                                                                                                                                              with:
+                                                                                                                                                                                                        name: python-package-distributions
+                                                                                                                                                                                                                  path: dist/
+                                                                                                                                                                                                                        - name: Publish to PyPI
+                                                                                                                                                                                                                                uses: pypa/gh-action-pypi-publish@release/v1
+                                                                                                                                                                                                                                


### PR DESCRIPTION
This workflow automates the process of building and publishing a Python package to PyPI upon release.

## What does this PR do?

<!-- Brief description of the change -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix

## Checklist

- [ ] Tests pass (`make test`)
- [ ] Linter passes (`make lint`)
- [ ] No hardcoded secrets or API keys
- [ ] Documentation updated (if applicable)
- [ ] CHANGELOG.md updated (if user-facing)
