### PR TITLE
M4 — Enforce origin signatures in strict mode

### DIFF
--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -7,7 +7,16 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from cortex.ledger.ledger_core import SovereignLedger
-    from cortex.ledger.models import LedgerEvent, SemanticStatus
+    from cortex.ledger.models import LedgerEvent, LedgerOriginSignature, SemanticStatus
+    from cortex.ledger.origin import (
+        OriginKeyRecord,
+        OriginKeyRegistry,
+        OriginSignatureError,
+        OriginSignaturePolicy,
+        origin_payload_hash,
+        sign_event_origin,
+        verify_event_origin,
+    )
     from cortex.ledger.queue import EnrichmentQueue
     from cortex.ledger.store import LedgerStore
     from cortex.ledger.verifier import LedgerVerifier
@@ -15,6 +24,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "LedgerEvent",
+    "LedgerOriginSignature",
     "SemanticStatus",
     "SovereignLedger",
     "ImmutableLedger",
@@ -22,15 +32,30 @@ __all__ = [
     "LedgerWriter",
     "LedgerVerifier",
     "EnrichmentQueue",
+    "OriginKeyRecord",
+    "OriginKeyRegistry",
+    "OriginSignatureError",
+    "OriginSignaturePolicy",
+    "origin_payload_hash",
+    "sign_event_origin",
+    "verify_event_origin",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "LedgerEvent": ("cortex.ledger.models", "LedgerEvent"),
+    "LedgerOriginSignature": ("cortex.ledger.models", "LedgerOriginSignature"),
     "SemanticStatus": ("cortex.ledger.models", "SemanticStatus"),
     "LedgerStore": ("cortex.ledger.store", "LedgerStore"),
     "LedgerWriter": ("cortex.ledger.writer", "LedgerWriter"),
     "LedgerVerifier": ("cortex.ledger.verifier", "LedgerVerifier"),
     "EnrichmentQueue": ("cortex.ledger.queue", "EnrichmentQueue"),
+    "OriginKeyRecord": ("cortex.ledger.origin", "OriginKeyRecord"),
+    "OriginKeyRegistry": ("cortex.ledger.origin", "OriginKeyRegistry"),
+    "OriginSignatureError": ("cortex.ledger.origin", "OriginSignatureError"),
+    "OriginSignaturePolicy": ("cortex.ledger.origin", "OriginSignaturePolicy"),
+    "origin_payload_hash": ("cortex.ledger.origin", "origin_payload_hash"),
+    "sign_event_origin": ("cortex.ledger.origin", "sign_event_origin"),
+    "verify_event_origin": ("cortex.ledger.origin", "verify_event_origin"),
 }
 
 

--- a/cortex/ledger/models.py
+++ b/cortex/ledger/models.py
@@ -51,6 +51,23 @@ class ActionResult:
 
 
 @dataclass(frozen=True)
+class LedgerOriginSignature:
+    actor_id: str
+    actor_key_id: str
+    tenant_id: str
+    action: str
+    payload_hash: str
+    nonce: str
+    issued_at: str
+    origin_signature: str | None = None
+    signature_alg: Literal["ed25519"] = "ed25519"
+    hash_alg: Literal["sha256"] = "sha256"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
 class LedgerEvent:
     event_id: str
     ts: str
@@ -62,6 +79,7 @@ class LedgerEvent:
     intent: IntentPayload | None = None
     correlation_id: str | None = None
     trace_id: str | None = None
+    origin: LedgerOriginSignature | None = None
     prev_hash: str | None = None
     hash: str | None = None
     semantic_status: SemanticStatus = "pending"
@@ -115,7 +133,7 @@ class LedgerEvent:
         )
 
     def to_payload(self) -> dict[str, Any]:
