### PR TITLE
M5 — Add replay/freshness protection with atomic writes

### DIFF
--- a/cortex/database/schema.py
+++ b/cortex/database/schema.py
@@ -59,6 +59,8 @@ __all__ = [
     "CREATE_HEARTBEATS",
     "CREATE_HEARTBEATS_INDEX",
     "CREATE_INTEGRITY_CHECKS",
+    "CREATE_LEDGER_REPLAY_ADMISSIONS",
+    "CREATE_LEDGER_REPLAY_ADMISSIONS_INDEXES",
     "CREATE_META",
     "CREATE_OUTCOMES",
     "CREATE_RWC_INDEXES",
@@ -84,7 +86,7 @@ __all__ = [
     "get_init_meta",
 ]
 
-SCHEMA_VERSION = "5.4.2"
+SCHEMA_VERSION = "5.4.3"
 
 # ─── Core Facts Table ────────────────────────────────────────────────
 CREATE_FACTS = """
@@ -328,6 +330,33 @@ CREATE TABLE IF NOT EXISTS tenants (
 );
 """
 
+# ─── Ledger Replay Admission ─────────────────────────────────────────
+CREATE_LEDGER_REPLAY_ADMISSIONS = """
+CREATE TABLE IF NOT EXISTS ledger_replay_admissions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    tenant_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    nonce TEXT NOT NULL,
+    request_hash TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    ledger_event_id TEXT NOT NULL,
+    actor_key_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    issued_at TEXT NOT NULL,
+    accepted_at TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+);
+"""
+
+CREATE_LEDGER_REPLAY_ADMISSIONS_INDEXES = """
+CREATE UNIQUE INDEX IF NOT EXISTS ux_ledger_replay_tenant_event_id
+    ON ledger_replay_admissions(tenant_id, event_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_ledger_replay_tenant_nonce
+    ON ledger_replay_admissions(tenant_id, nonce);
+CREATE INDEX IF NOT EXISTS idx_ledger_replay_tenant_accepted
+    ON ledger_replay_admissions(tenant_id, accepted_at);
+"""
+
 # ─── Migration SQLs ───────────────────────────────────────────────────
 MIGRATE_ADD_SIGNATURE_COLUMNS = """
 ALTER TABLE facts ADD COLUMN signature TEXT;
@@ -356,6 +385,8 @@ _CORE_SCHEMA = [
     CREATE_THREAT_INTEL,
     CREATE_THREAT_INTEL_INDEXES,
     CREATE_TENANTS,
+    CREATE_LEDGER_REPLAY_ADMISSIONS,
+    CREATE_LEDGER_REPLAY_ADMISSIONS_INDEXES,
 ]
 
 # Full ordered schema: core + extensions (consensus, episodes, signals, entity_events...)

--- a/cortex/ledger/__init__.py
+++ b/cortex/ledger/__init__.py
@@ -18,6 +18,13 @@ if TYPE_CHECKING:
         verify_event_origin,
     )
     from cortex.ledger.queue import EnrichmentQueue
+    from cortex.ledger.replay import (
+        ReplayAdmissionError,
+        ReplayAdmissionPolicy,
+        ReplayAdmissionResult,
+        replay_request_hash,
+        validate_batch_import_manifest,
+    )
     from cortex.ledger.store import LedgerStore
     from cortex.ledger.verifier import LedgerVerifier
     from cortex.ledger.writer import LedgerWriter
@@ -39,6 +46,11 @@ __all__ = [
     "origin_payload_hash",
     "sign_event_origin",
     "verify_event_origin",
+    "ReplayAdmissionError",
+    "ReplayAdmissionPolicy",
+    "ReplayAdmissionResult",
+    "replay_request_hash",
+    "validate_batch_import_manifest",
 ]
 
 _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
@@ -56,6 +68,14 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "origin_payload_hash": ("cortex.ledger.origin", "origin_payload_hash"),
     "sign_event_origin": ("cortex.ledger.origin", "sign_event_origin"),
     "verify_event_origin": ("cortex.ledger.origin", "verify_event_origin"),
+    "ReplayAdmissionError": ("cortex.ledger.replay", "ReplayAdmissionError"),
+    "ReplayAdmissionPolicy": ("cortex.ledger.replay", "ReplayAdmissionPolicy"),
+    "ReplayAdmissionResult": ("cortex.ledger.replay", "ReplayAdmissionResult"),
+    "replay_request_hash": ("cortex.ledger.replay", "replay_request_hash"),
+    "validate_batch_import_manifest": (
+        "cortex.ledger.replay",
+        "validate_batch_import_manifest",
+    ),
 }
 
 

--- a/cortex/ledger/replay.py
+++ b/cortex/ledger/replay.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from cortex.ledger.models import LedgerEvent, LedgerOriginSignature
+from cortex.ledger.public_verifier_utils import _canonical_public_json
+
+
+class ReplayAdmissionError(ValueError):
+    """Raised when online replay or freshness admission rejects an event."""
+
+    preserve_ledger_error = True
+
+
+ReplayAdmissionStatus = Literal["accepted", "idempotent"]
+
+
+@dataclass(frozen=True)
+class ReplayAdmissionResult:
+    status: ReplayAdmissionStatus
+    event_id: str
+
+
+@dataclass(frozen=True)
+class ReplayAdmissionPolicy:
+    max_age_seconds: int = 300
+    future_skew_seconds: int = 30
+    enforce_online_freshness: bool = True
+    idempotent_retries: bool = True
+    now: Callable[[], datetime] = lambda: datetime.now(timezone.utc)
+
+    def validate_event(self, event: LedgerEvent) -> None:
+        origin = _require_origin(event)
+        if not self.enforce_online_freshness:
+            return
+        now = _normalize_aware(self.now(), "online_freshness_now_invalid")
+        issued_at = _parse_utc(origin.issued_at)
+        if issued_at > now + timedelta(seconds=self.future_skew_seconds):
+            raise ReplayAdmissionError("online_freshness_future_event")
+        if issued_at < now - timedelta(seconds=self.max_age_seconds):
+            raise ReplayAdmissionError("online_freshness_stale_event")
+
+    def admit_event(
+        self,
+        conn: sqlite3.Connection,
+        event: LedgerEvent,
+    ) -> ReplayAdmissionResult:
+        origin = _require_origin(event)
+        tenant_id = _require_tenant(event, origin)
+        request_hash = replay_request_hash(event)
+        try:
+            conn.execute(
+                """
+                INSERT INTO ledger_replay_admissions (
+                    tenant_id,
+                    event_id,
+                    nonce,
+                    request_hash,
+                    payload_hash,
+                    ledger_event_id,
+                    actor_key_id,
+                    action,
+                    issued_at,
+                    accepted_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    tenant_id,
+                    event.event_id,
+                    origin.nonce,
+                    request_hash,
+                    origin.payload_hash,
+                    event.event_id,
+                    origin.actor_key_id,
+                    event.action,
+                    origin.issued_at,
+                    _format_utc(_normalize_aware(self.now(), "online_freshness_now_invalid")),
+                ),
+            )
+        except sqlite3.IntegrityError:
+            return self._classify_existing(conn, event, origin, tenant_id, request_hash)
+        return ReplayAdmissionResult(status="accepted", event_id=event.event_id)
+
+    def _classify_existing(
+        self,
+        conn: sqlite3.Connection,
+        event: LedgerEvent,
+        origin: LedgerOriginSignature,
+        tenant_id: str,
+        request_hash: str,
+    ) -> ReplayAdmissionResult:
+        rows = conn.execute(
+            """
+            SELECT event_id, nonce, request_hash, ledger_event_id
+            FROM ledger_replay_admissions
+            WHERE tenant_id = ? AND (event_id = ? OR nonce = ?)
+            ORDER BY id ASC
+            """,
+            (tenant_id, event.event_id, origin.nonce),
+        ).fetchall()
+        exact = [
+            row
+            for row in rows
+            if row["event_id"] == event.event_id
+            and row["nonce"] == origin.nonce
+            and row["request_hash"] == request_hash
+        ]
+        if exact and self.idempotent_retries:
+            return ReplayAdmissionResult(
+                status="idempotent",
+                event_id=str(exact[0]["ledger_event_id"]),
+            )
+
+        event_matches = [row for row in rows if row["event_id"] == event.event_id]
+        nonce_matches = [row for row in rows if row["nonce"] == origin.nonce]
+        if event_matches and nonce_matches:
+            raise ReplayAdmissionError(f"replay_retry_mutated:{tenant_id}:{event.event_id}")
+        if event_matches:
+            raise ReplayAdmissionError(f"replay_event_id_duplicate:{tenant_id}:{event.event_id}")
+        if nonce_matches:
+            raise ReplayAdmissionError(f"replay_nonce_duplicate:{tenant_id}:{origin.nonce}")
+        raise ReplayAdmissionError(f"replay_admission_conflict:{tenant_id}:{event.event_id}")
+
+
+def replay_request_hash(event: LedgerEvent) -> str:
+    payload = event.to_payload()
+    payload.pop("hash", None)
+    payload.pop("prev_hash", None)
+    return hashlib.sha256(_canonical_public_json(payload).encode("utf-8")).hexdigest()
+
+
+def validate_batch_import_manifest(export_dir: str | Path) -> dict[str, Any]:
+    root = Path(export_dir)
+    if not (root / "manifest.json").exists():
+        raise ReplayAdmissionError("batch_import_manifest_missing")
+
+    from cortex.ledger.public_verifier import verify_export
+
+    report = verify_export(root)
+    if report.get("result") != "VALID_FULL_STRICT":
+        raise ReplayAdmissionError(f"batch_import_not_full_strict:{report.get('result')}")
+    return report
+
+
+def _require_origin(event: LedgerEvent) -> LedgerOriginSignature:
+    if event.origin is None:
+        raise ReplayAdmissionError("replay_origin_missing")
+    if not event.origin.nonce:
+        raise ReplayAdmissionError("replay_nonce_missing")
+    return event.origin
+
+
+def _require_tenant(event: LedgerEvent, origin: LedgerOriginSignature) -> str:
+    tenant_id = event.metadata.get("tenant_id")
+    if not isinstance(tenant_id, str) or not tenant_id:
+        raise ReplayAdmissionError("replay_tenant_missing")
+    if tenant_id != origin.tenant_id:
+        raise ReplayAdmissionError("replay_tenant_mismatch")
+    return tenant_id
+
+
+def _parse_utc(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00") if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ReplayAdmissionError("online_freshness_timestamp_invalid") from exc
+    if parsed.tzinfo is None:
+        raise ReplayAdmissionError("online_freshness_timestamp_missing_timezone")
+    return parsed
+
+
+def _normalize_aware(value: datetime, error_code: str) -> datetime:
+    if value.tzinfo is None:
+        raise ReplayAdmissionError(error_code)
+    return value.astimezone(timezone.utc)
+
+
+def _format_utc(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")

--- a/cortex/ledger/store.py
+++ b/cortex/ledger/store.py
@@ -28,6 +28,8 @@ class LedgerStore:
             conn.commit()
         except Exception as exc:
             conn.rollback()
+            if getattr(exc, "preserve_ledger_error", False):
+                raise
             raise LedgerStoreError(str(exc)) from exc
         finally:
             conn.close()
@@ -99,6 +101,21 @@ class LedgerStore:
                     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
                     FOREIGN KEY(event_id) REFERENCES ledger_events(event_id) ON DELETE CASCADE
                 );
+
+                CREATE TABLE IF NOT EXISTS ledger_replay_admissions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    tenant_id TEXT NOT NULL,
+                    event_id TEXT NOT NULL,
+                    nonce TEXT NOT NULL,
+                    request_hash TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    ledger_event_id TEXT NOT NULL,
+                    actor_key_id TEXT NOT NULL,
+                    action TEXT NOT NULL,
+                    issued_at TEXT NOT NULL,
+                    accepted_at TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+                );
                 """
             )
             self._ensure_compat_columns(conn, "enrichment_jobs")
@@ -111,6 +128,12 @@ class LedgerStore:
                     ON ledger_events(semantic_status);
                 CREATE INDEX IF NOT EXISTS idx_ledger_enrichment_jobs_status_next_attempt_compat
                     ON ledger_enrichment_jobs(status, COALESCE(next_attempt_ts, next_attempt_at));
+                CREATE UNIQUE INDEX IF NOT EXISTS ux_ledger_replay_tenant_event_id
+                    ON ledger_replay_admissions(tenant_id, event_id);
+                CREATE UNIQUE INDEX IF NOT EXISTS ux_ledger_replay_tenant_nonce
+                    ON ledger_replay_admissions(tenant_id, nonce);
+                CREATE INDEX IF NOT EXISTS idx_ledger_replay_tenant_accepted
+                    ON ledger_replay_admissions(tenant_id, accepted_at);
 
                 CREATE TRIGGER IF NOT EXISTS enrichment_jobs_ledger_insert
                 AFTER INSERT ON enrichment_jobs

--- a/cortex/ledger/writer.py
+++ b/cortex/ledger/writer.py
@@ -1,4 +1,5 @@
 import dataclasses
+import sqlite3
 from typing import Protocol
 
 from cortex.ledger.models import LedgerEvent
@@ -10,6 +11,21 @@ class _OriginSignaturePolicy(Protocol):
     def validate_event(self, event: LedgerEvent) -> None: ...
 
 
+class _ReplayAdmissionResult(Protocol):
+    status: str
+    event_id: str
+
+
+class _ReplayAdmissionPolicy(Protocol):
+    def validate_event(self, event: LedgerEvent) -> None: ...
+
+    def admit_event(
+        self,
+        conn: sqlite3.Connection,
+        event: LedgerEvent,
+    ) -> _ReplayAdmissionResult: ...
+
+
 class LedgerWriter:
     def __init__(
         self,
@@ -17,16 +33,25 @@ class LedgerWriter:
         queue: EnrichmentQueue,
         *,
         origin_policy: _OriginSignaturePolicy | None = None,
+        replay_policy: _ReplayAdmissionPolicy | None = None,
     ) -> None:
         self.store = store
         self.queue = queue
         self.origin_policy = origin_policy
+        self.replay_policy = replay_policy
 
     def append(self, event: LedgerEvent) -> str:
         if self.origin_policy is not None:
             self.origin_policy.validate_event(event)
+        if self.replay_policy is not None:
+            self.replay_policy.validate_event(event)
 
         with self.store.tx() as conn:
+            if self.replay_policy is not None:
+                admission = self.replay_policy.admit_event(conn, event)
+                if admission.status == "idempotent":
+                    return admission.event_id
+
             # 1. Get last hash
             cursor = conn.execute("SELECT hash FROM ledger_events ORDER BY rowid DESC LIMIT 1")
             row = cursor.fetchone()

--- a/cortex/migrations/mig_ledger.py
+++ b/cortex/migrations/mig_ledger.py
@@ -168,3 +168,34 @@ def _migration_025_tenant_bound_merkle_roots(conn: sqlite3.Connection):
         "ON merkle_roots(tenant_id, tx_start_id, tx_end_id)"
     )
     logger.info("Migration 025: Added tenant scope metadata to merkle_roots")
+
+
+# DOWNGRADE TARGET: 25
+# Rollback strategy: this is an additive online-admission table. Downgrades may
+# leave ledger_replay_admissions in place; older readers ignore the table, and
+# dropping it would remove replay evidence needed to audit live admission.
+def _migration_026_ledger_replay_admission(conn: sqlite3.Connection):
+    """Add tenant-scoped replay admission reservations for strict ledger writes."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS ledger_replay_admissions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tenant_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            nonce TEXT NOT NULL,
+            request_hash TEXT NOT NULL,
+            payload_hash TEXT NOT NULL,
+            ledger_event_id TEXT NOT NULL,
+            actor_key_id TEXT NOT NULL,
+            action TEXT NOT NULL,
+            issued_at TEXT NOT NULL,
+            accepted_at TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_ledger_replay_tenant_event_id
+            ON ledger_replay_admissions(tenant_id, event_id);
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_ledger_replay_tenant_nonce
+            ON ledger_replay_admissions(tenant_id, nonce);
+        CREATE INDEX IF NOT EXISTS idx_ledger_replay_tenant_accepted
+            ON ledger_replay_admissions(tenant_id, accepted_at);
+    """)
+    logger.info("Migration 026: Added ledger replay admission reservations")

--- a/cortex/migrations/registry.py
+++ b/cortex/migrations/registry.py
@@ -21,6 +21,7 @@ from cortex.migrations.mig_ledger import (
     _migration_012_ghosts_table,
     _migration_014_vote_ledger_refinement,
     _migration_025_tenant_bound_merkle_roots,
+    _migration_026_ledger_replay_admission,
 )
 from cortex.migrations.mig_security_hardening import _migration_018_security_hardening
 from cortex.migrations.mig_signals import _migration_019_signal_bus
@@ -58,4 +59,5 @@ MIGRATIONS = [
     (22, "Stratified Cognition + Causal Anchoring", _migration_022_cognitive_layer),
     # (23) removed — mig_simplify_facts was never applied and is incompatible with live schema
     (25, "Tenant-bound Merkle checkpoints", _migration_025_tenant_bound_merkle_roots),
+    (26, "Ledger replay admission reservations", _migration_026_ledger_replay_admission),
 ]

--- a/docs/compliance/M4_ORIGIN_SIGNATURES_STRICT_MODE.md
+++ b/docs/compliance/M4_ORIGIN_SIGNATURES_STRICT_MODE.md
@@ -18,7 +18,7 @@ when any origin-auth control fails. Rejected events do not create:
 - a consumed nonce or other replay side effect;
 - a downstream semantic enrichment side effect from `LedgerWriter`.
 
-Nonce reservation remains a later replay-admission control. M4 verifies nonce
+Nonce reservation is implemented by M5 replay admission. M4 verifies nonce
 presence in the signed envelope and deliberately performs no durable nonce
 mutation before origin authenticity succeeds.
 

--- a/docs/compliance/M5_REPLAY_FRESHNESS_PROTECTION.md
+++ b/docs/compliance/M5_REPLAY_FRESHNESS_PROTECTION.md
@@ -1,0 +1,80 @@
+# M5 Replay And Freshness Protection
+
+Status: draft
+
+M5 adds online replay admission for strict ledger writes. It prevents a signed
+event from being replayed as a fresh action and separates live admission checks
+from historical offline verification.
+
+## Admission Storage
+
+`ledger_replay_admissions` records accepted live events with:
+
+- `tenant_id`
+- `event_id`
+- `nonce`
+- `request_hash`
+- `payload_hash`
+- `ledger_event_id`
+- `actor_key_id`
+- `action`
+- `issued_at`
+- `accepted_at`
+
+The table enforces tenant-scoped uniqueness with:
+
+- `ux_ledger_replay_tenant_event_id` on `(tenant_id, event_id)`
+- `ux_ledger_replay_tenant_nonce` on `(tenant_id, nonce)`
+
+`ledger_events.event_id` remains the ledger row primary key. Replay admission is
+tenant-scoped; callers should still issue globally collision-resistant event
+ids for ledger row portability.
+
+## Atomicity
+
+Replay reservation happens inside the same SQLite transaction as the
+`ledger_events` insert. If the ledger write rolls back, the reservation rolls
+back. Origin-auth and online freshness validation happen before reservation, so
+failed validation does not consume an event id or nonce.
+
+`EnrichmentQueue` remains a post-commit side effect. An idempotent retry returns
+the already-accepted event id and does not reinsert the ledger row or enqueue a
+second enrichment job.
+
+## Retry Semantics
+
+Exact retry means the same tenant, event id, nonce, and canonical request hash.
+It returns the original event id without re-executing the write.
+
+Mutated retry means the same tenant plus same event id and nonce but a different
+canonical request hash. It is rejected with `replay_retry_mutated`.
+
+Same tenant plus duplicate event id is rejected with
+`replay_event_id_duplicate`. Same tenant plus duplicate nonce is rejected with
+`replay_nonce_duplicate`.
+
+## Online Freshness
+
+Live agent admission checks `origin.issued_at` against the local admission
+clock:
+
+- events newer than `now + future_skew_seconds` are rejected;
+- events older than `now - max_age_seconds` are rejected.
+
+The default policy uses a five minute max age and a thirty second future skew.
+Tests inject a fixed clock. Operators may inject a different
+`ReplayAdmissionPolicy` where stricter or looser live windows are required.
+
+## Offline Separation
+
+Offline historical verifier reports keep `online_freshness_verified: false`.
+Missing manifests can still produce `VALID_WITH_LIMITATIONS` for historical
+inspection. Online batch import is stricter: `validate_batch_import_manifest`
+requires `manifest.json` and a `VALID_FULL_STRICT` verifier result before a
+batch can be admitted as live replay input.
+
+## Migration And Rollback
+
+Migration 026 adds the replay admission table and indexes. The rollback policy
+is additive: downgrades may leave the table in place because older readers
+ignore it, while dropping it would erase replay-admission evidence.

--- a/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
+++ b/docs/compliance/PUBLIC_LEDGER_EXPORT_PACKAGE.md
@@ -105,5 +105,6 @@ M3 does not:
 Those controls belong to later milestones, especially M4, M5, and M6.
 
 M4 adds runtime origin-signature admission for `LedgerWriter` strict mode. M5
-remains responsible for durable replay nonce reservation, and M6 remains
-responsible for immutable-ledger no-PII enforcement.
+adds live replay nonce reservation and online freshness admission; historical
+offline verification still reports `online_freshness_verified: false`. M6
+remains responsible for immutable-ledger no-PII enforcement.

--- a/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
+++ b/docs/compliance/PUBLIC_LEDGER_VERIFIER_SPEC.md
@@ -98,8 +98,9 @@ Reports must split guarantees:
 - `completeness_verified`
 - `truth_verified`
 
-For offline historical exports, `online_freshness_verified` is false. By
-default, `truth_verified` is false.
+For offline historical exports, `online_freshness_verified` is false. Online
+freshness is a live admission guarantee enforced by M5 replay policy, not by the
+offline verifier. By default, `truth_verified` is false.
 
 ## Key Rotation
 

--- a/tests/test_forensic_ledger_migration.py
+++ b/tests/test_forensic_ledger_migration.py
@@ -26,12 +26,14 @@ def test_fresh_schema_has_tenant_scoped_merkle_roots() -> None:
     applied = run_migrations(conn)
 
     assert applied == 0
-    assert get_current_version(conn) == 25
+    assert get_current_version(conn) == 26
     assert "tenant_id" in _columns(conn, "merkle_roots")
     tenant_id = _column_info(conn, "merkle_roots", "tenant_id")
     assert tenant_id["notnull"] == 1
     assert tenant_id["dflt_value"] == "'__global__'"
-    assert SCHEMA_VERSION == "5.4.2"
+    assert "tenant_id" in _columns(conn, "ledger_replay_admissions")
+    assert "nonce" in _columns(conn, "ledger_replay_admissions")
+    assert SCHEMA_VERSION == "5.4.3"
 
 
 def test_migration_025_adds_merkle_tenant_scope_without_data_loss() -> None:
@@ -57,8 +59,8 @@ def test_migration_025_adds_merkle_tenant_scope_without_data_loss() -> None:
 
     applied = run_migrations(conn)
 
-    assert applied == 1
-    assert get_current_version(conn) == 25
+    assert applied == 2
+    assert get_current_version(conn) == 26
     assert "tenant_id" in _columns(conn, "merkle_roots")
     tenant_id = _column_info(conn, "merkle_roots", "tenant_id")
     assert tenant_id["notnull"] == 1
@@ -73,6 +75,38 @@ def test_migration_025_adds_merkle_tenant_scope_without_data_loss() -> None:
 
 def test_migration_registry_tracks_forensic_ledger_schema_version() -> None:
     versions = [version for version, _description, _func in MIGRATIONS]
-    assert versions[-1] == 25
+    assert versions[-1] == 26
     assert versions == sorted(versions)
     assert len(versions) == len(set(versions))
+
+
+def test_migration_026_adds_replay_admission_table_and_tenant_scoped_uniques() -> None:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT DEFAULT (datetime('now')),
+            description TEXT
+        );
+        INSERT INTO schema_version (version, description) VALUES (25, 'pre replay baseline');
+    """)
+
+    applied = run_migrations(conn)
+
+    assert applied == 1
+    assert get_current_version(conn) == 26
+    columns = _columns(conn, "ledger_replay_admissions")
+    assert {
+        "tenant_id",
+        "event_id",
+        "nonce",
+        "request_hash",
+        "payload_hash",
+        "ledger_event_id",
+    } <= columns
+    indexes = {
+        row[1]: bool(row[2])
+        for row in conn.execute("PRAGMA index_list(ledger_replay_admissions)").fetchall()
+    }
+    assert indexes["ux_ledger_replay_tenant_event_id"] is True
+    assert indexes["ux_ledger_replay_tenant_nonce"] is True

