### PR TITLE
fix(registry): ensure deterministic loading of agent definitions

### DIFF
--- a/cortex/extensions/agents/registry.py
+++ b/cortex/extensions/agents/registry.py
@@ -243,7 +243,7 @@ class AgentRegistry:
         loaded_count = 0
         duplicate_count = 0
         seen_agent_ids: set[str] = set()
-        for yaml_path in directory.glob("*.yaml"):
+        for yaml_path in sorted(directory.glob("*.yaml")):
             if yaml_path.is_symlink() and not yaml_path.exists():
                 logger.error(
                     "☠️ [REGISTRY] Broken symlink skipped: %s -> %s",


### PR DESCRIPTION
The agent registry loads configurations via glob. On some file systems, the order is non-deterministic. This causes `test_load_all_case_insensitive_duplicates` to be flaky because depending on which file comes first, it prints the original or the duplicate agent definition.

This pull request makes the loading sequence deterministic by using `sorted(directory.glob("*.yaml"))`.

---
*PR created automatically by Jules for task [745146795724011461](https://jules.google.com/task/745146795724011461) started by @borjamoskv*