-        return {
+        payload = {
             "event_id": self.event_id,
             "timestamp": self.ts,
             "tool": self.tool,
@@ -126,11 +144,18 @@ class LedgerEvent:
             "intent": self.intent.to_dict() if self.intent else None,
             "correlation_id": self.correlation_id,
             "trace_id": self.trace_id,
-            "prev_hash": self.prev_hash,
-            "hash": self.hash,
-            "semantic_status": self.semantic_status,
-            "metadata": self.metadata,
         }
+        if self.origin is not None:
+            payload["origin"] = self.origin.to_dict()
+        payload.update(
+            {
+                "prev_hash": self.prev_hash,
+                "hash": self.hash,
+                "semantic_status": self.semantic_status,
+                "metadata": self.metadata,
+            }
+        )
+        return payload
 
     def to_json(self) -> str:
         return json.dumps(self.to_payload(), ensure_ascii=False, separators=(",", ":"))

--- a/cortex/ledger/origin.py
+++ b/cortex/ledger/origin.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import dataclasses
+import hashlib
+import secrets
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from cortex.ledger.models import LedgerEvent, LedgerOriginSignature
+from cortex.ledger.public_verifier_utils import _canonical_public_json
+
+
+class OriginSignatureError(ValueError):
+    """Raised when a ledger event fails strict origin-auth validation."""
+
+
+@dataclass(frozen=True)
+class OriginKeyRecord:
+    key_id: str
+    actor_id: str
+    public_key: Ed25519PublicKey
+    permissions: frozenset[str]
+    tenant_id: str | None = None
+    actor_type: str = "agent"
+    status: str = "active"
+    environment: str = "test"
+    valid_from: str | None = None
+    valid_until: str | None = None
+    hardware_backed: bool = False
+
+    @staticmethod
+    def from_public_key(
+        *,
+        key_id: str,
+        actor_id: str,
+        public_key: Ed25519PublicKey,
+        permissions: Sequence[str],
+        tenant_id: str | None = None,
+        actor_type: str = "agent",
+        status: str = "active",
+        environment: str = "test",
+        valid_from: str | None = None,
+        valid_until: str | None = None,
+        hardware_backed: bool = False,
+    ) -> OriginKeyRecord:
+        return OriginKeyRecord(
+            key_id=key_id,
+            actor_id=actor_id,
+            public_key=public_key,
+            permissions=frozenset(permissions),
+            tenant_id=tenant_id,
+            actor_type=actor_type,
+            status=status,
+            environment=environment,
+            valid_from=valid_from,
+            valid_until=valid_until,
+            hardware_backed=hardware_backed,
+        )
+
+    def to_public_dict(self) -> dict[str, Any]:
+        record: dict[str, Any] = {
+            "actor_id": self.actor_id,
+            "actor_type": self.actor_type,
+            "algorithm": "ed25519",
+            "environment": self.environment,
+            "hardware_backed": self.hardware_backed,
+            "key_id": self.key_id,
+            "permissions": sorted(self.permissions),
+            "public_key": _public_key_b64url(self.public_key),
+            "status": self.status,
+            "valid_from": self.valid_from,
+            "valid_until": self.valid_until,
+        }
+        if self.tenant_id is not None:
+            record["tenant_id"] = self.tenant_id
+        return record
+
+
+class OriginKeyRegistry:
+    def __init__(self, records: Sequence[OriginKeyRecord] = ()) -> None:
+        self._records: dict[str, OriginKeyRecord] = {}
+        for record in records:
+            self.add(record)
+
+    def add(self, record: OriginKeyRecord) -> None:
+        if record.key_id in self._records:
+            raise ValueError(f"duplicate origin key id: {record.key_id}")
+        self._records[record.key_id] = record
+
+    def get(self, key_id: str) -> OriginKeyRecord | None:
+        return self._records.get(key_id)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return {
+            "keys": [
+                record.to_public_dict()
+                for record in sorted(self._records.values(), key=lambda item: item.key_id)
+            ],
+            "schema_version": "cortex-origin-key-registry-v1",
+        }
+
+
+@dataclass(frozen=True)
+class OriginSignaturePolicy:
+    registry: OriginKeyRegistry
+    strict: bool = True
+
+    @staticmethod
+    def strict_mode(registry: OriginKeyRegistry) -> OriginSignaturePolicy:
+        return OriginSignaturePolicy(registry=registry, strict=True)
+
+    def validate_event(self, event: LedgerEvent) -> None:
+        if not self.strict:
+            return
+        verify_event_origin(event, self.registry)
+
+
+def sign_event_origin(
+    event: LedgerEvent,
+    *,
+    key_id: str,
+    private_key: Ed25519PrivateKey,
+    tenant_id: str | None = None,
+    issued_at: str | None = None,
+    nonce: str | None = None,
+) -> LedgerEvent:
+    """Attach an Ed25519 origin envelope to an event before ledger persistence."""
+    tenant = _resolve_tenant_id(event, tenant_id)
+    metadata = dict(event.metadata)
+    metadata["tenant_id"] = tenant
+    base_event = dataclasses.replace(event, metadata=metadata, origin=None)
+    unsigned_origin = LedgerOriginSignature(
+        actor_id=base_event.actor,
+        actor_key_id=key_id,
+        tenant_id=tenant,
+        action=base_event.action,
+        payload_hash=origin_payload_hash(base_event),
+        nonce=nonce or secrets.token_urlsafe(24),
+        issued_at=issued_at or _utc_now(),
+        origin_signature=None,
+    )
+    unsigned_event = dataclasses.replace(base_event, origin=unsigned_origin)
+    signature = _b64url_encode(private_key.sign(origin_signature_scope(unsigned_event)))
+    signed_origin = dataclasses.replace(unsigned_origin, origin_signature=signature)
+    return dataclasses.replace(unsigned_event, origin=signed_origin)
+
+
+def verify_event_origin(event: LedgerEvent, registry: OriginKeyRegistry) -> None:
+    origin = event.origin
+    if origin is None or not origin.origin_signature:
+        raise OriginSignatureError("origin_signature_missing")
+    if origin.signature_alg != "ed25519":
+        raise OriginSignatureError(f"origin_signature_alg_unsupported:{origin.signature_alg}")
+    if origin.hash_alg != "sha256":
+        raise OriginSignatureError(f"origin_payload_hash_alg_unsupported:{origin.hash_alg}")
+    if origin.actor_id != event.actor:
+        raise OriginSignatureError("origin_actor_mismatch")
+    if origin.action != event.action:
+        raise OriginSignatureError("origin_action_mismatch")
+    if origin.tenant_id != _event_tenant_id(event):
+        raise OriginSignatureError("origin_tenant_mismatch")
+    if origin.payload_hash != origin_payload_hash(event):
+        raise OriginSignatureError("origin_payload_hash_mismatch")
+
+    key = registry.get(origin.actor_key_id)
+    if key is None:
+        raise OriginSignatureError(f"origin_key_missing:{origin.actor_key_id}")
+    if key.actor_id != origin.actor_id:
+        raise OriginSignatureError("origin_key_actor_mismatch")
+    if key.tenant_id is not None and key.tenant_id != origin.tenant_id:
+        raise OriginSignatureError("origin_key_tenant_mismatch")
+    if event.action not in key.permissions:
+        raise OriginSignatureError(f"origin_key_permission_denied:{event.action}")
+    _validate_key_for_issued_at(key, origin.issued_at)
+
+    try:
+        key.public_key.verify(
+            _b64url_decode(origin.origin_signature),
+            origin_signature_scope(event),
+        )
+    except (InvalidSignature, ValueError) as exc:
+        raise OriginSignatureError("origin_signature_invalid") from exc
+
+
+def origin_payload_hash(event: LedgerEvent) -> str:
+    payload = event.to_payload()
+    payload.pop("hash", None)
+    payload.pop("prev_hash", None)
+    payload.pop("origin", None)
+    return hashlib.sha256(_canonical_public_json(payload).encode("utf-8")).hexdigest()
+
+
+def origin_signature_scope(event: LedgerEvent) -> bytes:
+    payload = event.to_payload()
+    payload.pop("hash", None)
+    payload.pop("prev_hash", None)
+    origin = payload.get("origin")
+    if not isinstance(origin, dict):
+        raise OriginSignatureError("origin_signature_missing")
+    signature_scope = dict(origin)
+    signature_scope.pop("origin_signature", None)
+    payload["origin"] = signature_scope
+    return _canonical_public_json(payload).encode("utf-8")
+
+
+def _resolve_tenant_id(event: LedgerEvent, requested_tenant_id: str | None) -> str:
+    event_tenant = event.metadata.get("tenant_id")
+    if isinstance(event_tenant, str) and event_tenant:
+        if requested_tenant_id is not None and requested_tenant_id != event_tenant:
+            raise OriginSignatureError("origin_tenant_mismatch")
+        return event_tenant
+    if requested_tenant_id is not None:
+        return requested_tenant_id
+    return "default"
+
+
+def _event_tenant_id(event: LedgerEvent) -> str:
+    tenant_id = event.metadata.get("tenant_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise OriginSignatureError("origin_tenant_missing")
+    return tenant_id
+
+
+def _validate_key_for_issued_at(key: OriginKeyRecord, issued_at: str) -> None:
+    issued = _parse_utc(issued_at)
+    if key.status == "future":
+        raise OriginSignatureError(f"origin_key_not_active:{key.key_id}")
+    if key.status not in {"active", "rotated", "revoked"}:
+        raise OriginSignatureError(f"origin_key_not_active:{key.key_id}")
+    if key.status == "revoked" and key.valid_until is None:
+        raise OriginSignatureError(f"origin_key_revoked_without_valid_until:{key.key_id}")
+    if key.valid_from is not None and issued < _parse_utc(key.valid_from):
+        raise OriginSignatureError(f"origin_key_not_yet_valid:{key.key_id}")
+    if key.valid_until is not None and issued > _parse_utc(key.valid_until):
+        raise OriginSignatureError(f"origin_key_expired:{key.key_id}")
+
+
+def _parse_utc(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise OriginSignatureError("origin_timestamp_invalid") from exc
+    if parsed.tzinfo is None:
+        raise OriginSignatureError("origin_timestamp_missing_timezone")
+    return parsed
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _b64url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _b64url_decode(value: str) -> bytes:
+    if not value:
+        raise ValueError("empty_base64url")
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.b64decode((value + padding).encode("ascii"), altchars=b"-_", validate=True)
+    except (binascii.Error, UnicodeEncodeError) as exc:
+        raise ValueError("invalid_base64url") from exc
+
+
+def _public_key_b64url(public_key: Ed25519PublicKey) -> str:
+    return _b64url_encode(public_key.public_bytes(Encoding.Raw, PublicFormat.Raw))

--- a/cortex/ledger/public_export.py
+++ b/cortex/ledger/public_export.py
@@ -111,7 +111,14 @@ def write_public_ledger_export(
         stream_id=stream_id,
     )
     _validate_public_key_records(key_objects)
-    _assert_no_private_material({"events": event_objects, "public_keys": key_objects})
+    key_event_objects = [dict(event) for event in key_events]
+    _assert_no_private_material(
+        {
+            "events": event_objects,
+            "key_events": key_event_objects,
+            "public_keys": key_objects,
+        }
+    )
 
     generated_at = created_at or _utc_now()
     events_path = root / "events.jsonl"
@@ -128,7 +135,7 @@ def write_public_ledger_export(
     )
     _write_text_atomic(
         key_events_path,
-        "".join(_canonical_public_json(dict(event)) + "\n" for event in key_events),
+        "".join(_canonical_public_json(event) + "\n" for event in key_event_objects),
     )
     _write_json_atomic(schema_path, _schema_document())
     _write_json_atomic(verification_profile_path, _verification_profile_document())

--- a/cortex/ledger/public_verifier.py
+++ b/cortex/ledger/public_verifier.py
@@ -398,15 +398,19 @@ class _PublicLedgerVerifier:
         event: Mapping[str, Any],
         index: int,
     ) -> bool:
+        status = key.get("status")
+        if status not in {"active", "rotated", "revoked"}:
+            self.errors.append(f"event_key_not_active:{index}")
+            return False
+        if status == "revoked" and not key.get("valid_until"):
+            self.errors.append(f"event_key_revoked_without_valid_until:{index}")
+            return False
         try:
             issued_at = _parse_utc(str(event["issued_at"]))
             valid_from = _parse_utc(str(key["valid_from"]))
             valid_until = _parse_utc(str(key["valid_until"]))
         except (KeyError, PublicVerifierError) as exc:
             self.errors.append(f"event_key_validity_invalid:{index}:{exc.__class__.__name__}")
-            return False
-        if key.get("status") != "active":
-            self.errors.append(f"event_key_not_active:{index}")
             return False
         if not valid_from <= issued_at <= valid_until:
             self.errors.append(f"event_key_outside_validity:{index}")

--- a/cortex/ledger/verifier.py
+++ b/cortex/ledger/verifier.py
@@ -4,7 +4,13 @@ import json
 import logging
 from typing import TYPE_CHECKING
 
-from cortex.ledger.models import ActionResult, ActionTarget, IntentPayload, LedgerEvent
+from cortex.ledger.models import (
+    ActionResult,
+    ActionTarget,
+    IntentPayload,
+    LedgerEvent,
+    LedgerOriginSignature,
+)
 from cortex.ledger.store import LedgerStore
 
 if TYPE_CHECKING:
@@ -139,6 +145,11 @@ class LedgerVerifier:
         target = ActionTarget(**payload["target"])
         result = ActionResult(**payload["result"])
         intent = IntentPayload(**payload["intent"]) if payload.get("intent") else None
+        origin = (
+            LedgerOriginSignature(**payload["origin"])
+            if isinstance(payload.get("origin"), dict)
+            else None
+        )
 
         return LedgerEvent(
             event_id=payload["event_id"],
@@ -151,6 +162,7 @@ class LedgerVerifier:
             intent=intent,
             correlation_id=payload.get("correlation_id"),
             trace_id=payload.get("trace_id"),
+            origin=origin,
             prev_hash=payload.get("prev_hash"),
             hash=payload.get("hash"),
             semantic_status=payload.get("semantic_status", "pending"),

--- a/cortex/ledger/writer.py
+++ b/cortex/ledger/writer.py
@@ -1,16 +1,31 @@
 import dataclasses
+from typing import Protocol
 
 from cortex.ledger.models import LedgerEvent
 from cortex.ledger.queue import EnrichmentQueue
 from cortex.ledger.store import LedgerStore
 
 
+class _OriginSignaturePolicy(Protocol):
+    def validate_event(self, event: LedgerEvent) -> None: ...
+
+
 class LedgerWriter:
-    def __init__(self, store: LedgerStore, queue: EnrichmentQueue) -> None:
+    def __init__(
+        self,
+        store: LedgerStore,
+        queue: EnrichmentQueue,
+        *,
+        origin_policy: _OriginSignaturePolicy | None = None,
+    ) -> None:
         self.store = store
         self.queue = queue
+        self.origin_policy = origin_policy
 
     def append(self, event: LedgerEvent) -> str:
+        if self.origin_policy is not None:
+            self.origin_policy.validate_event(event)
+
         with self.store.tx() as conn:
             # 1. Get last hash
             cursor = conn.execute("SELECT hash FROM ledger_events ORDER BY rowid DESC LIMIT 1")

--- a/docs/compliance/M4_ORIGIN_SIGNATURES_STRICT_MODE.md
+++ b/docs/compliance/M4_ORIGIN_SIGNATURES_STRICT_MODE.md
@@ -1,0 +1,88 @@
+# M4 Origin Signatures Strict Mode
+
+Status: draft
+
+M4 adds runtime admission checks for strict ledger events before persistence.
+It turns origin fields from export-only evidence into a write-time contract:
+agent or external events in strict mode must carry a valid Ed25519 origin
+signature, an actor key, a tenant binding, a namespaced action, a payload hash,
+a nonce, and an issued timestamp.
+
+## Admission Contract
+
+Strict admission rejects the event before opening the ledger write transaction
+when any origin-auth control fails. Rejected events do not create:
+
+- a `ledger_events` row;
+- an enrichment job;
+- a consumed nonce or other replay side effect;
+- a downstream semantic enrichment side effect from `LedgerWriter`.
+
+Nonce reservation remains a later replay-admission control. M4 verifies nonce
+presence in the signed envelope and deliberately performs no durable nonce
+mutation before origin authenticity succeeds.
+
+## Signed Envelope
+
+The runtime envelope is stored under `LedgerEvent.origin` and contains:
+
+- `actor_id`
+- `actor_key_id`
+- `tenant_id`
+- `action`
+- `payload_hash`
+- `nonce`
+- `issued_at`
+- `signature_alg`
+- `hash_alg`
+- `origin_signature`
+
+`payload_hash` is:
+
+```text
+SHA-256(canonical_json(event without prev_hash, hash, and origin))
+```
+
+`origin_signature` is:
+
+```text
+Ed25519.sign(actor_private_key, canonical_json(event without prev_hash, hash, and origin_signature))
+```
+
+The hash and signature scope exclude ledger-chain fields because those are
+assigned by the writer after admission. This lets the writer reject invalid
+origin auth before persistence while still computing the normal chain hash.
+
+## Key Registry
+
+`OriginKeyRegistry` binds each `actor_key_id` to:
+
+- the actor id;
+- optional tenant id;
+- Ed25519 public key material;
+- namespaced permissions such as `fact.store`, `fact.deprecate`, or
+  `ledger.export`;
+- status and validity window.
+
+Private keys never appear in public registry output. `OriginKeyRecord` stores
+only the public key, and `to_public_dict()` serializes public material only.
+
+## Key Status Semantics
+
+`active` keys verify events issued inside their validity window.
+
+`revoked` or `rotated` keys can verify historical events issued inside their
+declared validity window. Events issued after `valid_until` are rejected. A
+revoked key without a cutoff is rejected because offline verification cannot
+bound the historical authority period.
+
+`future`, disabled, unknown, or otherwise unsupported statuses are rejected.
+Keys with `valid_from` after the event `issued_at` are rejected.
+
+## Trust Semantics
+
+Origin authenticity is attribution, not truth. A valid signature proves the
+registered actor key signed the event scope and was authorized for the action at
+the event time. It does not prove the event content is factually true, complete,
+fresh online, or free of later operational compromise. `truth_verified` remains
+false unless a future truth-verification mechanism explicitly proves it.

--- a/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
+++ b/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
@@ -4,8 +4,9 @@ Status: draft
 
 This document defines the forensic ledger export package produced for
 independent offline verification. The package is evidence packaging only: it
-does not enforce runtime origin signing, authorize agent actions, reserve
-nonces, or export fact payloads.
+does not reserve replay nonces, prove source-database completeness, or export
+fact payloads. Runtime strict origin signing is defined in
+[`M4_ORIGIN_SIGNATURES_STRICT_MODE.md`](M4_ORIGIN_SIGNATURES_STRICT_MODE.md).
 
 ## Required Artifacts
 
@@ -102,3 +103,7 @@ M3 does not:
 - export plaintext facts or reconstruct fact contents.
 
 Those controls belong to later milestones, especially M4, M5, and M6.
+
+M4 adds runtime origin-signature admission for `LedgerWriter` strict mode. M5
+remains responsible for durable replay nonce reservation, and M6 remains
+responsible for immutable-ledger no-PII enforcement.

--- a/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
+++ b/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
@@ -101,6 +101,13 @@ Reports must split guarantees:
 For offline historical exports, `online_freshness_verified` is false. By
 default, `truth_verified` is false.
 
+## Key Rotation
+
+Actor keys are valid only for events whose `issued_at` falls inside the key
+validity window. `active` keys verify current events. `rotated` and `revoked`
+keys may still verify historical events inside their declared window, but
+events after `valid_until` are rejected.
+
 ## CLI Contract
 
 The read-only verifier CLI accepts either a `public-v1-strict` export directory

--- a/tests/test_lazy_package_imports.py
+++ b/tests/test_lazy_package_imports.py
@@ -78,6 +78,22 @@ def test_routes_submodules_materialize_on_demand() -> None:
         assert graph_module not in sys.modules
 
 
+def test_ledger_origin_signatures_materialize_on_demand() -> None:
+    package_name = "cortex.ledger"
+    models_module = "cortex.ledger.models"
+    origin_module = "cortex.ledger.origin"
+
+    with _temporarily_reset_modules(package_name, models_module, origin_module):
+        module = importlib.import_module(package_name)
+
+        assert origin_module not in sys.modules
+        assert module.LedgerEvent.__name__ == "LedgerEvent"
+        assert models_module in sys.modules
+        assert origin_module not in sys.modules
+        assert module.OriginKeyRegistry.__name__ == "OriginKeyRegistry"
+        assert origin_module in sys.modules
+
+
 def test_browser_package_import_is_lazy_without_playwright() -> None:
     package_name = "cortex.extensions.browser"
     engine_module = "cortex.extensions.browser.engine"

--- a/tests/test_ledger_origin_signatures.py
+++ b/tests/test_ledger_origin_signatures.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.ledger.models import ActionResult, ActionTarget, LedgerEvent
+from cortex.ledger.origin import (
+    OriginKeyRecord,
+    OriginKeyRegistry,
+    OriginSignatureError,
+    OriginSignaturePolicy,
+    sign_event_origin,
+    verify_event_origin,
+)
+from cortex.ledger.queue import EnrichmentQueue
+from cortex.ledger.store import LedgerStore
+from cortex.ledger.verifier import LedgerVerifier
+from cortex.ledger.writer import LedgerWriter
+
+ACTOR_ID = "agent-risk-01"
+OTHER_ACTOR_ID = "agent-risk-02"
+TENANT_ID = "tenant-acme"
+KEY_ID = "ed25519:agent-risk-01:runtime-001"
+ISSUED_AT = "2026-02-03T10:15:30Z"
+NONCE = "nonce_01HXORIGIN000000000000001"
+
+
+def test_strict_origin_policy_accepts_signed_authorized_event(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        issued_at=ISSUED_AT,
+        nonce=NONCE,
+    )
+
+    event_id = writer.append(event)
+
+    with store.tx() as conn:
+        row = conn.execute(
+            "SELECT payload_json FROM ledger_events WHERE event_id = ?",
+            (event_id,),
+        ).fetchone()
+    assert row is not None
+    payload = json.loads(row["payload_json"])
+    assert payload["origin"]["actor_id"] == ACTOR_ID
+    assert payload["origin"]["actor_key_id"] == KEY_ID
+    assert payload["origin"]["tenant_id"] == TENANT_ID
+    assert payload["origin"]["action"] == "fact.store"
+    assert payload["origin"]["hash_alg"] == "sha256"
+    assert payload["origin"]["signature_alg"] == "ed25519"
+    assert payload["origin"]["nonce"] == NONCE
+    assert isinstance(payload["origin"]["payload_hash"], str)
+    assert LedgerVerifier(store).verify_chain()["valid"] is True
+
+
+def test_strict_origin_policy_rejects_unsigned_event_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+
+    with pytest.raises(OriginSignatureError, match="origin_signature_missing"):
+        writer.append(_event())
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_bad_signature_before_persistence(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _strict_writer(tmp_path, private_key)
+    signed = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        issued_at=ISSUED_AT,
+        nonce=NONCE,
+    )
+    assert signed.origin is not None
+    bad_origin = dataclasses.replace(signed.origin, origin_signature="not-a-valid-signature")
+    bad_event = dataclasses.replace(signed, origin=bad_origin)
+
+    with pytest.raises(OriginSignatureError, match="origin_signature_invalid"):
+        writer.append(bad_event)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_actor_key_mismatch_before_persistence(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [
+            _record(
+                private_key,
+                actor_id=OTHER_ACTOR_ID,
+                permissions=["fact.store"],
+            )
+        ]
+    )
+    store, writer = _writer_with_registry(tmp_path, registry)
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        issued_at=ISSUED_AT,
+        nonce=NONCE,
+    )
+
+    with pytest.raises(OriginSignatureError, match="origin_key_actor_mismatch"):
+        writer.append(event)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_action_not_permitted_before_persistence(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [_record(private_key, permissions=["fact.deprecate"], valid_from="2026-01-01T00:00:00Z")]
+    )
+    store, writer = _writer_with_registry(tmp_path, registry)
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        issued_at=ISSUED_AT,
+        nonce=NONCE,
+    )
+
+    with pytest.raises(OriginSignatureError, match="origin_key_permission_denied:fact.store"):
+        writer.append(event)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_strict_origin_policy_rejects_revoked_future_key_before_persistence(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [
+            _record(
+                private_key,
+                status="revoked",
+                valid_from="2026-01-01T00:00:00Z",
+                valid_until="2026-02-01T00:00:00Z",
+            )
+        ]
+    )
+    store, writer = _writer_with_registry(tmp_path, registry)
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        issued_at=ISSUED_AT,
+        nonce=NONCE,
+    )
+
+    with pytest.raises(OriginSignatureError, match="origin_key_expired"):
+        writer.append(event)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+
+
+def test_rotated_historical_key_verifies_for_event_within_validity_window() -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry(
+        [
+            _record(
+                private_key,
+                status="revoked",
+                valid_from="2026-01-01T00:00:00Z",
+                valid_until="2026-03-01T00:00:00Z",
+            )
+        ]
+    )
+    event = sign_event_origin(
+        _event(),
+        key_id=KEY_ID,
+        private_key=private_key,
+        issued_at=ISSUED_AT,
+        nonce=NONCE,
+    )
+
+    verify_event_origin(event, registry)
+
+
+def test_origin_registry_public_export_excludes_private_key_material() -> None:
+    private_key = Ed25519PrivateKey.generate()
+    registry = OriginKeyRegistry([_record(private_key, permissions=["fact.store"])])
+
+    public_registry = registry.to_public_dict()
+    encoded = json.dumps(public_registry, sort_keys=True)
+
+    assert "public_key" in encoded
+    assert "private_key" not in encoded
+    assert "seed" not in encoded
+    assert "secret" not in encoded
+
+
+def _strict_writer(
+    tmp_path: Path,
+    private_key: Ed25519PrivateKey,
+) -> tuple[LedgerStore, LedgerWriter]:
+    registry = OriginKeyRegistry([_record(private_key, permissions=["fact.store"])])
+    return _writer_with_registry(tmp_path, registry)
+
+
+def _writer_with_registry(
+    tmp_path: Path,
+    registry: OriginKeyRegistry,
+) -> tuple[LedgerStore, LedgerWriter]:
+    store = LedgerStore(tmp_path / "ledger.db")
+    return (
+        store,
+        LedgerWriter(
+            store,
+            EnrichmentQueue(store),
+            origin_policy=OriginSignaturePolicy.strict_mode(registry),
+        ),
+    )
+
+
+def _record(
+    private_key: Ed25519PrivateKey,
+    *,
+    permissions: list[str] | None = None,
+    actor_id: str = ACTOR_ID,
+    tenant_id: str = TENANT_ID,
+    status: str = "active",
+    valid_from: str | None = "2026-01-01T00:00:00Z",
+    valid_until: str | None = "2027-01-01T00:00:00Z",
+) -> OriginKeyRecord:
+    return OriginKeyRecord.from_public_key(
+        key_id=KEY_ID,
+        actor_id=actor_id,
+        tenant_id=tenant_id,
+        public_key=private_key.public_key(),
+        permissions=permissions or ["fact.store"],
+        status=status,
+        valid_from=valid_from,
+        valid_until=valid_until,
+    )
+
+
+def _event() -> LedgerEvent:
+    return LedgerEvent.new(
+        tool="agent-runtime",
+        actor=ACTOR_ID,
+        action="fact.store",
+        target=ActionTarget(app="CORTEX", identifier="fact:001"),
+        result=ActionResult(ok=True, latency_ms=12, verified=True),
+        metadata={"project": "cortex-persist", "tenant_id": TENANT_ID},
+    )
+
+
+def _row_count(store: LedgerStore, table_name: str) -> int:
+    if table_name not in {"ledger_events", "enrichment_jobs"}:
+        raise ValueError(f"unsupported table: {table_name}")
+    with store.tx() as conn:
+        row = conn.execute(f"SELECT COUNT(*) AS count FROM {table_name}").fetchone()
+    return int(row["count"])

