### PR TITLE
fix(deps): add numpy as core dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "keyring>=25.7.0",
     "cryptography>=46.0.7",
     "pydantic>=2.0",
+    "numpy",
 ]
 
 [project.urls]


### PR DESCRIPTION
Resolves missing dependency `numpy` that was causing test failures. Added `numpy` to the core project dependencies in `pyproject.toml`. Verified that tests now pass successfully.

---
*PR created automatically by Jules for task [15522667228098980517](https://jules.google.com/task/15522667228098980517) started by @borjamoskv*