### PR TITLE
Fix: Dynamically construct project root paths and mock forge dependency tests

### DIFF
--- a/cortex-core/ouroboros_engine.py
+++ b/cortex-core/ouroboros_engine.py
@@ -4,12 +4,14 @@ import logging
 import re
 import sqlite3
 import time
+import json
 
 # CORTEX V5 Pulse Integration
 from cortex.extensions.signals.bus import SignalBus
 from cortex.config import DB_PATH
 
-SCRATCH_BASE = "/Users/borjafernandezangulo/Cortex-Persist/.scratch/ouroboros"
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SCRATCH_BASE = os.path.join(PROJECT_ROOT, ".scratch/ouroboros")
 FORGE_PATH = "forge" # Verified in path
 logger = logging.getLogger("cortex.ouroboros")
 
@@ -183,7 +185,7 @@ contract {contract_name}OuroborosTest is Test {{
                 "id": f"remed_{int(time.time())}",
                 "agent": "SURGEON-1",
                 "type": "remediation",
-                "command": f"python3 /Users/borjafernandezangulo/Cortex-Persist/cortex-core/remediator.py {target_file} {log_file}",
+                "command": f"python3 {os.path.join(PROJECT_ROOT, 'cortex-core', 'remediator.py')} {target_file} {log_file}",
                 "timestamp": time.time()
             })
             

--- a/cortex-core/ouroboros_engine.py
+++ b/cortex-core/ouroboros_engine.py
@@ -12,8 +12,9 @@ from cortex.config import DB_PATH
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 SCRATCH_BASE = os.path.join(PROJECT_ROOT, ".scratch/ouroboros")
-FORGE_PATH = "forge" # Verified in path
+FORGE_PATH = "forge"  # Verified in path
 logger = logging.getLogger("cortex.ouroboros")
+
 
 class OuroborosEngine:
     """Foundry-backed Security Audit Engine (V5)."""
@@ -22,7 +23,7 @@ class OuroborosEngine:
         self.target_url = target_url
         self.scratch_dir = None
         self.findings = []
-        
+
         # Initialize SignalBus
         try:
             conn = sqlite3.connect(DB_PATH, check_same_thread=False)
@@ -38,22 +39,23 @@ class OuroborosEngine:
         """Prepare the audit environment."""
         if not os.path.exists(SCRATCH_BASE):
             os.makedirs(SCRATCH_BASE, exist_ok=True)
-            
-        repo_name = self.target_url.split("/")[-1].replace(".git", "") if self.target_url else "temp_audit"
+
+        repo_name = (
+            self.target_url.split("/")[-1].replace(".git", "") if self.target_url else "temp_audit"
+        )
         self.scratch_dir = os.path.join(SCRATCH_BASE, f"{repo_name}_{int(time.time())}")
         os.makedirs(self.scratch_dir, exist_ok=True)
-        
+
         logger.info("Provisioned Ouroboros workspace: %s", self.scratch_dir)
 
     async def clone_target(self):
         """Clones the target repository."""
         if not self.target_url:
             return
-            
+
         logger.info("Cloning target: %s", self.target_url)
         process = await asyncio.create_subprocess_exec(
-            "git", "clone", "--depth", "1", self.target_url, ".",
-            cwd=self.scratch_dir
+            "git", "clone", "--depth", "1", self.target_url, ".", cwd=self.scratch_dir
         )
         await process.wait()
 
@@ -65,7 +67,7 @@ class OuroborosEngine:
                 if file.endswith(".sol") and "test" not in file.lower():
                     path = os.path.join(root, file)
                     try:
-                        with open(path, "r") as f:
+                        with open(path) as f:
                             content = f.read()
                             matches = re.findall(r"contract\s+(\w+)", content)
                             for m in matches:
@@ -78,9 +80,9 @@ class OuroborosEngine:
         """Auto-generates a Foundry fuzz test for the detected contract."""
         test_file = os.path.join(self.scratch_dir, f"test/{contract_name}Ouroboros.t.sol")
         os.makedirs(os.path.join(self.scratch_dir, "test"), exist_ok=True)
-        
+
         relative_path = os.path.relpath(contract_file, self.scratch_dir)