--- a/tests/test_public_ledger_export.py
+++ b/tests/test_public_ledger_export.py
@@ -195,6 +195,32 @@ def test_export_rejects_inline_fact_payload_and_private_material(tmp_path: Path)
             created_at=CREATED_AT,
         )
 
+    leaky_key_events_dir = tmp_path / "private-key-event"
+    with pytest.raises(ValueError, match="forbidden token: private_key"):
+        write_public_ledger_export(
+            events=[event],
+            export_dir=leaky_key_events_dir,
+            public_keys=[
+                public_key_record(
+                    key_id=ACTOR_KEY_ID,
+                    actor_id=ACTOR_ID,
+                    public_key=actor_private_key.public_key(),
+                    permissions=["fact.store"],
+                )
+            ],
+            export_authority=ExportAuthority(
+                key_id=EXPORT_KEY_ID,
+                actor_id="export-authority-01",
+                private_key=export_private_key,
+            ),
+            export_id="export-2026-02-03-001",
+            tenant_id=TENANT_ID,
+            stream_id=STREAM_ID,
+            created_at=CREATED_AT,
+            key_events=[{"key_id": ACTOR_KEY_ID, "private_key": "never write this"}],
+        )
+    assert not (leaky_key_events_dir / "key-events.jsonl").exists()
+
 
 def test_export_contains_no_private_keys_secrets_or_executables(tmp_path: Path) -> None:
     export_dir = _write_valid_export(tmp_path)

