### PR TITLE
[codex] Add forensic ledger export package

### DIFF
--- a/cortex/cli/public_export_cmds.py
+++ b/cortex/cli/public_export_cmds.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.cli.common import cli
+from cortex.ledger.public_export import (
+    ExportAuthority,
+    write_public_ledger_export,
+)
+from cortex.ledger.public_verifier_utils import _loads_json_strict
+
+
+@cli.command("export-ledger")
+@click.argument("events_jsonl", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("export_dir", type=click.Path(file_okay=False, path_type=Path))
+@click.option(
+    "--public-keys",
+    "public_keys_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option("--export-id", required=True)
+@click.option("--tenant-id", required=True)
+@click.option("--stream-id", required=True)
+@click.option("--export-authority-key-id", required=True)
+@click.option("--export-authority-actor-id", required=True)
+@click.option(
+    "--export-authority-private-key-seed",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to a base64url-encoded raw Ed25519 private key seed.",
+)
+@click.option("--created-at")
+@click.option("--purpose", default="forensic_ledger_export", show_default=True)
+@click.option("--environment", default="test", show_default=True)
+@click.option("--include-verification-report", is_flag=True)
+def export_ledger(
+    events_jsonl: Path,
+    export_dir: Path,
+    public_keys_path: Path,
+    export_id: str,
+    tenant_id: str,
+    stream_id: str,
+    export_authority_key_id: str,
+    export_authority_actor_id: str,
+    export_authority_private_key_seed: Path,
+    created_at: str | None,
+    purpose: str,
+    environment: str,
+    include_verification_report: bool,
+) -> None:
+    """Write a signed public ledger export package from public-v1 JSONL."""
+    events = _load_events_jsonl(events_jsonl)
+    public_keys = _load_public_keys(public_keys_path)
+    private_key = Ed25519PrivateKey.from_private_bytes(
+        _decode_b64url_file(export_authority_private_key_seed)
+    )
+
+    result = write_public_ledger_export(
+        events=events,
+        export_dir=export_dir,
+        public_keys=public_keys,
+        export_authority=ExportAuthority(
+            key_id=export_authority_key_id,
+            actor_id=export_authority_actor_id,
+            private_key=private_key,
+            environment=environment,
+        ),
+        export_id=export_id,
+        tenant_id=tenant_id,
+        stream_id=stream_id,
+        purpose=purpose,
+        environment=environment,
+        created_at=created_at,
+        include_verification_report=include_verification_report,
+    )
+    click.echo(
+        json.dumps(
+            {
+                "export_dir": str(result.export_dir),
+                "manifest_hash": result.manifest_hash,
+                "verification_result": result.verification_result,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def _load_events_jsonl(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line:
+            continue
+        value = _loads_json_strict(line)
+        if not isinstance(value, dict):
+            raise click.ClickException(f"events_jsonl_non_object:{line_number}")
+        events.append(value)
+    if not events:
+        raise click.ClickException("events_jsonl_empty")
+    return events
+
+
+def _load_public_keys(path: Path) -> list[dict[str, Any]]:
+    value = _loads_json_strict(path.read_text(encoding="utf-8"))
+    if isinstance(value, dict):
+        keys = value.get("keys")
+    else:
+        keys = value
+    if not isinstance(keys, list) or not all(isinstance(key, dict) for key in keys):
+        raise click.ClickException("public_keys_invalid")
+    return [dict(key) for key in keys]
+
+
+def _decode_b64url_file(path: Path) -> bytes:
+    value = path.read_text(encoding="utf-8").strip()
+    padding = "=" * (-len(value) % 4)
+    seed = base64.urlsafe_b64decode(value + padding)
+    if len(seed) != 32:
+        raise click.ClickException("export_authority_private_key_seed_must_be_32_bytes")
+    return seed

--- a/cortex/ledger/public_export.py
+++ b/cortex/ledger/public_export.py
@@ -1,0 +1,473 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import stat
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from cortex.ledger.public_verifier import STRICT_REQUIRED_EVENT_FIELDS, verify_export
+from cortex.ledger.public_verifier_utils import (
+    _canonical_public_json,
+    _event_hash,
+    _merkle_root_v1,
+    _sha256_file,
+)
+
+PUBLIC_EXPORT_MANIFEST_VERSION = "cortex-forensic-export-manifest-v1"
+KEY_REGISTRY_VERSION = "cortex-key-registry-v1"
+EVENT_SCHEMA_VERSION = "cortex-ledger-event-schema-v1"
+VERIFICATION_PROFILE_VERSION = "cortex-verification-profile-v1"
+LEGACY_LIMITATIONS = (
+    "legacy_v0_integrity_only",
+    "origin_authenticity_not_verified",
+    "manifest_completeness_not_available",
+)
+PUBLIC_EXPORT_FILES = frozenset(
+    {
+        "events.jsonl",
+        "key-events.jsonl",
+        "manifest.json",
+        "public-keys.json",
+        "schema.json",
+        "verification-profile.json",
+        "verification-report.json",
+    }
+)
+FORBIDDEN_EXPORT_TOKENS = (
+    "private_key",
+    "seed_hex",
+    "begin private key",
+    "api_key",
+    "secret_key",
+    "password",
+)
+EXECUTABLE_SUFFIXES = (".bat", ".cmd", ".exe", ".js", ".mjs", ".py", ".sh")
+
+
+@dataclass(frozen=True)
+class ExportAuthority:
+    key_id: str
+    actor_id: str
+    private_key: Ed25519PrivateKey
+    environment: str = "test"
+
+
+@dataclass(frozen=True)
+class LedgerExportResult:
+    export_dir: Path
+    manifest_path: Path
+    events_path: Path
+    public_keys_path: Path
+    verification_report_path: Path | None
+    manifest_hash: str
+    verification_result: str | None
+
+
+@dataclass(frozen=True)
+class LegacyLedgerExportResult:
+    export_dir: Path
+    vector_paths: tuple[Path, ...]
+    limitations_path: Path
+    verification_result: str
+    limitations: tuple[str, ...]
+
+
+def write_public_ledger_export(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    export_dir: str | Path,
+    public_keys: Sequence[Mapping[str, Any]],
+    export_authority: ExportAuthority,
+    export_id: str,
+    tenant_id: str,
+    stream_id: str,
+    purpose: str = "forensic_ledger_export",
+    environment: str = "test",
+    created_at: str | None = None,
+    key_events: Sequence[Mapping[str, Any]] = (),
+    include_verification_report: bool = False,
+    allow_overwrite: bool = False,
+) -> LedgerExportResult:
+    """Write a signed public ledger export package without exporting fact payloads."""
+    if not events:
+        raise ValueError("at least one ledger event is required")
+
+    root = Path(export_dir)
+    _prepare_export_dir(root, allow_overwrite=allow_overwrite)
+
+    event_objects = [dict(event) for event in events]
+    key_objects = [dict(key) for key in public_keys]
+    event_hashes = _validate_public_events(
+        event_objects,
+        tenant_id=tenant_id,
+        stream_id=stream_id,
+    )
+    _validate_public_key_records(key_objects)
+    _assert_no_private_material({"events": event_objects, "public_keys": key_objects})
+
+    generated_at = created_at or _utc_now()
+    events_path = root / "events.jsonl"
+    public_keys_path = root / "public-keys.json"
+    key_events_path = root / "key-events.jsonl"
+    schema_path = root / "schema.json"
+    verification_profile_path = root / "verification-profile.json"
+    manifest_path = root / "manifest.json"
+    verification_report_path = root / "verification-report.json"
+
+    _write_text_atomic(
+        events_path,
+        "".join(_canonical_public_json(event) + "\n" for event in event_objects),
+    )
+    _write_text_atomic(
+        key_events_path,
+        "".join(_canonical_public_json(dict(event)) + "\n" for event in key_events),
+    )
+    _write_json_atomic(schema_path, _schema_document())
+    _write_json_atomic(verification_profile_path, _verification_profile_document())
+    _write_json_atomic(
+        public_keys_path,
+        _key_registry_document(
+            tenant_id=tenant_id,
+            public_keys=key_objects,
+            export_authority=export_authority,
+            generated_at=generated_at,
+        ),
+    )
+
+    manifest_without_signature = _manifest_document(
+        events=event_objects,
+        event_hashes=event_hashes,
+        export_id=export_id,
+        tenant_id=tenant_id,
+        stream_id=stream_id,
+        created_by=export_authority.actor_id,
+        created_at=generated_at,
+        purpose=purpose,
+        environment=environment,
+        root=root,
+    )
+    manifest = dict(manifest_without_signature)
+    manifest["signature"] = {
+        "key_id": export_authority.key_id,
+        "signature_scope": "canonical_manifest_without_signature",
+        "value": _b64url_encode(
+            export_authority.private_key.sign(
+                _canonical_public_json(manifest_without_signature).encode("utf-8")
+            )
+        ),
+    }
+    _write_json_atomic(manifest_path, manifest)
+
+    verification_result: str | None = None
+    if include_verification_report:
+        report = verify_export(root)
+        verification_result = str(report["result"])
+        _write_json_atomic(verification_report_path, report)
+    else:
+        verification_report_path = None
+
+    _scan_export_safety(root)
+
+    return LedgerExportResult(
+        export_dir=root,
+        manifest_path=manifest_path,
+        events_path=events_path,
+        public_keys_path=public_keys_path,
+        verification_report_path=verification_report_path,
+        manifest_hash=_sha256_file(manifest_path),
+        verification_result=verification_result,
+    )
+
+
+def write_legacy_ledger_export(
+    *,
+    vectors: Sequence[Mapping[str, Any]],
+    export_dir: str | Path,
+    allow_overwrite: bool = False,
+) -> LegacyLedgerExportResult:
+    """Write legacy-v0 integrity vectors and explicit limitation notes."""
+    if not vectors:
+        raise ValueError("at least one legacy vector is required")
+    root = Path(export_dir)
+    _prepare_export_dir(root, allow_overwrite=allow_overwrite)
+
+    vector_paths: list[Path] = []
+    for index, vector in enumerate(vectors, start=1):
+        value = dict(vector)
+        if value.get("profile") != "legacy-v0":
+            raise ValueError(f"legacy vector profile unsupported: {value.get('profile')}")
+        path = root / f"legacy_v0_vector_{index}.json"
+        _write_json_atomic(path, value)
+        vector_paths.append(path)
+
+    limitations_path = root / "LIMITATIONS.txt"
+    _write_text_atomic(
+        limitations_path,
+        "\n".join(
+            [
+                "Legacy-v0 ledger export is integrity-only.",
+                "Origin authenticity, manifest completeness, online freshness, and truth are not verified.",
+                *LEGACY_LIMITATIONS,
+                "",
+            ]
+        ),
+    )
+    report = verify_export(root)
+    _scan_export_safety(
+        root, allowed_files={path.name for path in vector_paths} | {"LIMITATIONS.txt"}
+    )
+    return LegacyLedgerExportResult(
+        export_dir=root,
+        vector_paths=tuple(vector_paths),
+        limitations_path=limitations_path,
+        verification_result=str(report["result"]),
+        limitations=LEGACY_LIMITATIONS,
+    )
+
+
+def public_key_record(
+    *,
+    key_id: str,
+    actor_id: str,
+    public_key: Ed25519PublicKey,
+    permissions: Sequence[str],
+    actor_type: str = "agent",
+    environment: str = "test",
+    valid_from: str = "2026-01-01T00:00:00Z",
+    valid_until: str = "2027-01-01T00:00:00Z",
+    hardware_backed: bool = False,
+) -> dict[str, Any]:
+    """Build a public key registry record for exported ledger verification."""
+    return {
+        "actor_id": actor_id,
+        "actor_type": actor_type,
+        "algorithm": "ed25519",
+        "environment": environment,
+        "hardware_backed": hardware_backed,
+        "key_id": key_id,
+        "permissions": list(permissions),
+        "public_key": _public_key_b64url(public_key),
+        "status": "active",
+        "valid_from": valid_from,
+        "valid_until": valid_until,
+    }
+
+
+def _manifest_document(
+    *,
+    events: Sequence[Mapping[str, Any]],
+    event_hashes: Sequence[str],
+    export_id: str,
+    tenant_id: str,
+    stream_id: str,
+    created_by: str,
+    created_at: str,
+    purpose: str,
+    environment: str,
+    root: Path,
+) -> dict[str, Any]:
+    first = events[0]
+    last = events[-1]
+    return {
+        "algorithms": {
+            "event_hash": "sha256",
+            "manifest_hash": "sha256",
+            "merkle": "merkle-profile-v1",
+            "signature": "ed25519",
+        },
+        "counts": {
+            "erasure_tombstone_count": 0,
+            "event_count": len(events),
+            "redacted_event_count": 0,
+        },
+        "created_at": created_at,
+        "created_by": created_by,
+        "environment": environment,
+        "export_id": export_id,
+        "hashes": {
+            "events_file_sha256": _sha256_file(root / "events.jsonl"),
+            "first_event_hash": event_hashes[0],
+            "key_events_file_sha256": _sha256_file(root / "key-events.jsonl"),
+            "last_event_hash": event_hashes[-1],
+            "merkle_root": _merkle_root_v1(event_hashes),
+            "public_keys_file_sha256": _sha256_file(root / "public-keys.json"),
+            "schema_file_sha256": _sha256_file(root / "schema.json"),
+            "verification_profile_sha256": _sha256_file(root / "verification-profile.json"),
+        },
+        "limitations": [],
+        "purpose": purpose,
+        "range": {
+            "first_recorded_at": first["recorded_at"],
+            "first_sequence": first["sequence"],
+            "last_recorded_at": last["recorded_at"],
+            "last_sequence": last["sequence"],
+        },
+        "schema_version": PUBLIC_EXPORT_MANIFEST_VERSION,
+        "stream_id": stream_id,
+        "tenant_id": tenant_id,
+    }
+
+
+def _key_registry_document(
+    *,
+    tenant_id: str,
+    public_keys: Sequence[Mapping[str, Any]],
+    export_authority: ExportAuthority,
+    generated_at: str,
+) -> dict[str, Any]:
+    keys = [dict(key) for key in public_keys]
+    if not any(key.get("key_id") == export_authority.key_id for key in keys):
+        keys.append(
+            public_key_record(
+                key_id=export_authority.key_id,
+                actor_id=export_authority.actor_id,
+                actor_type="export_authority",
+                environment=export_authority.environment,
+                public_key=export_authority.private_key.public_key(),
+                permissions=["ledger.export"],
+            )
+        )
+    return {
+        "generated_at": generated_at,
+        "keys": sorted(keys, key=lambda key: str(key["key_id"])),
+        "schema_version": KEY_REGISTRY_VERSION,
+        "tenant_id": tenant_id,
+    }
+
+
+def _schema_document() -> dict[str, str]:
+    return {"profile": "public-v1-strict", "schema_version": EVENT_SCHEMA_VERSION}
+
+
+def _verification_profile_document() -> dict[str, str]:
+    return {
+        "canonicalization": "canonical-json-v1",
+        "merkle": "merkle-profile-v1",
+        "profile": "public-v1-strict",
+        "schema_version": VERIFICATION_PROFILE_VERSION,
+    }
+
+
+def _validate_public_events(
+    events: Sequence[Mapping[str, Any]],
+    *,
+    tenant_id: str,
+    stream_id: str,
+) -> list[str]:
+    previous_sequence: int | None = None
+    previous_hash = "GENESIS"
+    seen_event_ids: set[str] = set()
+    seen_nonces: set[str] = set()
+    event_hashes: list[str] = []
+    for index, event in enumerate(events, start=1):
+        missing = sorted(STRICT_REQUIRED_EVENT_FIELDS - event.keys())
+        if missing:
+            raise ValueError(f"event missing public-v1 fields at {index}: {','.join(missing)}")
+        event_id = str(event["event_id"])
+        nonce = str(event["nonce"])
+        if event_id in seen_event_ids:
+            raise ValueError(f"duplicate event_id before export: {event_id}")
+        if nonce in seen_nonces:
+            raise ValueError(f"duplicate nonce before export: {nonce}")
+        seen_event_ids.add(event_id)
+        seen_nonces.add(nonce)
+        if event.get("tenant_id") != tenant_id:
+            raise ValueError(f"event tenant mismatch: {event_id}")
+        if event.get("stream_id") != stream_id:
+            raise ValueError(f"event stream mismatch: {event_id}")
+        if event.get("prev_hash") != previous_hash:
+            raise ValueError(f"event chain break before export: {event_id}")
+        sequence = event.get("sequence")
+        if isinstance(sequence, bool) or not isinstance(sequence, int):
+            raise ValueError(f"event sequence invalid: {event_id}")
+        if previous_sequence is None and sequence != 1:
+            raise ValueError(f"event sequence must start at 1: {event_id}")
+        if previous_sequence is not None and sequence != previous_sequence + 1:
+            raise ValueError(f"event sequence gap: {event_id}")
+        detail = event.get("detail")
+        if isinstance(detail, Mapping) and any(
+            field in detail for field in ("content", "payload", "plaintext", "fact_content")
+        ):
+            raise ValueError(f"event contains inline fact payload: {event_id}")
+        actual_hash = _event_hash(event)
+        if actual_hash != event.get("hash"):
+            raise ValueError(f"event hash mismatch before export: {event_id}")
+        event_hashes.append(actual_hash)
+        previous_sequence = sequence
+        previous_hash = actual_hash
+    return event_hashes
+
+
+def _validate_public_key_records(keys: Sequence[Mapping[str, Any]]) -> None:
+    seen: set[str] = set()
+    for key in keys:
+        key_id = key.get("key_id")
+        if not isinstance(key_id, str) or not key_id:
+            raise ValueError("public key record missing key_id")
+        if key_id in seen:
+            raise ValueError(f"duplicate public key id: {key_id}")
+        seen.add(key_id)
+        if key.get("algorithm") != "ed25519":
+            raise ValueError(f"public key algorithm unsupported: {key_id}")
+        if not isinstance(key.get("public_key"), str):
+            raise ValueError(f"public key missing material: {key_id}")
+        if not isinstance(key.get("permissions"), list):
+            raise ValueError(f"public key permissions missing: {key_id}")
+
+
+def _prepare_export_dir(root: Path, *, allow_overwrite: bool) -> None:
+    if root.exists() and any(root.iterdir()) and not allow_overwrite:
+        raise FileExistsError(f"export directory is not empty: {root}")
+    root.mkdir(parents=True, exist_ok=True)
+
+
+def _assert_no_private_material(value: Any) -> None:
+    text = _canonical_public_json(value).lower()
+    for token in FORBIDDEN_EXPORT_TOKENS:
+        if token in text:
+            raise ValueError(f"export contains forbidden token: {token}")
+
+
+def _scan_export_safety(root: Path, *, allowed_files: set[str] | None = None) -> None:
+    allowed = allowed_files or set(PUBLIC_EXPORT_FILES)
+    for path in root.iterdir():
+        if not path.is_file():
+            raise ValueError(f"export contains non-file entry: {path.name}")
+        if path.name not in allowed:
+            raise ValueError(f"export contains unexpected file: {path.name}")
+        if path.suffix in EXECUTABLE_SUFFIXES:
+            raise ValueError(f"export contains executable-like file: {path.name}")
+        mode = path.stat().st_mode
+        if mode & (stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH):
+            raise ValueError(f"export contains executable file: {path.name}")
+        _assert_no_private_material(path.read_text(encoding="utf-8"))
+
+
+def _write_json_atomic(path: Path, value: Mapping[str, Any]) -> None:
+    _write_text_atomic(path, _canonical_public_json(value))
+
+
+def _write_text_atomic(path: Path, value: str) -> None:
+    tmp_path = path.with_name(path.name + ".tmp")
+    tmp_path.write_text(value, encoding="utf-8")
+    os.replace(tmp_path, path)
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _public_key_b64url(public_key: Ed25519PublicKey) -> str:
+    return _b64url_encode(public_key.public_bytes(Encoding.Raw, PublicFormat.Raw))
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
+++ b/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
@@ -1,0 +1,104 @@
+# Public Ledger Export Package
+
+Status: draft
+
+This document defines the forensic ledger export package produced for
+independent offline verification. The package is evidence packaging only: it
+does not enforce runtime origin signing, authorize agent actions, reserve
+nonces, or export fact payloads.
+
+## Required Artifacts
+
+A `public-v1-strict` export directory contains:
+
+- `events.jsonl`: canonical JSON Lines ledger events.
+- `manifest.json`: signed manifest over package artifacts and event range.
+- `public-keys.json`: actor and export-authority public key registry.
+- `key-events.jsonl`: reserved key lifecycle event stream.
+- `schema.json`: event schema/profile descriptor.
+- `verification-profile.json`: canonicalization, hash, signature, and Merkle
+  profile descriptor.
+
+When requested, the exporter also writes:
+
+- `verification-report.json`: deterministic output from the offline verifier.
+
+The package must not contain `facts.jsonl`, plaintext fact payload files, private
+keys, secrets, or executable files. Fact export is a separate product surface
+with separate retention, redaction, and erasure controls.
+
+## Manifest Scope
+
+`manifest.json` includes:
+
+- export identity, tenant, stream, purpose, environment, creator, and creation
+  time;
+- event count and sequence/time range;
+- SHA-256 hashes of `events.jsonl`, `public-keys.json`, `key-events.jsonl`,
+  `schema.json`, and `verification-profile.json`;
+- first and last event hash;
+- `merkle-profile-v1` root over event hashes;
+- Ed25519 signature by an export authority key.
+
+The manifest signature scope is:
+
+```text
+Ed25519.sign(export_authority_private_key, canonical_json(manifest without signature))
+```
+
+## Event Payload Boundary
+
+The public ledger export may include references to encrypted or externally
+controlled fact material, for example `payload_ref` or `subject_ref`.
+
+The export builder rejects common inline fact payload keys inside event
+`detail`:
+
+- `content`
+- `payload`
+- `plaintext`
+- `fact_content`
+
+This is a guardrail for forensic packaging, not a complete PII detector. M6 is
+the enforcement milestone for immutable-ledger no-PII policy.
+
+## Guarantee Split
+
+If the optional verifier report is generated, it preserves the offline guarantee
+split:
+
+- `integrity_verified`
+- `origin_authenticity_verified`
+- `authority_verified`
+- `replay_consistency_verified`
+- `temporal_consistency_verified`
+- `online_freshness_verified`
+- `completeness_verified`
+- `truth_verified`
+
+For offline exports, `online_freshness_verified` remains false. The verifier
+does not assert that event contents are true; `truth_verified` remains false by
+default.
+
+## Legacy Streams
+
+Legacy-v0 exports are explicitly integrity-only. They may include deterministic
+legacy hash vectors and a `LIMITATIONS.txt` note, but they do not claim origin
+authenticity, manifest completeness, online freshness, or truth verification.
+
+## Current Limitations
+
+M3 assumes strict public events already carry `public-v1-strict` fields,
+including `origin_signature`, `actor_key_id`, `nonce`, and hash-chain
+continuity.
+
+M3 does not:
+
+- sign ledger events on behalf of actors;
+- reject unsigned runtime writes before persistence;
+- create actor-key authorization policy;
+- reserve or consume replay nonces;
+- prove that a source database contains no omitted events;
+- export plaintext facts or reconstruct fact contents.
+
+Those controls belong to later milestones, especially M4, M5, and M6.

--- a/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
+++ b/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
@@ -6,6 +6,9 @@ This document defines the minimum contract for an offline public verifier for
 CORTEX ledger exports. The verifier must validate exported bytes without
 accessing SQLite, network services, or a running CORTEX process.
 
+The matching package layout is documented in
+[`PUBLIC_LEDGER_EXPORT_PACKAGE.md`](PUBLIC_LEDGER_EXPORT_PACKAGE.md).
+
 ## Profiles
 
 - `legacy-v0`: verifies the current transaction hash shape for legacy data. It

--- a/tests/test_public_ledger_export.py
+++ b/tests/test_public_ledger_export.py
@@ -1,0 +1,384 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat
+
+from cortex.cli import cli
+from cortex.ledger.public_export import (
+    ExportAuthority,
+    public_key_record,
+    write_legacy_ledger_export,
+    write_public_ledger_export,
+)
+from cortex.ledger.public_verifier import verify_export
+
+TENANT_ID = "tenant-acme"
+STREAM_ID = "tenant:acme:ledger:primary"
+ACTOR_ID = "agent-risk-01"
+ACTOR_KEY_ID = "ed25519:agent-risk-01:test-export-001"
+EXPORT_KEY_ID = "ed25519:export-authority:test-export-001"
+CREATED_AT = "2026-02-03T10:15:30Z"
+
+
+def test_write_public_ledger_export_package_with_verification_report(tmp_path: Path) -> None:
+    actor_private_key = Ed25519PrivateKey.generate()
+    export_private_key = Ed25519PrivateKey.generate()
+    first = _signed_event(actor_private_key, sequence=1, prev_hash="GENESIS")
+    second = _signed_event(actor_private_key, sequence=2, prev_hash=first["hash"])
+    export_dir = tmp_path / "forensic-export"
+
+    result = write_public_ledger_export(
+        events=[first, second],
+        export_dir=export_dir,
+        public_keys=[
+            public_key_record(
+                key_id=ACTOR_KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=actor_private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ],
+        export_authority=ExportAuthority(
+            key_id=EXPORT_KEY_ID,
+            actor_id="export-authority-01",
+            private_key=export_private_key,
+        ),
+        export_id="export-2026-02-03-001",
+        tenant_id=TENANT_ID,
+        stream_id=STREAM_ID,
+        created_at=CREATED_AT,
+        include_verification_report=True,
+    )
+
+    expected_files = {
+        "events.jsonl",
+        "key-events.jsonl",
+        "manifest.json",
+        "public-keys.json",
+        "schema.json",
+        "verification-profile.json",
+        "verification-report.json",
+    }
+    assert expected_files == {path.name for path in export_dir.iterdir()}
+    assert not (export_dir / "facts.jsonl").exists()
+    assert result.verification_report_path == export_dir / "verification-report.json"
+    assert result.verification_result == "VALID_FULL_STRICT"
+    assert result.manifest_hash == _sha256_file(export_dir / "manifest.json")
+
+    report = verify_export(export_dir)
+    assert report["result"] == "VALID_FULL_STRICT"
+    assert report["guarantees"]["integrity_verified"] is True
+    assert report["guarantees"]["origin_authenticity_verified"] is True
+    assert report["guarantees"]["authority_verified"] is True
+    assert report["guarantees"]["completeness_verified"] is True
+    assert report["guarantees"]["truth_verified"] is False
+    assert report == _load_json(export_dir / "verification-report.json")
+
+    manifest = _load_json(export_dir / "manifest.json")
+    public_keys = _load_json(export_dir / "public-keys.json")
+    assert manifest["signature"]["key_id"] == EXPORT_KEY_ID
+    assert manifest["hashes"]["events_file_sha256"] == _sha256_file(export_dir / "events.jsonl")
+    assert manifest["hashes"]["public_keys_file_sha256"] == _sha256_file(
+        export_dir / "public-keys.json"
+    )
+    assert {key["key_id"] for key in public_keys["keys"]} == {ACTOR_KEY_ID, EXPORT_KEY_ID}
+    assert manifest["counts"]["event_count"] == 2
+    assert manifest["range"]["first_sequence"] == 1
+    assert manifest["range"]["last_sequence"] == 2
+
+
+def test_export_tail_truncation_causes_manifest_mismatch(tmp_path: Path) -> None:
+    export_dir = _write_valid_export(tmp_path)
+    lines = (export_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    (export_dir / "events.jsonl").write_text(lines[0] + "\n", encoding="utf-8")
+
+    report = verify_export(export_dir)
+
+    assert report["result"] == "INVALID"
+    assert "manifest_file_hash_mismatch:events_file_sha256" in report["errors"]
+    assert "manifest_event_count_mismatch" in report["errors"]
+
+
+def test_export_detail_tampering_causes_hash_mismatch(tmp_path: Path) -> None:
+    export_dir = _write_valid_export(tmp_path)
+    events = [
+        json.loads(line)
+        for line in (export_dir / "events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    events[0]["detail"]["fact_type"] = "tampered"
+    (export_dir / "events.jsonl").write_text(
+        "".join(_canonical_json(event) + "\n" for event in events),
+        encoding="utf-8",
+    )
+
+    report = verify_export(export_dir)
+
+    assert report["result"] == "INVALID"
+    assert "event_hash_mismatch:evt_01HXEXPORT0000000000000001" in report["errors"]
+
+
+def test_export_missing_manifest_cannot_be_full_strict(tmp_path: Path) -> None:
+    export_dir = _write_valid_export(tmp_path)
+    (export_dir / "manifest.json").unlink()
+
+    report = verify_export(export_dir)
+
+    assert report["result"] == "VALID_WITH_LIMITATIONS"
+    assert report["guarantees"]["completeness_verified"] is False
+    assert report["guarantees"]["truth_verified"] is False
+
+
+def test_export_rejects_inline_fact_payload_and_private_material(tmp_path: Path) -> None:
+    actor_private_key = Ed25519PrivateKey.generate()
+    export_private_key = Ed25519PrivateKey.generate()
+    event = _signed_event(actor_private_key, sequence=1, prev_hash="GENESIS")
+    event["detail"] = dict(event["detail"])
+    event["detail"]["payload"] = "plaintext fact body"
+
+    with pytest.raises(ValueError, match="inline fact payload"):
+        write_public_ledger_export(
+            events=[event],
+            export_dir=tmp_path / "inline-payload",
+            public_keys=[
+                public_key_record(
+                    key_id=ACTOR_KEY_ID,
+                    actor_id=ACTOR_ID,
+                    public_key=actor_private_key.public_key(),
+                    permissions=["fact.store"],
+                )
+            ],
+            export_authority=ExportAuthority(
+                key_id=EXPORT_KEY_ID,
+                actor_id="export-authority-01",
+                private_key=export_private_key,
+            ),
+            export_id="export-2026-02-03-001",
+            tenant_id=TENANT_ID,
+            stream_id=STREAM_ID,
+            created_at=CREATED_AT,
+        )
+
+    event = _signed_event(actor_private_key, sequence=1, prev_hash="GENESIS")
+    with pytest.raises(ValueError, match="forbidden token: private_key"):
+        write_public_ledger_export(
+            events=[event],
+            export_dir=tmp_path / "private-material",
+            public_keys=[
+                {
+                    **public_key_record(
+                        key_id=ACTOR_KEY_ID,
+                        actor_id=ACTOR_ID,
+                        public_key=actor_private_key.public_key(),
+                        permissions=["fact.store"],
+                    ),
+                    "private_key": "never export this",
+                }
+            ],
+            export_authority=ExportAuthority(
+                key_id=EXPORT_KEY_ID,
+                actor_id="export-authority-01",
+                private_key=export_private_key,
+            ),
+            export_id="export-2026-02-03-001",
+            tenant_id=TENANT_ID,
+            stream_id=STREAM_ID,
+            created_at=CREATED_AT,
+        )
+
+
+def test_export_contains_no_private_keys_secrets_or_executables(tmp_path: Path) -> None:
+    export_dir = _write_valid_export(tmp_path)
+
+    for path in export_dir.iterdir():
+        assert path.suffix in {".json", ".jsonl"}
+        assert not os.access(path, os.X_OK)
+        text = path.read_text(encoding="utf-8").lower()
+        assert "private_key" not in text
+        assert "begin private key" not in text
+        assert "secret_key" not in text
+
+
+def test_legacy_export_is_marked_integrity_only(tmp_path: Path) -> None:
+    vector = _load_json(Path("tests/fixtures/ledger_verifier/legacy_v0_vector_1.json"))
+    export_dir = tmp_path / "legacy-export"
+
+    result = write_legacy_ledger_export(vectors=[vector], export_dir=export_dir)
+
+    assert result.verification_result == "VALID_INTEGRITY_ONLY"
+    assert result.limitations == (
+        "legacy_v0_integrity_only",
+        "origin_authenticity_not_verified",
+        "manifest_completeness_not_available",
+    )
+    assert "integrity-only" in result.limitations_path.read_text(encoding="utf-8")
+    assert verify_export(export_dir)["result"] == "VALID_INTEGRITY_ONLY"
+
+
+def test_export_ledger_cli_writes_verifiable_package(tmp_path: Path) -> None:
+    actor_private_key = Ed25519PrivateKey.generate()
+    export_private_key = Ed25519PrivateKey.generate()
+    event = _signed_event(actor_private_key, sequence=1, prev_hash="GENESIS")
+    events_path = tmp_path / "events.jsonl"
+    keys_path = tmp_path / "public-keys.json"
+    seed_path = tmp_path / "export-authority.seed"
+    export_dir = tmp_path / "cli-export"
+    events_path.write_text(_canonical_json(event) + "\n", encoding="utf-8")
+    keys_path.write_text(
+        _canonical_json(
+            {
+                "keys": [
+                    public_key_record(
+                        key_id=ACTOR_KEY_ID,
+                        actor_id=ACTOR_ID,
+                        public_key=actor_private_key.public_key(),
+                        permissions=["fact.store"],
+                    )
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    seed_path.write_text(_private_seed_b64url(export_private_key), encoding="utf-8")
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "export-ledger",
+            str(events_path),
+            str(export_dir),
+            "--public-keys",
+            str(keys_path),
+            "--export-id",
+            "export-2026-02-03-001",
+            "--tenant-id",
+            TENANT_ID,
+            "--stream-id",
+            STREAM_ID,
+            "--export-authority-key-id",
+            EXPORT_KEY_ID,
+            "--export-authority-actor-id",
+            "export-authority-01",
+            "--export-authority-private-key-seed",
+            str(seed_path),
+            "--created-at",
+            CREATED_AT,
+            "--include-verification-report",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    summary = json.loads(result.output)
+    assert summary["verification_result"] == "VALID_FULL_STRICT"
+    assert verify_export(export_dir)["result"] == "VALID_FULL_STRICT"
+    assert not (export_dir / "facts.jsonl").exists()
+
+
+def _write_valid_export(tmp_path: Path) -> Path:
+    actor_private_key = Ed25519PrivateKey.generate()
+    export_private_key = Ed25519PrivateKey.generate()
+    first = _signed_event(actor_private_key, sequence=1, prev_hash="GENESIS")
+    second = _signed_event(actor_private_key, sequence=2, prev_hash=first["hash"])
+    export_dir = tmp_path / "forensic-export"
+    write_public_ledger_export(
+        events=[first, second],
+        export_dir=export_dir,
+        public_keys=[
+            public_key_record(
+                key_id=ACTOR_KEY_ID,
+                actor_id=ACTOR_ID,
+                public_key=actor_private_key.public_key(),
+                permissions=["fact.store"],
+            )
+        ],
+        export_authority=ExportAuthority(
+            key_id=EXPORT_KEY_ID,
+            actor_id="export-authority-01",
+            private_key=export_private_key,
+        ),
+        export_id="export-2026-02-03-001",
+        tenant_id=TENANT_ID,
+        stream_id=STREAM_ID,
+        created_at=CREATED_AT,
+        include_verification_report=True,
+    )
+    return export_dir
+
+
+def _signed_event(
+    private_key: Ed25519PrivateKey, *, sequence: int, prev_hash: str
+) -> dict[str, Any]:
+    event: dict[str, Any] = {
+        "action": "fact.store",
+        "actor_id": ACTOR_ID,
+        "actor_key_id": ACTOR_KEY_ID,
+        "detail": {
+            "fact_type": "risk_signal",
+            "payload_ref": f"facts/tenant-acme/fact-{sequence:03d}.enc.json",
+            "subject_ref": "subject:hmac-sha256:01HX",
+        },
+        "event_id": f"evt_01HXEXPORT000000000000000{sequence}",
+        "hash_alg": "sha256",
+        "issued_at": CREATED_AT,
+        "nonce": f"nonce_01HXEXPORT000000000000000{sequence}",
+        "prev_hash": prev_hash,
+        "project": "cortex-persist",
+        "recorded_at": CREATED_AT,
+        "schema_version": "cortex-ledger-event-v1",
+        "sequence": sequence,
+        "signature_alg": "ed25519",
+        "stream_id": STREAM_ID,
+        "target": f"fact:{sequence:03d}",
+        "tenant_id": TENANT_ID,
+    }
+    event["hash"] = _event_hash(event)
+    event["origin_signature"] = _b64url_encode(
+        private_key.sign(_canonical_json(event).encode("utf-8"))
+    )
+    return event
+
+
+def _event_hash(event: dict[str, Any]) -> str:
+    scope = dict(event)
+    scope.pop("hash", None)
+    scope.pop("origin_signature", None)
+    return hashlib.sha256(_canonical_json(scope).encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _private_seed_b64url(private_key: Ed25519PrivateKey) -> str:
+    seed = private_key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
+    return _b64url_encode(seed)
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(value, dict)
+    return value


### PR DESCRIPTION
## Summary
- Add a forensic public ledger export package writer for `public-v1-strict` events.
- Add `cortex export-ledger` to write `events.jsonl`, signed `manifest.json`, `public-keys.json`, `key-events.jsonl`, `schema.json`, `verification-profile.json`, and optional `verification-report.json`.
- Keep fact export separate by rejecting inline fact payload fields and never writing `facts.jsonl`.
- Add legacy-v0 integrity-only export support with explicit limitations instead of claiming origin authenticity or manifest completeness.

## Scope
Stacked on PR #352 / branch `codex/m2-offline-ledger-verifier`. This PR is export generation only. It does not enforce runtime origin signatures, add replay tables, mutate write paths, change migrations, add GDPR erasure runtime, or add human oversight runtime.

Closes #281

## Validation
- `ruff check cortex/ledger/public_export.py cortex/cli/public_export_cmds.py tests/test_public_ledger_export.py` -> passed
- `ruff format --check cortex/ledger/public_export.py cortex/cli/public_export_cmds.py tests/test_public_ledger_export.py` -> passed
- `pyright cortex/ledger/public_export.py cortex/cli/public_export_cmds.py tests/test_public_ledger_export.py` -> 0 errors
- `python3 -m py_compile cortex/ledger/public_export.py cortex/cli/public_export_cmds.py tests/test_public_ledger_export.py` -> passed
- `pytest tests/test_ledger_integrity_verification.py tests/test_cli_init.py tests/test_public_ledger_export.py tests/test_public_ledger_verifier.py tests/test_public_ledger_verifier_vectors.py -v` -> 37 passed, 1 dependency warning
- `git diff --check origin/codex/m2-offline-ledger-verifier...HEAD && git diff --check` -> passed
- pre-push hooks: `ruff` and `ruff-format` -> passed