-        
+
         # V5 Template: Basic Fuzzing against Reentrancy/Overflow
         template = f"""// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
@@ -109,64 +111,78 @@ contract {contract_name}OuroborosTest is Test {{
         """Executes the Forge Fuzzer and yields findings."""
         await self.provision()
         await self.clone_target()
-        
+
         contracts = self._detect_contracts()
         logger.info("Detected %d contracts for audit.", len(contracts))
-        
+
         if not contracts:
-             # Fallback: Create a dummy for telemetry
-             contracts = [{"name": "CortexVault", "file": "src/Vault.sol"}]
-             os.makedirs(os.path.join(self.scratch_dir, "src"), exist_ok=True)
-             with open(os.path.join(self.scratch_dir, "src/Vault.sol"), "w") as f:
-                 f.write("contract CortexVault { function deposit() external payable {} }")
+            # Fallback: Create a dummy for telemetry
+            contracts = [{"name": "CortexVault", "file": "src/Vault.sol"}]
+            os.makedirs(os.path.join(self.scratch_dir, "src"), exist_ok=True)
+            with open(os.path.join(self.scratch_dir, "src/Vault.sol"), "w") as f:
+                f.write("contract CortexVault { function deposit() external payable {} }")
 
         # Initialize Forge project
         os.system(f"cd {self.scratch_dir} && forge init --no-git")
 
-        for c in contracts[:2]: # Limit to 2 for performance
+        for c in contracts[:2]:  # Limit to 2 for performance
             await self.generate_fuzz_test(c["name"], c["file"])
-            
+
             logger.info("🚀 Auditing %s...", c["name"])
-            await self._emit_event("swarm_task", {
-                "agent": "Ouroboros-1",
-                "command": f"forge test --match-contract {c['name']}",
-                "status": "fuzzing"
-            })
-            
+            await self._emit_event(
+                "swarm_task",
+                {
+                    "agent": "Ouroboros-1",
+                    "command": f"forge test --match-contract {c['name']}",
+                    "status": "fuzzing",
+                },
+            )
+
             process = await asyncio.create_subprocess_exec(
-                FORGE_PATH, "test", "--match-contract", c["name"],
+                FORGE_PATH,
+                "test",
+                "--match-contract",
+                c["name"],
                 cwd=self.scratch_dir,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE
+                stderr=asyncio.subprocess.PIPE,
             )
             stdout, stderr = await process.communicate()
-            
-            score = 150.0 if process.returncode == 0 else 500.0 # Failures = Critical Finding = High Yield
-            
+
+            score = (
+                150.0 if process.returncode == 0 else 500.0
+            )  # Failures = Critical Finding = High Yield
+
             # 2. Detective Analysis: If failure, queue remediation
             if process.returncode != 0:
                 error_log = f"{self.scratch_dir}/error.log"
                 with open(error_log, "w") as f:
                     f.write(stdout.decode() + "\n" + stderr.decode())
-                
+
                 logger.warning("❌ [VULN] Found in %s. Queuing Sovereign Surgeon...", c["name"])
-                
+
                 # Emit finding
-                await self._emit_event("critical_finding", {
-                    "id": f"VULN_{int(time.time())}",
-                    "msg": "CRITICAL_FINDING",
-                    "val": f"Exploit detected in {c['name']} (Revert Flow)"
-                })
-                
+                await self._emit_event(
+                    "critical_finding",
+                    {
+                        "id": f"VULN_{int(time.time())}",
+                        "msg": "CRITICAL_FINDING",
+                        "val": f"Exploit detected in {c['name']} (Revert Flow)",
+                    },
+                )
+
                 # Queue Remediation Task
                 self._queue_remediation(c["file"], error_log)
             else:
-                await self._emit_event("ledger_append", {
-                    "hash": f"AUR_{int(time.time())}_{c['name']}",
-                    "action": f"Security Audit: {c['name']}",
-                    "yield_amount": score,
-                    "vector_id": "Ouroboros-Fuzzer"
-                })
+                await self._emit_event(
+                    "ledger_append",
+                    {
+                        "hash": f"AUR_{int(time.time())}_{c['name']}",
+                        "action": f"Security Audit: {c['name']}",
+                        "yield_amount": score,
+                        "vector_id": "Ouroboros-Fuzzer",
+                    },
+                )
 
         # Cleanup entropy
         # shutil.rmtree(self.scratch_dir)
@@ -178,17 +194,19 @@ contract {contract_name}OuroborosTest is Test {{
         try:
             queue = {"pending_tasks": []}
             if os.path.exists(queue_path):
-                with open(queue_path, "r") as f:
+                with open(queue_path) as f:
                     queue = json.load(f)
-            
-            queue["pending_tasks"].append({
-                "id": f"remed_{int(time.time())}",
-                "agent": "SURGEON-1",
-                "type": "remediation",
-                "command": f"python3 {os.path.join(PROJECT_ROOT, 'cortex-core', 'remediator.py')} {target_file} {log_file}",
-                "timestamp": time.time()
-            })
-            
+
+            queue["pending_tasks"].append(
+                {
+                    "id": f"remed_{int(time.time())}",
+                    "agent": "SURGEON-1",
+                    "type": "remediation",
+                    "command": f"python3 {os.path.join(PROJECT_ROOT, 'cortex-core', 'remediator.py')} {target_file} {log_file}",
+                    "timestamp": time.time(),
+                }
+            )
+
             with open(queue_path, "w") as f:
                 json.dump(queue, f, indent=2)
             logger.info("📌 [SURGEON] Remediation mission queued for %s", target_file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 
 dependencies = [
     "sqlite-vec>=0.1.6",
+    "numpy>=1.24.0",
     "click>=8.0",
     "rich>=13.0",
     "aiosqlite>=0.20.0",

--- a/tests/test_ouroboros_forge.py
+++ b/tests/test_ouroboros_forge.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from unittest.mock import patch, MagicMock, AsyncMock
 import unittest
 from pathlib import Path
 
@@ -17,10 +18,20 @@ class TestOuroborosForge(unittest.IsolatedAsyncioTestCase):
         self.engine = OuroborosEngine()
         self.test_repo = "https://github.com/Uniswap/v4-core"
 
-    async def test_audit_cycle(self):
+    @patch('ouroboros_engine.os.system')
+    @patch('ouroboros_engine.asyncio.create_subprocess_exec')
+    async def test_audit_cycle(self, mock_exec, mock_system):
         """Standard Audit Cycle on mock contract."""
         logger = logging.getLogger("cortex.ouroboros.test")
         logger.info("Starting Ouroboros-1 Verification...")
+
+        mock_process = AsyncMock()
+        mock_process.returncode = 0
+        mock_process.communicate.return_value = (b'mock stdout', b'mock stderr')
+        mock_process.wait.return_value = 0
+        mock_exec.return_value = mock_process
+
+        mock_system.return_value = 0
 
         # This will clone and audit
         try:

--- a/tests/test_ouroboros_forge.py
+++ b/tests/test_ouroboros_forge.py
@@ -1,5 +1,7 @@
 import logging
 import sys
+import tempfile
+import os
 from unittest.mock import patch, MagicMock, AsyncMock
 import unittest
 from pathlib import Path
@@ -15,11 +17,21 @@ class TestOuroborosForge(unittest.IsolatedAsyncioTestCase):
     """Verifies the Forge-backed Ouroboros audit pipeline (V5)."""
 
     async def asyncSetUp(self):
+        self.temp_db = tempfile.NamedTemporaryFile(delete=False)
+        self.temp_db.close()
+        self.db_patcher = patch("cortex.config.DB_PATH", self.temp_db.name)
+        self.db_patcher.start()
+
         self.engine = OuroborosEngine()
         self.test_repo = "https://github.com/Uniswap/v4-core"
 
-    @patch('ouroboros_engine.os.system')
-    @patch('ouroboros_engine.asyncio.create_subprocess_exec')
+    async def asyncTearDown(self):
+        self.db_patcher.stop()
+        if os.path.exists(self.temp_db.name):
+            os.remove(self.temp_db.name)
+
+    @patch("ouroboros_engine.os.system")
+    @patch("ouroboros_engine.asyncio.create_subprocess_exec")
     async def test_audit_cycle(self, mock_exec, mock_system):
         """Standard Audit Cycle on mock contract."""
         logger = logging.getLogger("cortex.ouroboros.test")
@@ -27,7 +39,7 @@ class TestOuroborosForge(unittest.IsolatedAsyncioTestCase):
 
         mock_process = AsyncMock()
         mock_process.returncode = 0
-        mock_process.communicate.return_value = (b'mock stdout', b'mock stderr')
+        mock_process.communicate.return_value = (b"mock stdout", b"mock stderr")
         mock_process.wait.return_value = 0
         mock_exec.return_value = mock_process
 
@@ -48,8 +60,9 @@ class TestOuroborosForge(unittest.IsolatedAsyncioTestCase):
         from cortex.extensions.signals.bus import SignalBus
 
         # Ensure schema initialization
-        conn = sqlite3.connect(DB_PATH)
+        conn = sqlite3.connect(self.temp_db.name)
         _bus = SignalBus(conn)
+        _bus.ensure_table()
 
         # Check if signals exist for 'ouroboros'
         cursor = conn.cursor()

--- a/tests/test_search_exergy.py
+++ b/tests/test_search_exergy.py
@@ -29,6 +29,9 @@ async def test_exergy_prioritization(temp_db_path, mock_encoder):
     to rank outputs when their semantic embeddings are identical.
     """
     store = SovereignVectorStoreL2(encoder=mock_encoder, db_path=temp_db_path, half_life_days=7)
+    store._get_conn()
+    if not store._vector_enabled:
+        pytest.skip("sqlite-vec not enabled, cannot test vector ranking")
 
     # Prepare identical embeddings so vector similarity is strictly equal
     embedding_vec = [1] * 384


### PR DESCRIPTION
The codebase contained issues where hardcoded absolute paths pointing to a specific user's directory (`/Users/borjafernandezangulo/...`) caused tests testing the `ouroboros_engine.py` component to crash with `PermissionError` in isolated environments. The codebase also required the `numpy` dependency, which was failing `test_search_exergy.py` during `pytest` collection, and `test_ouroboros_forge.py` tests needed mocking instead of execution to avoid test failures when `forge` isn't installed. 

This PR dynamically constructs the paths in `ouroboros_engine.py`, mocks the external binary calls in the forge tests, skips tests safely if `sqlite-vec` extensions aren't found, and defines `numpy` as a base dependency.

---
*PR created automatically by Jules for task [1268927843318661747](https://jules.google.com/task/1268927843318661747) started by @borjamoskv*