--- a/tests/test_public_ledger_verifier.py
+++ b/tests/test_public_ledger_verifier.py
@@ -113,6 +113,45 @@ def test_verify_export_rejects_actor_without_action_permission(tmp_path: Path) -
     assert "event_actor_key_permission_denied:evt_01HX0000000000000000000000" in report["errors"]
 
 
+def test_verify_export_accepts_rotated_historical_actor_key_without_manifest(
+    tmp_path: Path,
+) -> None:
+    export_dir = tmp_path / "export"
+    shutil.copytree(STRICT, export_dir)
+    (export_dir / "manifest.json").unlink()
+    registry_path = export_dir / "public-keys.json"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["keys"][0]["status"] = "revoked"
+    registry["keys"][0]["valid_until"] = "2026-06-01T00:00:00Z"
+    registry_path.write_text(json.dumps(registry), encoding="utf-8")
+
+    report = verify_export(export_dir)
+
+    assert report["result"] == "VALID_WITH_LIMITATIONS"
+    assert report["guarantees"]["authority_verified"] is True
+    assert report["guarantees"]["origin_authenticity_verified"] is True
+    assert not any(error.startswith("event_key_") for error in report["errors"])
+
+
+def test_verify_export_rejects_revoked_key_for_future_event_without_manifest(
+    tmp_path: Path,
+) -> None:
+    export_dir = tmp_path / "export"
+    shutil.copytree(STRICT, export_dir)
+    (export_dir / "manifest.json").unlink()
+    registry_path = export_dir / "public-keys.json"
+    registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    registry["keys"][0]["status"] = "revoked"
+    registry["keys"][0]["valid_until"] = "2026-01-02T00:00:00Z"
+    registry_path.write_text(json.dumps(registry), encoding="utf-8")
+
+    report = verify_export(export_dir)
+
+    assert report["result"] == "INVALID"
+    assert report["guarantees"]["authority_verified"] is False
+    assert "event_key_outside_validity:1" in report["errors"]
+
+
 def test_verify_export_rejects_manifest_file_hash_mismatch(tmp_path: Path) -> None:
     export_dir = tmp_path / "export"
     shutil.copytree(STRICT, export_dir)


