### PR TITLE
Codecov: require 100% project/patch coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,43 +2,37 @@
 # https://docs.codecov.com/docs/codecov-yaml
 
 coverage:
+  precision: 2
+  round: down
+  range: "95...100"
+
   status:
     project:
       default:
-        target: auto          # maintain or improve coverage
-        threshold: 1%         # allow up to 1% drop
-        if_not_found: success
+        target: 100%
+        threshold: 0%
         if_ci_failed: error
+
     patch:
       default:
-        target: 80%           # new code must have at least 80% coverage
-        threshold: 5%
-        if_not_found: success
+        target: 100%
+        threshold: 0%
         if_ci_failed: error
 
 ignore:
   - "tests/**"
   - "scripts/**"
-  - "**/conftest.py"
+  - "docs/**"
+  - "benchmarks/**"
+  - "examples/**"
+  - "experimental/**"
   - "**/__pycache__/**"
+  - "**/conftest.py"
+  - "setup.py"
 
 comment:
-  layout: "header, diff, flags, components"
+  layout: "reach,diff,flags,files"
   behavior: default
   require_changes: false
   require_base: false
   require_head: true
-
-parsers:
-  gcov:
-    branch_detection:
-      conditional: true
-      loop: true
-      method: false
-      macro: false
-
-flags:
-  unittests:
-    paths:
-      - cortex/
-    carryforward: false


### PR DESCRIPTION
## Changes
- Codecov status targets set to 100% (project + patch)
- Threshold set to 0% to disallow regressions

## Follow-ups
- Remove duplicate `.codecov.yml`
- Enforce `--cov-fail-under=100 --cov-branch` in CI
- Add `fail_under = 100` in coverage config