### PR TITLE
Refactor Crystal Consolidator to eliminate N+1 query patterns

### DIFF
--- a/cortex/extensions/swarm/crystal_consolidator.py
+++ b/cortex/extensions/swarm/crystal_consolidator.py
@@ -124,11 +124,10 @@ async def _execute_cold_purge(
                 placeholders = ",".join("?" * len(chunk))
 
                 cursor.execute(
-                    f"DELETE FROM vec_facts WHERE rowid IN "
-                    f"(SELECT rowid FROM facts_meta WHERE id IN ({placeholders}))",
+                    f"DELETE FROM vec_facts WHERE rowid IN (SELECT rowid FROM facts_meta WHERE id IN ({placeholders}))",  # noqa: S608
                     chunk,
                 )
-                cursor.execute(f"DELETE FROM facts_meta WHERE id IN ({placeholders})", chunk)
+                cursor.execute(f"DELETE FROM facts_meta WHERE id IN ({placeholders})", chunk)  # noqa: S608
 
             db_conn.commit()
 
@@ -186,7 +185,7 @@ async def _execute_semantic_merge(
                 SELECT f.id, f.content, v.embedding FROM facts_meta f
                 JOIN vec_facts v ON f.rowid = v.rowid
                 WHERE f.id IN ({placeholders})
-                """,
+                """,  # noqa: S608
                 chunk,
             )
 
@@ -302,7 +301,7 @@ async def _execute_diamond_promotion(
                 chunk = fact_ids[i:i + chunk_size]
                 placeholders = ",".join("?" * len(chunk))
                 cursor.execute(
-                    f"UPDATE facts_meta SET is_diamond = 1 WHERE id IN ({placeholders})",
+                    f"UPDATE facts_meta SET is_diamond = 1 WHERE id IN ({placeholders})",  # noqa: S608
                     chunk,
                 )
 

--- a/cortex/extensions/swarm/crystal_consolidator.py
+++ b/cortex/extensions/swarm/crystal_consolidator.py
@@ -92,32 +92,47 @@ async def _execute_cold_purge(
 
     logger.info("🗑️ [CONSOLIDATOR] Cold purge: %d candidates", len(purge_candidates))
 
-    for v in purge_candidates:
-        try:
-            if not dry_run:
-                cursor = db_conn.cursor()
-                # Soft delete: mark as deprecated in metadata
-                cursor.execute(
-                    """
-                    UPDATE facts_meta
-                    SET metadata = json_set(COALESCE(metadata, '{}'),
-                        '$.nightshift_purged', ?,
-                        '$.purge_reason', 'cold_dead_weight',
-                        '$.purge_temperature', ?,
-                        '$.purge_resonance', ?)
-                    WHERE id = ?
-                    """,
-                    (time.time(), v.temperature, v.resonance, v.fact_id),
-                )
-                # Actually remove from vector index for recall hygiene
-                cursor.execute(
-                    "DELETE FROM vec_facts WHERE rowid IN "
-                    "(SELECT rowid FROM facts_meta WHERE id = ?)",
-                    (v.fact_id,),
-                )
-                cursor.execute("DELETE FROM facts_meta WHERE id = ?", (v.fact_id,))
-                db_conn.commit()
+    try:
+        if not dry_run:
+            cursor = db_conn.cursor()
 
+            # 1. Update metadata in batch
+            update_data = [
+                (time.time(), v.temperature, v.resonance, v.fact_id)
+                for v in purge_candidates
+            ]
+            cursor.executemany(
+                """
+                UPDATE facts_meta
+                SET metadata = json_set(COALESCE(metadata, '{}'),
+                    '$.nightshift_purged', ?,
+                    '$.purge_reason', 'cold_dead_weight',
+                    '$.purge_temperature', ?,
+                    '$.purge_resonance', ?)
+                WHERE id = ?
+                """,
+                update_data,
+            )
+
+            # 2. Delete from vec_facts and facts_meta using WHERE IN
+            fact_ids = [v.fact_id for v in purge_candidates]
+
+            # Chunking to avoid SQLite limits on IN clause (typically 999)
+            chunk_size = 900
+            for i in range(0, len(fact_ids), chunk_size):
+                chunk = fact_ids[i:i + chunk_size]
+                placeholders = ",".join("?" * len(chunk))
+
+                cursor.execute(
+                    f"DELETE FROM vec_facts WHERE rowid IN "
+                    f"(SELECT rowid FROM facts_meta WHERE id IN ({placeholders}))",
+                    chunk,
+                )
+                cursor.execute(f"DELETE FROM facts_meta WHERE id IN ({placeholders})", chunk)
+
+            db_conn.commit()
+
+        for v in purge_candidates:
             result.purged += 1
             logger.info(
                 "🗑️ [PURGE] %s — temp=%.3f, res=%.3f, age=%.0fd%s",
@@ -127,9 +142,10 @@ async def _execute_cold_purge(
                 v.age_days,
                 " (DRY)" if dry_run else "",
             )
-        except (sqlite3.Error, ValueError, TypeError) as e:
-            logger.error("🗑️ [PURGE] Error on %s: %s", v.fact_id, e)
-            result.errors += 1
+    except (sqlite3.Error, ValueError, TypeError) as e:
+        logger.error("🗑️ [PURGE] Batch error: %s", e)
+        # If batch fails, we record errors for all candidates to be conservative
+        result.errors += len(purge_candidates)
 
 
 # ── Strategy 2: Semantic Merge ────────────────────────────────────────────
@@ -153,25 +169,31 @@ async def _execute_semantic_merge(
     if len(mergeable) < 2:
         return
 
-    # Load content and embeddings
+    # Load content and embeddings in a batch to avoid N+1 queries
     try:
         cursor = db_conn.cursor()
         data: dict[str, dict[str, Any]] = {}
 
-        for v in mergeable:
+        fact_ids = [v.fact_id for v in mergeable]
+        chunk_size = 900
+
+        for i in range(0, len(fact_ids), chunk_size):
+            chunk = fact_ids[i:i + chunk_size]
+            placeholders = ",".join("?" * len(chunk))
+
             cursor.execute(
-                """
-                SELECT f.content, v.embedding FROM facts_meta f
+                f"""
+                SELECT f.id, f.content, v.embedding FROM facts_meta f
                 JOIN vec_facts v ON f.rowid = v.rowid
-                WHERE f.id = ?
+                WHERE f.id IN ({placeholders})
                 """,
-                (v.fact_id,),
+                chunk,
             )
-            row = cursor.fetchone()
-            if row:
-                data[v.fact_id] = {
-                    "content": row[0],
-                    "embedding": np.frombuffer(row[1], dtype=np.float32),
+
+            for row in cursor.fetchall():
+                data[row[0]] = {
+                    "content": row[1],
+                    "embedding": np.frombuffer(row[2], dtype=np.float32),
                 }
     except (sqlite3.Error, ValueError, TypeError) as e:
         logger.error("🔗 [MERGE] Failed to load data: %s", e)
@@ -224,7 +246,6 @@ async def _execute_semantic_merge(
                             (id_b,),
                         )
                         cursor.execute("DELETE FROM facts_meta WHERE id = ?", (id_b,))
-                        db_conn.commit()
 
                     merged_ids.add(id_b)
                     result.merged += 1
@@ -238,6 +259,14 @@ async def _execute_semantic_merge(
                     logger.error("🔗 [MERGE] Synthesis failed for %s/%s: %s", id_a, id_b, e)
                     result.errors += 1
                     continue
+
+    if not dry_run and result.merged > 0:
+        try:
+            db_conn.commit()
+        except sqlite3.Error as e:
+            logger.error("🔗 [MERGE] Failed to commit merge batch: %s", e)
+            result.errors += result.merged
+            result.merged = 0
 
 
 # ── Strategy 3: Diamond Promotion ─────────────────────────────────────────
@@ -263,16 +292,23 @@ async def _execute_diamond_promotion(
 
     logger.info("💎 [CONSOLIDATOR] Diamond promotion: %d candidates", len(promote_candidates))
 
-    for v in promote_candidates:
-        try:
-            if not dry_run:
-                cursor = db_conn.cursor()
-                cursor.execute(
-                    "UPDATE facts_meta SET is_diamond = 1 WHERE id = ?",
-                    (v.fact_id,),
-                )
-                db_conn.commit()
+    try:
+        if not dry_run:
+            cursor = db_conn.cursor()
+            fact_ids = [v.fact_id for v in promote_candidates]
+            chunk_size = 900
 
+            for i in range(0, len(fact_ids), chunk_size):
+                chunk = fact_ids[i:i + chunk_size]
+                placeholders = ",".join("?" * len(chunk))
+                cursor.execute(
+                    f"UPDATE facts_meta SET is_diamond = 1 WHERE id IN ({placeholders})",
+                    chunk,
+                )
+
+            db_conn.commit()
+
+        for v in promote_candidates:
             result.promoted += 1
             logger.info(
                 "💎 [PROMOTE] %s → DIAMOND (temp=%.3f, res=%.3f)%s",
@@ -281,9 +317,9 @@ async def _execute_diamond_promotion(
                 v.resonance,
                 " (DRY)" if dry_run else "",
             )
-        except (sqlite3.Error, ValueError, TypeError) as e:
-            logger.error("💎 [PROMOTE] Error on %s: %s", v.fact_id, e)
-            result.errors += 1
+    except (sqlite3.Error, ValueError, TypeError) as e:
+        logger.error("💎 [PROMOTE] Batch error: %s", e)
+        result.errors += len(promote_candidates)
 
 
 # ── Public API ────────────────────────────────────────────────────────────


### PR DESCRIPTION
This PR implements batch operations in `cortex/extensions/swarm/crystal_consolidator.py` to resolve N+1 sequential database interactions, significantly improving performance and aligning with the project's entropic asymmetry (Ω₂) axiom. Uses batched metadata deletions and updates utilizing chunking techniques to remain within SQLite limitations.

---
*PR created automatically by Jules for task [12024794455323912625](https://jules.google.com/task/12024794455323912625) started by @borjamoskv*