### PR DESCRIPTION
## Summary

- Adds runtime origin-signature envelopes for ledger events with actor key, tenant, action, payload hash, nonce, issued timestamp, and Ed25519 signature fields.
- Adds strict `OriginSignaturePolicy` admission for `LedgerWriter` so unsigned, invalid, mismatched, unauthorized, future, or expired/revoked writes are rejected before persistence or enrichment enqueue.
- Adds actor-key registry/public export helpers, historical key-rotation semantics, verifier reconstruction for signed events, and M4 docs clarifying origin authenticity is not truth.
- Tightens public export safety so `key-events.jsonl` is pre-scanned for private material before anything sensitive can be written.

## Stack

- Stacked on `codex/forensic-ledger-export` / PR #353.
- Addresses #282.

## Validation

- `ruff check cortex/ledger/models.py cortex/ledger/origin.py cortex/ledger/writer.py cortex/ledger/verifier.py cortex/ledger/__init__.py cortex/ledger/public_export.py cortex/ledger/public_verifier.py tests/test_ledger_origin_signatures.py tests/test_public_ledger_export.py tests/test_public_ledger_verifier.py tests/test_lazy_package_imports.py`
- `ruff format --check cortex/ledger/models.py cortex/ledger/origin.py cortex/ledger/writer.py cortex/ledger/verifier.py cortex/ledger/__init__.py cortex/ledger/public_export.py cortex/ledger/public_verifier.py tests/test_ledger_origin_signatures.py tests/test_public_ledger_export.py tests/test_public_ledger_verifier.py tests/test_lazy_package_imports.py`
- `python3 -m py_compile cortex/ledger/models.py cortex/ledger/origin.py cortex/ledger/writer.py cortex/ledger/verifier.py cortex/ledger/__init__.py cortex/ledger/public_export.py cortex/ledger/public_verifier.py tests/test_ledger_origin_signatures.py tests/test_public_ledger_export.py tests/test_public_ledger_verifier.py tests/test_lazy_package_imports.py`
- `pyright cortex/ledger/models.py cortex/ledger/origin.py cortex/ledger/writer.py cortex/ledger/verifier.py cortex/ledger/__init__.py cortex/ledger/public_export.py cortex/ledger/public_verifier.py tests/test_ledger_origin_signatures.py tests/test_public_ledger_export.py tests/test_public_ledger_verifier.py tests/test_lazy_package_imports.py` — 0 errors, 1 existing lazy-export warning for `ImmutableLedger`.
- `pytest tests/test_ledger_origin_signatures.py tests/test_ledger_integrity_verification.py tests/test_ledger_survives_without_embeddings.py tests/test_ledger_checkpointing.py tests/test_public_ledger_verifier.py tests/test_public_ledger_export.py tests/test_public_ledger_verifier_vectors.py tests/test_lazy_package_imports.py -v` — 65 passed, 1 dependency deprecation warning.
- `git diff --check`