--- a/tests/test_lazy_package_imports.py
+++ b/tests/test_lazy_package_imports.py
@@ -82,16 +82,22 @@ def test_ledger_origin_signatures_materialize_on_demand() -> None:
     package_name = "cortex.ledger"
     models_module = "cortex.ledger.models"
     origin_module = "cortex.ledger.origin"
+    replay_module = "cortex.ledger.replay"
 
-    with _temporarily_reset_modules(package_name, models_module, origin_module):
+    with _temporarily_reset_modules(package_name, models_module, origin_module, replay_module):
         module = importlib.import_module(package_name)
 
         assert origin_module not in sys.modules
+        assert replay_module not in sys.modules
         assert module.LedgerEvent.__name__ == "LedgerEvent"
         assert models_module in sys.modules
         assert origin_module not in sys.modules
+        assert replay_module not in sys.modules
         assert module.OriginKeyRegistry.__name__ == "OriginKeyRegistry"
         assert origin_module in sys.modules
+        assert replay_module not in sys.modules
+        assert module.ReplayAdmissionPolicy.__name__ == "ReplayAdmissionPolicy"
+        assert replay_module in sys.modules
 
 
 def test_browser_package_import_is_lazy_without_playwright() -> None:

--- a/tests/test_ledger_replay_freshness.py
+++ b/tests/test_ledger_replay_freshness.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import shutil
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from cortex.ledger.models import ActionResult, ActionTarget, LedgerEvent
+from cortex.ledger.origin import OriginKeyRecord, OriginKeyRegistry, OriginSignaturePolicy
+from cortex.ledger.queue import EnrichmentQueue
+from cortex.ledger.replay import (
+    ReplayAdmissionError,
+    ReplayAdmissionPolicy,
+    validate_batch_import_manifest,
+)
+from cortex.ledger.store import LedgerStore
+from cortex.ledger.writer import LedgerWriter
+
+ACTOR_ID = "agent-risk-01"
+TENANT_ID = "tenant-acme"
+OTHER_TENANT_ID = "tenant-beta"
+KEY_ID = "ed25519:agent-risk-01:runtime-001"
+OTHER_KEY_ID = "ed25519:agent-risk-01:runtime-002"
+NOW = datetime(2026, 2, 3, 10, 15, 30, tzinfo=timezone.utc)
+ISSUED_AT = "2026-02-03T10:15:30Z"
+FIXTURES = Path(__file__).parent / "fixtures" / "ledger_verifier"
+STRICT = FIXTURES / "public_v1_strict"
+
+
+def test_replay_admission_records_reservation_atomically_with_ledger_write(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    event = _signed_event(private_key, event_id="evt-001", nonce="nonce-001")
+
+    event_id = writer.append(event)
+
+    assert event_id == "evt-001"
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+    with store.tx() as conn:
+        row = conn.execute(
+            """
+            SELECT tenant_id, event_id, nonce, payload_hash, actor_key_id, action
+            FROM ledger_replay_admissions
+            """
+        ).fetchone()
+    assert dict(row) == {
+        "tenant_id": TENANT_ID,
+        "event_id": "evt-001",
+        "nonce": "nonce-001",
+        "payload_hash": event.origin.payload_hash if event.origin else "",
+        "actor_key_id": KEY_ID,
+        "action": "fact.store",
+    }
+
+
+def test_duplicate_event_id_rejected_without_consuming_new_nonce(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    writer.append(_signed_event(private_key, event_id="evt-001", nonce="nonce-001"))
+    duplicate = _signed_event(private_key, event_id="evt-001", nonce="nonce-002")
+
+    with pytest.raises(ReplayAdmissionError, match="replay_event_id_duplicate"):
+        writer.append(duplicate)
+
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+    assert _row_count(store, "ledger_replay_admissions") == 1
+
+
+def test_duplicate_nonce_rejected_without_consuming_new_event_id(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    writer.append(_signed_event(private_key, event_id="evt-001", nonce="nonce-001"))
+    duplicate = _signed_event(private_key, event_id="evt-002", nonce="nonce-001")
+
+    with pytest.raises(ReplayAdmissionError, match="replay_nonce_duplicate"):
+        writer.append(duplicate)
+
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+    assert _row_count(store, "ledger_replay_admissions") == 1
+
+
+def test_mutated_retry_rejected_but_exact_retry_is_idempotent(tmp_path: Path) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key, permissions=["fact.store", "fact.deprecate"])
+    event = _signed_event(private_key, event_id="evt-001", nonce="nonce-001")
+    first = writer.append(event)
+
+    exact_retry = writer.append(event)
+
+    assert exact_retry == first
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+    assert _row_count(store, "ledger_replay_admissions") == 1
+
+    mutated = _signed_event(
+        private_key,
+        event_id="evt-001",
+        nonce="nonce-001",
+        action="fact.deprecate",
+    )
+    with pytest.raises(ReplayAdmissionError, match="replay_retry_mutated"):
+        writer.append(mutated)
+
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+    assert _row_count(store, "ledger_replay_admissions") == 1
+
+
+def test_online_freshness_rejects_future_and_stale_events_before_reservation(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+
+    future = _signed_event(
+        private_key,
+        event_id="evt-future",
+        nonce="nonce-future",
+        issued_at="2026-02-03T10:17:00Z",
+    )
+    with pytest.raises(ReplayAdmissionError, match="online_freshness_future_event"):
+        writer.append(future)
+
+    stale = _signed_event(
+        private_key,
+        event_id="evt-stale",
+        nonce="nonce-stale",
+        issued_at="2026-02-03T10:00:00Z",
+    )
+    with pytest.raises(ReplayAdmissionError, match="online_freshness_stale_event"):
+        writer.append(stale)
+
+    assert _row_count(store, "ledger_events") == 0
+    assert _row_count(store, "enrichment_jobs") == 0
+    assert _row_count(store, "ledger_replay_admissions") == 0
+
+
+def test_replay_constraints_are_tenant_scoped_for_event_ids_and_nonces(tmp_path: Path) -> None:
+    store = LedgerStore(tmp_path / "ledger.db")
+
+    with store.tx() as conn:
+        _insert_admission(conn, tenant_id=TENANT_ID, event_id="evt-shared", nonce="nonce-shared")
+        _insert_admission(
+            conn,
+            tenant_id=OTHER_TENANT_ID,
+            event_id="evt-shared",
+            nonce="nonce-shared",
+        )
+        count = conn.execute("SELECT COUNT(*) AS count FROM ledger_replay_admissions").fetchone()
+
+    assert count["count"] == 2
+
+
+def test_batch_import_without_manifest_is_rejected_but_offline_verify_stays_limited(
+    tmp_path: Path,
+) -> None:
+    from cortex.ledger.public_verifier import verify_export
+
+    export_dir = tmp_path / "export"
+    shutil.copytree(STRICT, export_dir)
+    (export_dir / "manifest.json").unlink()
+
+    offline_report = verify_export(export_dir)
+    assert offline_report["result"] == "VALID_WITH_LIMITATIONS"
+    with pytest.raises(ReplayAdmissionError, match="batch_import_manifest_missing"):
+        validate_batch_import_manifest(export_dir)
+
+
+def test_concurrent_duplicate_nonce_has_one_accept_and_one_deterministic_reject(
+    tmp_path: Path,
+) -> None:
+    private_key = Ed25519PrivateKey.generate()
+    store, writer = _writer(tmp_path, private_key)
+    events = [
+        _signed_event(private_key, event_id="evt-001", nonce="nonce-race"),
+        _signed_event(private_key, event_id="evt-002", nonce="nonce-race"),
+    ]
+
+    def submit(event: LedgerEvent) -> tuple[str, str]:
+        try:
+            return ("accepted", writer.append(event))
+        except ReplayAdmissionError as exc:
+            return ("rejected", str(exc))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(submit, events))
+
+    accepted = [value for status, value in results if status == "accepted"]
+    rejected = [value for status, value in results if status == "rejected"]
+    assert len(accepted) == 1
+    assert len(rejected) == 1
+    assert rejected[0].startswith(f"replay_nonce_duplicate:{TENANT_ID}:nonce-race")
+    assert _row_count(store, "ledger_events") == 1
+    assert _row_count(store, "enrichment_jobs") == 1
+    assert _row_count(store, "ledger_replay_admissions") == 1
+
+
+def test_legacy_ledger_store_upgrade_adds_replay_table_without_data_loss(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy-ledger.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE ledger_events (
+            event_id TEXT PRIMARY KEY,
+            ts TEXT NOT NULL,
+            tool TEXT NOT NULL,
+            actor TEXT NOT NULL,
+            action TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            prev_hash TEXT,
+            hash TEXT,
+            semantic_status TEXT NOT NULL DEFAULT 'pending',
+            semantic_error TEXT,
+            correlation_id TEXT,
+            trace_id TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+        );
+        INSERT INTO ledger_events (
+            event_id, ts, tool, actor, action, payload_json, semantic_status
+        )
+        VALUES ('legacy-evt', '2026-01-01T00:00:00Z', 'cli', 'legacy', 'fact.store', '{}', 'pending');
+    """)
+    conn.commit()
+    conn.close()
+
+    store = LedgerStore(db_path)
+
+    with store.tx() as upgraded:
+        legacy = upgraded.execute(
+            "SELECT event_id FROM ledger_events WHERE event_id = 'legacy-evt'"
+        ).fetchone()
+        replay_columns = {
+            row[1] for row in upgraded.execute("PRAGMA table_info(ledger_replay_admissions)")
+        }
+    assert legacy is not None
+    assert {"tenant_id", "event_id", "nonce", "request_hash"} <= replay_columns
+
+
+def _writer(
+    tmp_path: Path,
+    private_key: Ed25519PrivateKey,
+    *,
+    permissions: list[str] | None = None,
+) -> tuple[LedgerStore, LedgerWriter]:
+    store = LedgerStore(tmp_path / "ledger.db")
+    registry = OriginKeyRegistry(
+        [
+            _record(
+                private_key,
+                key_id=KEY_ID,
+                tenant_id=TENANT_ID,
+                permissions=permissions or ["fact.store"],
+            )
+        ]
+    )
+    return (
+        store,
+        LedgerWriter(
+            store,
+            EnrichmentQueue(store),
+            origin_policy=OriginSignaturePolicy.strict_mode(registry),
+            replay_policy=ReplayAdmissionPolicy(now=lambda: NOW),
+        ),
+    )
+
+
+def _record(
+    private_key: Ed25519PrivateKey,
+    *,
+    key_id: str,
+    tenant_id: str,
+    permissions: list[str],
+) -> OriginKeyRecord:
+    return OriginKeyRecord.from_public_key(
+        key_id=key_id,
+        actor_id=ACTOR_ID,
+        tenant_id=tenant_id,
+        public_key=private_key.public_key(),
+        permissions=permissions,
+        valid_from="2026-01-01T00:00:00Z",
+        valid_until="2027-01-01T00:00:00Z",
+    )
+
+
+def _signed_event(
+    private_key: Ed25519PrivateKey,
+    *,
+    event_id: str,
+    nonce: str,
+    tenant_id: str = TENANT_ID,
+    key_id: str = KEY_ID,
+    action: str = "fact.store",
+    issued_at: str = ISSUED_AT,
+) -> LedgerEvent:
+    from cortex.ledger.origin import sign_event_origin
+
+    event = LedgerEvent.new(
+        tool="agent-runtime",
+        actor=ACTOR_ID,
+        action=action,
+        target=ActionTarget(app="CORTEX", identifier=event_id),
+        result=ActionResult(ok=True, latency_ms=12, verified=True),
+        metadata={"project": "cortex-persist", "tenant_id": tenant_id},
+    )
+    event = dataclasses.replace(event, event_id=event_id)
+    return sign_event_origin(
+        event,
+        key_id=key_id,
+        private_key=private_key,
+        tenant_id=tenant_id,
+        issued_at=issued_at,
+        nonce=nonce,
+    )
+
+
+def _insert_admission(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    event_id: str,
+    nonce: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO ledger_replay_admissions (
+            tenant_id,
+            event_id,
+            nonce,
+            request_hash,
+            payload_hash,
+            ledger_event_id,
+            actor_key_id,
+            action,
+            issued_at,
+            accepted_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            tenant_id,
+            event_id,
+            nonce,
+            f"request:{tenant_id}",
+            f"payload:{tenant_id}",
+            event_id,
+            f"key:{tenant_id}",
+            "fact.store",
+            ISSUED_AT,
+            ISSUED_AT,
+        ),
+    )
+
+
+def _row_count(store: LedgerStore, table_name: str) -> int:
+    if table_name not in {"ledger_events", "enrichment_jobs", "ledger_replay_admissions"}:
+        raise ValueError(f"unsupported table: {table_name}")
+    with store.tx() as conn:
+        row = conn.execute(f"SELECT COUNT(*) AS count FROM {table_name}").fetchone()
+    return int(row["count"])


### PR DESCRIPTION
## Summary
- add tenant-scoped replay admission reservations for event IDs and nonces, with exact retry idempotency and mutated retry rejection
- enforce online live-event freshness before persistence while keeping offline historical verification separate
- add migration 026, legacy compatibility coverage, and M5 compliance docs for rollback/upgrade behavior

## Validation
- `ruff check cortex/ledger/replay.py cortex/ledger/store.py cortex/ledger/writer.py cortex/ledger/__init__.py cortex/migrations/mig_ledger.py cortex/migrations/registry.py cortex/database/schema.py tests/test_ledger_replay_freshness.py tests/test_forensic_ledger_migration.py tests/test_lazy_package_imports.py`
- `ruff format --check cortex/ledger/replay.py cortex/ledger/store.py cortex/ledger/writer.py cortex/ledger/__init__.py cortex/migrations/mig_ledger.py cortex/migrations/registry.py cortex/database/schema.py tests/test_ledger_replay_freshness.py tests/test_forensic_ledger_migration.py tests/test_lazy_package_imports.py`
- `pyright cortex/ledger/replay.py cortex/ledger/store.py cortex/ledger/writer.py cortex/ledger/__init__.py cortex/migrations/mig_ledger.py cortex/migrations/registry.py cortex/database/schema.py tests/test_ledger_replay_freshness.py tests/test_forensic_ledger_migration.py tests/test_lazy_package_imports.py` (0 errors, 1 existing `ImmutableLedger` lazy-export warning)
- `git diff --check`
- `python3 -m pytest tests/test_ledger_replay_freshness.py tests/test_ledger_origin_signatures.py tests/test_ledger_integrity_verification.py tests/test_ledger_survives_without_embeddings.py tests/test_ledger_checkpointing.py tests/test_public_ledger_verifier.py tests/test_public_ledger_export.py tests/test_public_ledger_verifier_vectors.py tests/test_forensic_ledger_migration.py tests/test_lazy_package_imports.py -v` (78 passed, 1 warning)

Closes #283.